### PR TITLE
Use proper context in topup's keeper methods

### DIFF
--- a/x/topup/keeper/keeper.go
+++ b/x/topup/keeper/keeper.go
@@ -73,7 +73,7 @@ func (k Keeper) Logger(ctx context.Context) log.Logger {
 }
 
 // GetAllTopupSequences returns all the topup sequences
-func (k *Keeper) GetAllTopupSequences(ctx sdk.Context) (seq []string, e error) {
+func (k *Keeper) GetAllTopupSequences(ctx context.Context) (seq []string, e error) {
 	logger := k.Logger(ctx)
 
 	// get the sequences iterator
@@ -105,7 +105,7 @@ func (k *Keeper) GetAllTopupSequences(ctx sdk.Context) (seq []string, e error) {
 }
 
 // SetTopupSequence sets the topup sequence value in the store for the given key
-func (k *Keeper) SetTopupSequence(ctx sdk.Context, sequence string) error {
+func (k *Keeper) SetTopupSequence(ctx context.Context, sequence string) error {
 	logger := k.Logger(ctx)
 
 	err := k.sequences.Set(ctx, sequence)
@@ -120,7 +120,7 @@ func (k *Keeper) SetTopupSequence(ctx sdk.Context, sequence string) error {
 }
 
 // HasTopupSequence checks if the topup sequence exists
-func (k *Keeper) HasTopupSequence(ctx sdk.Context, sequence string) (bool, error) {
+func (k *Keeper) HasTopupSequence(ctx context.Context, sequence string) (bool, error) {
 	logger := k.Logger(ctx)
 
 	isSequencePresent, err := k.sequences.Has(ctx, sequence)
@@ -135,7 +135,7 @@ func (k *Keeper) HasTopupSequence(ctx sdk.Context, sequence string) (bool, error
 }
 
 // GetAllDividendAccounts returns all the dividend accounts
-func (k *Keeper) GetAllDividendAccounts(ctx sdk.Context) (da []hTypes.DividendAccount, e error) {
+func (k *Keeper) GetAllDividendAccounts(ctx context.Context) (da []hTypes.DividendAccount, e error) {
 	logger := k.Logger(ctx)
 
 	// get the dividend accounts iterator
@@ -167,7 +167,7 @@ func (k *Keeper) GetAllDividendAccounts(ctx sdk.Context) (da []hTypes.DividendAc
 }
 
 // SetDividendAccount sets the dividend account in the store for the given dividendAccount
-func (k *Keeper) SetDividendAccount(ctx sdk.Context, dividendAccount hTypes.DividendAccount) error {
+func (k *Keeper) SetDividendAccount(ctx context.Context, dividendAccount hTypes.DividendAccount) error {
 	logger := k.Logger(ctx)
 
 	err := k.dividendAccounts.Set(ctx, dividendAccount.User, dividendAccount)
@@ -182,7 +182,7 @@ func (k *Keeper) SetDividendAccount(ctx sdk.Context, dividendAccount hTypes.Divi
 }
 
 // HasDividendAccount checks if the dividend account exists
-func (k *Keeper) HasDividendAccount(ctx sdk.Context, user string) (bool, error) {
+func (k *Keeper) HasDividendAccount(ctx context.Context, user string) (bool, error) {
 	logger := k.Logger(ctx)
 
 	isDividendAccountPresent, err := k.dividendAccounts.Has(ctx, user)
@@ -197,7 +197,7 @@ func (k *Keeper) HasDividendAccount(ctx sdk.Context, user string) (bool, error) 
 }
 
 // GetDividendAccount returns the dividend account for the given user
-func (k *Keeper) GetDividendAccount(ctx sdk.Context, user string) (hTypes.DividendAccount, error) {
+func (k *Keeper) GetDividendAccount(ctx context.Context, user string) (hTypes.DividendAccount, error) {
 	logger := k.Logger(ctx)
 
 	dividendAccount, err := k.dividendAccounts.Get(ctx, user)
@@ -212,7 +212,7 @@ func (k *Keeper) GetDividendAccount(ctx sdk.Context, user string) (hTypes.Divide
 }
 
 // AddFeeToDividendAccount adds the fee to the dividend account for the given user
-func (k *Keeper) AddFeeToDividendAccount(ctx sdk.Context, user string, fee *big.Int) error {
+func (k *Keeper) AddFeeToDividendAccount(ctx context.Context, user string, fee *big.Int) error {
 	logger := k.Logger(ctx)
 
 	// check if dividendAccount exists


### PR DESCRIPTION
# Description

Change the context in keeper's methods for topup module

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
