### PR TITLE
Milestone Events

### DIFF
--- a/x/milestone/README.md
+++ b/x/milestone/README.md
@@ -97,6 +97,25 @@ string from = 1 [
 }
 ```
 
+## Events
+
+The milestone module emit events on its keeper:
+
+### Keeper Events
+
+Any time we `AddMilestone`, it will trigger the following events
+
+| Type      | Attribute Key |
+| --------  | ------------- |
+| milestone | proposer     |
+| milestone | hash         |
+| milestone | start_block  |
+| milestone | end_block    |
+| milestone | bor_chain_id |
+| milestone | milestone_id |
+| milestone | timestamp    |
+| milestone | number       |
+
 ## Interact with the Node
 
 ### Tx Commands

--- a/x/milestone/keeper/keeper.go
+++ b/x/milestone/keeper/keeper.go
@@ -116,6 +116,8 @@ func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) 
 
 // AddMilestone adds a milestone to the store
 func (k *Keeper) AddMilestone(ctx context.Context, milestone types.Milestone) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
 	// GetMilestoneCount gives the number of previous milestone
 	milestoneNumber, err := k.GetMilestoneCount(ctx)
 	if err != nil {
@@ -136,6 +138,11 @@ func (k *Keeper) AddMilestone(ctx context.Context, milestone types.Milestone) er
 		k.Logger(ctx).Error("error while storing milestone count in store", "err", err)
 		return err
 	}
+
+	// emit milestone event
+	sdkCtx.EventManager().EmitEvent(
+		types.NewMilestoneEvent(milestone, milestoneNumber),
+	)
 
 	return nil
 }

--- a/x/milestone/keeper/keeper_test.go
+++ b/x/milestone/keeper/keeper_test.go
@@ -120,6 +120,12 @@ func (s *KeeperTestSuite) TestAddMilestone() {
 	result, err = keeper.GetMilestoneByNumber(ctx, 2)
 	require.Nil(result)
 	require.Error(err)
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	events := sdkCtx.EventManager().ABCIEvents()
+
+	require.Equal(1, len(events))
+	require.Equal(types.EventTypeMilestone, events[0].Type)
 }
 
 func (s *KeeperTestSuite) TestGetMilestoneCount() {

--- a/x/milestone/types/events.go
+++ b/x/milestone/types/events.go
@@ -1,5 +1,12 @@
 package types
 
+import (
+	"encoding/hex"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // Milestone tags
 var (
 	AttributeKeyProposer      = "proposer"
@@ -12,3 +19,19 @@ var (
 	EventTypeMilestone        = "milestone"
 	EventTypeMilestoneTimeout = "milestone-timeout"
 )
+
+// NewMilestoneEvent construct a new coin minted sdk.Event
+func NewMilestoneEvent(milestone Milestone, milestoneNumber uint64) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeMilestone,
+		sdk.NewAttribute("hash", string(milestone.Hash)),
+		sdk.NewAttribute("proposer", milestone.Proposer),
+		sdk.NewAttribute("hash", hex.EncodeToString(milestone.Hash)),
+		sdk.NewAttribute("start_block", strconv.FormatUint(milestone.StartBlock, 10)),
+		sdk.NewAttribute("end_block", strconv.FormatUint(milestone.EndBlock, 10)),
+		sdk.NewAttribute("bor_chain_id", milestone.BorChainId),
+		sdk.NewAttribute("milestone_id", milestone.MilestoneId),
+		sdk.NewAttribute("timestamp", strconv.FormatUint(milestone.Timestamp, 10)),
+		sdk.NewAttribute("number", strconv.FormatUint(milestoneNumber, 10)),
+	)
+}

--- a/x/milestone/types/events.go
+++ b/x/milestone/types/events.go
@@ -24,7 +24,6 @@ var (
 func NewMilestoneEvent(milestone Milestone, milestoneNumber uint64) sdk.Event {
 	return sdk.NewEvent(
 		EventTypeMilestone,
-		sdk.NewAttribute("hash", string(milestone.Hash)),
 		sdk.NewAttribute("proposer", milestone.Proposer),
 		sdk.NewAttribute("hash", hex.EncodeToString(milestone.Hash)),
 		sdk.NewAttribute("start_block", strconv.FormatUint(milestone.StartBlock, 10)),


### PR DESCRIPTION
# Description

This features enables us including milestone events on cosmos sdk event feature. It allows us subscribe to new blocks and filter milestone events.

You can query events via websocket endpoint:

```
echo '{ "jsonrpc": "2.0","method": "subscribe","id": 0,"params": {"query": "tm.event='"'NewBlock'"' AND milestone.number>0"} }' | websocat -n -t ws://127.0.0.1:26657/websocket
```

And the result will be like:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "query": "tm.event='NewBlock'",
        "data": {
            "type": "tendermint/event/NewBlock",
            "value": {
                "block": {
                    "header": {
                        "version": {
                            "block": "11"
                        },
                        "chain_id": "heimdall-8509",
                        "height": "1983",
                        "time": "2025-03-04T15:13:39.613566597Z",
                        "last_block_id": {
                            "hash": "10AA8156D08D7B3EE963CDF8DC69AB4D2CEFD9151612120EEC6D23CC0AA58C08",
                            "parts": {
                                "total": 1,
                                "hash": "F962ED66CA7F606E062D5B2249A3F715648D01E1F43BDED0E3D9A15A46F74106"
                            }
                        },
                        "last_commit_hash": "7CED70D2E994C325F471F7218FB14446840393F1809C63D0244BF533FEFC197B",
                        "data_hash": "261FA6009219C8B1FFFEAF9CBF526B1AC68D719259A5319ABF70EC98CDF7C86F",
                        "validators_hash": "8FEE2AADCC436D6272D59016783DF28BE340B891D49CEA7414FCA62F8D8EABC0",
                        "next_validators_hash": "8FEE2AADCC436D6272D59016783DF28BE340B891D49CEA7414FCA62F8D8EABC0",
                        "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
                        "app_hash": "6B85F206E343306FCD778DE2D2DDEE08A7BADD371FCE57654ED947F602ACD19D",
                        "last_results_hash": "697AC0DA637A4D63975EEEC4D0114CA918111C81B7B2C0DD7F9BE63F9EC40B40",
                        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
                        "proposer_address": "0DB3924C18D33A4B2B65116B4447EB3DE1CBF730"
                    },
                    "data": {
                        "txs": [
                            "EqkCChkKFA2zkkwY0zpLK2URa0RH6z3hy/cwGJBOGkwKIBCqgVbQjXs+6WPN+Nxpq00s79kVFhISDuxtI8wKpYwIEL4PIiUKIJgmpcOm0Ah9kFEJmGs3MYMNBHk3LYHHOXQIqpvBCI3iEKUGIkEs7GRJNggoKGOjeqt+8Ma0wskVLHHnVwj+wE3YpLaiVy1zQTHCKfQDm7ZAu+FWVAD93v4GVOZUl3X0fTVNzUUQACgCMjYJDQojSEVJTURBTEwtVk9URS1FWFRFTlNJT04jDQoJfAAAAAAAAAe+fGhlaW1kYWxsLTg1MDk6QaFV7M+/Bejmbm8XYtqKPbrSexRKapKU6Ua/Baa8ELHiNW6wXQpMDqHllNZxV9aJHicXqo+Pl7fIwZZ2QNuAqD4BEqkCChkKFI9SJJDmi5BzBX7SL54pJwZkv1MjGJBOGkwKIBCqgVbQjXs+6WPN+Nxpq00s79kVFhISDuxtI8wKpYwIEL4PIiUKIJgmpcOm0Ah9kFEJmGs3MYMNBHk3LYHHOXQIqpvBCI3iEKUGIkHVuiPaJa3t7wp0jbhfYX/ScJNABQOsazFtrl8lDfAEGnenXMOUmfyuL9nK/EU4GCUfjcz1pJysIdivoORG9GK+ASgCMjYJDQojSEVJTURBTEwtVk9URS1FWFRFTlNJT04jDQoJfAAAAAAAAAe+fGhlaW1kYWxsLTg1MDk6Qa7K3upReoipGrtfjEwVlZh3MpswT3GKdOg9U6GZGKznOvx0GxcimbIcM1YxtLR+apT97nsTujr4ChLax+kkT2AA"
                        ]
                    },
                    "evidence": {
                        "evidence": []
                    },
                    "last_commit": {
                        "height": "1982",
                        "round": 0,
                        "block_id": {
                            "hash": "10AA8156D08D7B3EE963CDF8DC69AB4D2CEFD9151612120EEC6D23CC0AA58C08",
                            "parts": {
                                "total": 1,
                                "hash": "F962ED66CA7F606E062D5B2249A3F715648D01E1F43BDED0E3D9A15A46F74106"
                            }
                        },
                        "signatures": [
                            {
                                "block_id_flag": 2,
                                "validator_address": "0DB3924C18D33A4B2B65116B4447EB3DE1CBF730",
                                "timestamp": "2025-03-04T15:13:39.613566597Z",
                                "signature": "XGW8NZqal24skls+mE+n3ffRnHJ0a1y/a249Lqk8xWo8AW0x/MQfNRKKGMYdlDJiyh/zfWgRbC7aS6fPGWk90gA="
                            },
                            {
                                "block_id_flag": 2,
                                "validator_address": "8F522490E68B9073057ED22F9E29270664BF5323",
                                "timestamp": "2025-03-04T15:13:39.709985018Z",
                                "signature": "OblJACV5x0T97WneJBrVwVU7atcj6hOTs6SHh68KMtpKlEyEkcoUSmfHyxALkj4SR0mqgFmBuimDXdbfhMHefgE="
                            }
                        ]
                    }
                },
                "block_id": {
                    "hash": "3FA09E2F20FC305E240A4299436127751E10DFB984B3683A82DF7050C9317C36",
                    "parts": {
                        "total": 1,
                        "hash": "EA4657C96C190C42B6826A91EAF8D4434D87949E1FE6BEF15B6FA9BB0E08A4F8"
                    }
                },
                "result_finalize_block": {
                    "events": [
                        {
                            "type": "milestone",
                            "attributes": [
                                {
                                    "key": "proposer",
                                    "value": "0x0db3924c18d33a4b2b65116b4447eb3de1cbf730",
                                    "index": false
                                },
                                {
                                    "key": "hash",
                                    "value": "9826a5c3a6d0087d905109986b3731830d0479372d81c7397408aa9bc1088de2",
                                    "index": false
                                },
                                {
                                    "key": "start_block",
                                    "value": "805",
                                    "index": false
                                },
                                {
                                    "key": "end_block",
                                    "value": "805",
                                    "index": false
                                },
                                {
                                    "key": "bor_chain_id",
                                    "value": "8509",
                                    "index": false
                                },
                                {
                                    "key": "milestone_id",
                                    "value": "7591f79b6ba7c3dd494a9086d27e02b0a27506bca5eb0d01f0dc2406bfecca3e",
                                    "index": false
                                },
                                {
                                    "key": "timestamp",
                                    "value": "1741101219",
                                    "index": false
                                },
                                {
                                    "key": "number",
                                    "value": "801",
                                    "index": false
                                }
                            ]
                        }
                    ],
                    "tx_results": [
                        {
                            "code": 2,
                            "data": null,
                            "log": "tx parse error",
                            "info": "",
                            "gas_wanted": "0",
                            "gas_used": "0",
                            "events": [],
                            "codespace": "sdk"
                        }
                    ],
                    "validator_updates": [],
                    "consensus_param_updates": {
                        "block": {
                            "max_bytes": "22020096",
                            "max_gas": "-1"
                        },
                        "evidence": {
                            "max_age_num_blocks": "100000",
                            "max_age_duration": "172800000000000",
                            "max_bytes": "1048576"
                        },
                        "validator": {
                            "pub_key_types": [
                                "secp256k1"
                            ]
                        },
                        "version": {},
                        "abci": {
                            "vote_extensions_enable_height": "1"
                        }
                    },
                    "app_hash": "QoVnc+Bvrq7iApEAWIxFPUplfOeTLNApA7PHqF5hg68="
                }
            }
        },
        "events": {
            "milestone.end_block": [
                "805"
            ],
            "tm.event": [
                "NewBlock"
            ],
            "milestone.start_block": [
                "805"
            ],
            "milestone.proposer": [
                "0x0db3924c18d33a4b2b65116b4447eb3de1cbf730"
            ],
            "milestone.bor_chain_id": [
                "8509"
            ],
            "milestone.milestone_id": [
                "7591f79b6ba7c3dd494a9086d27e02b0a27506bca5eb0d01f0dc2406bfecca3e"
            ],
            "milestone.timestamp": [
                "1741101219"
            ],
            "milestone.number": [
                "801"
            ],
            "milestone.hash": [
                "9826a5c3a6d0087d905109986b3731830d0479372d81c7397408aa9bc1088de2"
            ]
        }
    }
}

```

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli
