### PR TITLE
Fix default api path for proto go packages

### DIFF
--- a/proto/buf.gen.pulsar.yaml
+++ b/proto/buf.gen.pulsar.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: cosmossdk.io/api
+    default: github.com/0xPolygon/heimdall-v2/api
     except:
       - buf.build/googleapis/googleapis
       - buf.build/cosmos/gogo-proto


### PR DESCRIPTION
# Description

Change the default api path of proto go packages from `cosmossdk.io` to `heimdall-v2`

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli