### PR TITLE
Remove stake keeper from topup module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -319,7 +319,6 @@ func NewHeimdallApp(
 		appCodec,
 		runtime.NewKVStoreService(keys[topupTypes.StoreKey]),
 		app.BankKeeper,
-		app.StakeKeeper,
 		app.ChainManagerKeeper,
 		&app.caller,
 	)

--- a/x/topup/keeper/keeper.go
+++ b/x/topup/keeper/keeper.go
@@ -23,7 +23,6 @@ type Keeper struct {
 	schema       collections.Schema
 
 	BankKeeper     types.BankKeeper
-	stakeKeeper    types.StakeKeeper
 	ChainKeeper    types.ChainKeeper
 	contractCaller helper.IContractCaller
 
@@ -36,7 +35,6 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService store.KVStoreService,
 	bankKeeper types.BankKeeper,
-	stakeKeeper types.StakeKeeper,
 	chainKeeper types.ChainKeeper,
 	contractCaller helper.IContractCaller,
 ) Keeper {
@@ -46,7 +44,6 @@ func NewKeeper(
 		cdc:            cdc,
 		storeService:   storeService,
 		BankKeeper:     bankKeeper,
-		stakeKeeper:    stakeKeeper,
 		ChainKeeper:    chainKeeper,
 		contractCaller: contractCaller,
 

--- a/x/topup/keeper/keeper_test.go
+++ b/x/topup/keeper/keeper_test.go
@@ -70,8 +70,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 		encCfg.Codec,
 		storeService,
 		bankKeeper,
-		// TODO HV2: replace nil with stakeKeeper mock once implemented
-		nil,
 		chainKeeper,
 		&suite.contractCaller,
 	)

--- a/x/topup/testutil/expected_keepers_mocks.go
+++ b/x/topup/testutil/expected_keepers_mocks.go
@@ -134,29 +134,6 @@ func (mr *MockBankKeeperMockRecorder) SpendableCoin(ctx, addr, denom interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpendableCoin", reflect.TypeOf((*MockBankKeeper)(nil).SpendableCoin), ctx, addr, denom)
 }
 
-// MockStakeKeeper is a mock of StakeKeeper interface.
-type MockStakeKeeper struct {
-	ctrl     *gomock.Controller
-	recorder *MockStakeKeeperMockRecorder
-}
-
-// MockStakeKeeperMockRecorder is the mock recorder for MockStakeKeeper.
-type MockStakeKeeperMockRecorder struct {
-	mock *MockStakeKeeper
-}
-
-// NewMockStakeKeeper creates a new mock instance.
-func NewMockStakeKeeper(ctrl *gomock.Controller) *MockStakeKeeper {
-	mock := &MockStakeKeeper{ctrl: ctrl}
-	mock.recorder = &MockStakeKeeperMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockStakeKeeper) EXPECT() *MockStakeKeeperMockRecorder {
-	return m.recorder
-}
-
 // MockChainKeeper is a mock of ChainKeeper interface.
 type MockChainKeeper struct {
 	ctrl     *gomock.Controller

--- a/x/topup/types/expected_keepers.go
+++ b/x/topup/types/expected_keepers.go
@@ -19,11 +19,6 @@ type BankKeeper interface {
 	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 }
 
-// StakeKeeper defines the stake keeper contract used by x/topup module
-type StakeKeeper interface {
-	// TODO HV2: implement functions for StakeKeeper and generate its mocks
-}
-
 // ChainKeeper defines the chain keeper contract used by x/topup module
 type ChainKeeper interface {
 	GetParams(ctx context.Context) (chainmanagertypes.Params, error)


### PR DESCRIPTION
# Description

Apparently, `stake` keeper in not used in `topup` module (not even in v1, where it's initialized but never accessed).
With this PR, we remove such keeper from the `topup` module.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli