### PR TITLE
fix migrate command

### DIFF
--- a/cmd/heimdalld/cmd/migrate.go
+++ b/cmd/heimdalld/cmd/migrate.go
@@ -87,7 +87,10 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	genesisFileV1 := args[0]
+	genesisFileV1, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
 
 	if _, err := os.Stat(genesisFileV1); os.IsNotExist(err) {
 		return fmt.Errorf("genesis file does not exist: %s", genesisFileV1)

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -105,7 +105,10 @@ func NewRootCmd() *cobra.Command {
 			customAppTemplate, customAppConfig := initAppConfig()
 			customCMTConfig := initCometBFTConfig()
 
-			if cmd.Name() != commands.InitFilesCmd.Name() && cmd.Name() != commands.VersionCmd.Name() && cmd.Name() != testnetCmdName {
+			if cmd.Name() != commands.InitFilesCmd.Name() &&
+				cmd.Name() != commands.VersionCmd.Name() &&
+				cmd.Name() != MigrateCommand().Name() &&
+				cmd.Name() != testnetCmdName {
 				helper.InitHeimdallConfig("")
 			}
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -917,7 +917,7 @@ func (c *ContractCaller) GetSpanDetails(id *big.Int, validatorSetInstance *valid
 	if err != nil {
 		return nil, nil, nil, errors.New("unable to get span details")
 	}
-	return d.Number, d.StartBlock, d.EndBlock, err
+	return d.Number, d.StartBlock, d.EndBlock, nil
 }
 
 // CurrentStateCounter get state counter


### PR DESCRIPTION
# Description

Fix the `migrate` command based on the migration execution needs:
1. Use absolute path for the `genesis` file path
2. Don't scan for configs in heimdall when running `migrate`

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli