### PR TITLE
Pulsar fix

### DIFF
--- a/proto/buf.gen.pulsar.yaml
+++ b/proto/buf.gen.pulsar.yaml
@@ -7,6 +7,7 @@ managed:
       - buf.build/googleapis/googleapis
       - buf.build/cosmos/gogo-proto
       - buf.build/cosmos/cosmos-proto
+      - buf.build/cosmos/cosmos-sdk
     override:
 plugins:
   - name: go-pulsar

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -3,6 +3,7 @@ deps:
   - buf.build/cosmos/gogo-proto
   - buf.build/cosmos/cosmos-proto
   - buf.build/cosmos/cosmos-sdk
+  - buf.build/googleapis/googleapis
 breaking:
   use:
     - FILE


### PR DESCRIPTION
# Description

With this PR, we fix an inconsistency of imported files by `pulsar` using the wrong `heimdall-v2` namespace (instead of the `cosmos-sdk` one)

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli