### PR TITLE
fix: `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y && apt-get upgrade -y \
 WORKDIR ${HEIMDALL_DIR}
 COPY . .
 
-RUN make install
+RUN make heimdalld && cp build/heimdalld /usr/local/bin/
 
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
## Description

Fix the `Dockerfile`.

Before:

```bash
$ docker build --tag heimdall-v2 --file Dockerfile .
[+] Building 0.8s (9/10)                                                                                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 485B                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/golang:latest                                                                                                                                               0.4s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [1/6] FROM docker.io/library/golang:latest@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                              0.0s
 => => transferring context: 96.39kB                                                                                                                                                                           0.0s
 => CACHED [2/6] RUN apt-get update -y && apt-get upgrade -y     && apt install build-essential git -y     && mkdir -p /var/lib/heimdall                                                                       0.0s
 => CACHED [3/6] WORKDIR /var/lib/heimdall                                                                                                                                                                     0.0s
 => [4/6] COPY . .                                                                                                                                                                                             0.1s
 => ERROR [5/6] RUN make install                                                                                                                                                                               0.3s
------                                                                                                                                                                                                              
 > [5/6] RUN make install:                                                                                                                                                                                          
0.087 fatal: No names found, cannot describe anything.                                                                                                                                                              
0.088 fatal: No names found, cannot describe anything.
0.247 make: *** No rule to make target 'install'.  Stop.
------

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)
Dockerfile:14
--------------------
  12 |     COPY . .
  13 |     
  14 | >>> RUN make install
  15 |     
  16 |     COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
--------------------
ERROR: failed to solve: process "/bin/sh -c make install" did not complete successfully: exit code: 2

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/0j8fkf9xeb29w8mgzvr26zdh8
```

After:

```bash
$ docker build --tag heimdall-v2 --file Dockerfile .
# ✅ build command works

$ docker run --rm --entrypoint sh -it heimdall-v2
# heimdalld --help
# ✅ command works
```
