### PR TITLE
Fix make build command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: "Run linter"
         run: make lint
-      
+
       - name: "Build binaries"
-        run: make build
+        run: make heimdalld
 
 
   test:


### PR DESCRIPTION
# Description

Fix make build command in CI after bridge PR got merged

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
