### PR TITLE
metrics for engine client

### DIFF
--- a/engine-api-poc/docker-compose.yaml
+++ b/engine-api-poc/docker-compose.yaml
@@ -266,6 +266,36 @@ services:
       heimdalld-localnet:
         ipv4_address: 172.18.0.11
 
+# Metrics components
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/config.yml:/etc/prometheus/config.yml
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/config.yml"
+    networks:
+      heimdalld-localnet:
+        ipv4_address: 172.18.0.20
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+    environment:
+      # default admin user is "admin"
+      - GF_SECURITY_ADMIN_PASSWORD=secret
+    networks:
+      heimdalld-localnet:
+        ipv4_address: 172.18.0.21
 
 networks:
   heimdalld-localnet:

--- a/engine-api-poc/docker-compose.yaml
+++ b/engine-api-poc/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       - ./build/erigon-0:/erigon
     ports:
       - "8545:8545"
+      - "8551:8551"
 
   erigon-1:
     <<: *erigon-image
@@ -121,7 +122,7 @@ services:
       - ./build/erigon-2:/erigon
     ports:
       - "10545:8545"
-    
+
 
   erigon-3:
     <<: *erigon-image
@@ -182,7 +183,7 @@ services:
   node0:
     <<: *heimdalld-image
     entrypoint: ["./engine-api-poc/start-heimdalld-script.sh"]
-    environment: 
+    environment:
       - BOR_ENGINE_JWT=/erigon/jwt.hex
       - BOR_ENGINE_URL=http://erigon-0:8551
       - BOR_RPC_URL=http://erigon-0:8545
@@ -200,7 +201,7 @@ services:
   node1:
     <<: *heimdalld-image
     entrypoint: ["./engine-api-poc/start-heimdalld-script.sh"]
-    environment: 
+    environment:
       - BOR_ENGINE_JWT=/erigon/jwt.hex
       - BOR_ENGINE_URL=http://erigon-1:8551
       - BOR_RPC_URL=http://erigon-1:8545
@@ -217,7 +218,7 @@ services:
   node2:
     <<: *heimdalld-image
     entrypoint: ["./engine-api-poc/start-heimdalld-script.sh"]
-    environment: 
+    environment:
       - BOR_ENGINE_JWT=/erigon/jwt.hex
       - BOR_ENGINE_URL=http://erigon-2:8551
       - BOR_RPC_URL=http://erigon-2:8545
@@ -234,7 +235,7 @@ services:
   node3:
     <<: *heimdalld-image
     entrypoint: ["./engine-api-poc/start-heimdalld-script.sh"]
-    environment: 
+    environment:
       - BOR_ENGINE_JWT=/erigon/jwt.hex
       - BOR_ENGINE_URL=http://erigon-3:8551
       - BOR_RPC_URL=http://erigon-3:8545
@@ -251,7 +252,7 @@ services:
   node4:
     <<: *heimdalld-image
     entrypoint: ["./engine-api-poc/start-heimdalld-script.sh"]
-    environment: 
+    environment:
       - BOR_ENGINE_JWT=/erigon/jwt.hex
       - BOR_ENGINE_URL=http://erigon-4:8551
       - BOR_RPC_URL=http://erigon-4:8545

--- a/engine-api-poc/grafana/provisioning/datasources/prometheus.yml
+++ b/engine-api-poc/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Heimdall Engine
+    type: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true

--- a/engine-api-poc/prometheus/config.yml
+++ b/engine-api-poc/prometheus/config.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: "heimdalld-nodes"
+    static_configs:
+      - targets:
+        - "node0:2113"
+        - "node1:2113"
+        - "node2:2113"
+        - "node3:2113"
+        - "node4:2113"
+

--- a/engine/auth.go
+++ b/engine/auth.go
@@ -12,19 +12,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-type jwtTransport struct {
-	underlyingTransport http.RoundTripper
-	jwtSecret           []byte
+type JWTTransport struct {
+	Transport http.RoundTripper
+	JWTSecret []byte
 }
 
 // RoundTrip is an HTTP filter that injects a generated JWT token for authentication
-func (t *jwtTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	tokenString, err := generateTokenString(t.jwtSecret)
+func (t *JWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tokenString, err := generateTokenString(t.JWTSecret)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not produce signed JWT token")
 	}
 	req.Header.Set("Authorization", "Bearer "+tokenString)
-	return t.underlyingTransport.RoundTrip(req)
+	return t.Transport.RoundTrip(req)
 }
 
 func parseJWTSecretFromFile(path string) ([]byte, error) {

--- a/engine/auth_test.go
+++ b/engine/auth_test.go
@@ -44,9 +44,9 @@ func TestJWTAuthTransport(t *testing.T) {
 	secret, err := parseJWTSecretFromFile(jwtFile)
 	require.NoError(t, err)
 
-	authTransport := &jwtTransport{
-		underlyingTransport: http.DefaultTransport,
-		jwtSecret:           secret,
+	authTransport := &JWTTransport{
+		Transport: http.DefaultTransport,
+		JWTSecret: secret,
 	}
 	client := &http.Client{
 		Timeout:   DefaultRPCTimeout,

--- a/engine/client.go
+++ b/engine/client.go
@@ -92,7 +92,7 @@ func (ec *EngineClient) NewPayloadV2(ctx context.Context, payload ExecutionPaylo
 	defer observe(newPayloadV2, start, err)
 
 	var msg json.RawMessage
-	msg, err = ec.call(ctx, "engine_newPayloadV2", payload)
+	msg, err = ec.call(ctx, newPayloadV2, payload)
 	if err != nil {
 		return
 	}
@@ -105,7 +105,7 @@ func (ec *EngineClient) CheckCapabilities(ctx context.Context, requiredMethods [
 	defer observe(exchangeCapabilitiesV2, start, err)
 
 	var data []byte
-	data, err = ec.call(ctx, "engine_exchangeCapabilities", requiredMethods)
+	data, err = ec.call(ctx, exchangeCapabilitiesV2, requiredMethods)
 	if err != nil {
 		return err
 	}

--- a/engine/client.go
+++ b/engine/client.go
@@ -51,9 +51,6 @@ func NewEngineClient(url string, jwtFile string) (*EngineClient, error) {
 
 func (ec *EngineClient) Close() {
 	ec.client.CloseIdleConnections()
-	if metricsServer != nil {
-		metricsServer.Shutdown(context.Background())
-	}
 }
 
 func (ec *EngineClient) ForkchoiceUpdatedV2(ctx context.Context, state *ForkChoiceState, attrs *PayloadAttributes) (resp *ForkchoiceUpdatedResponse, err error) {

--- a/engine/client.go
+++ b/engine/client.go
@@ -119,12 +119,12 @@ func (ec *EngineClient) CheckCapabilities(ctx context.Context, requiredMethods [
 	return
 }
 
-func observe(rpc string, start time.Time, err error) {
+func observe(method string, start time.Time, err error) {
 	elapsed := time.Since(start)
-	rpcCalls.WithLabelValues(rpc).Inc()
-	rpcCallDuration.WithLabelValues(rpc).Observe(float64(elapsed.Milliseconds()))
+	rpcCalls.WithLabelValues(method).Inc()
+	rpcDuration.WithLabelValues(method).Observe(float64(elapsed.Milliseconds()))
 	if err != nil {
-		rpcErrors.WithLabelValues(rpc, reflect.TypeOf(err).String()).Inc()
+		rpcErrors.WithLabelValues(method, reflect.TypeOf(err).String()).Inc()
 	}
 }
 

--- a/engine/metrics.go
+++ b/engine/metrics.go
@@ -1,0 +1,79 @@
+package engine
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// For the HTTP transport
+	httpRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_requests",
+			Help: "Total number of HTTP requests made.",
+		},
+		[]string{"method", "status_code"},
+	)
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_request_duration_seconds",
+			Help:    "Histogram of HTTP request durations.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "status_code"},
+	)
+
+	// For specific RPC calls
+	rpcCalls = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rpc_calls",
+			Help: "Total number of RPC calls made.",
+		},
+		[]string{"rpc"},
+	)
+	rpcCallDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rpc_call_duration_seconds",
+			Help:    "Histogram of HTTP request durations.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method"},
+	)
+	rpcErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rpc_errors",
+			Help: "Total number of RPC errors encountered.",
+		},
+		[]string{"rpc", "error"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(httpRequests)
+	prometheus.MustRegister(httpRequestDuration)
+	prometheus.MustRegister(rpcCalls)
+	prometheus.MustRegister(rpcCallDuration)
+	prometheus.MustRegister(rpcErrors)
+}
+
+type MetricsTransport struct {
+	Transport http.RoundTripper
+}
+
+func (mt *MetricsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := mt.Transport.RoundTrip(req)
+	duration := time.Since(start).Seconds()
+
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequests.WithLabelValues(req.Method, fmt.Sprintf("%d", resp.StatusCode)).Inc()
+	httpRequestDuration.WithLabelValues(req.Method, fmt.Sprintf("%d", resp.StatusCode)).Observe(duration)
+
+	return resp, nil
+}

--- a/engine/types.go
+++ b/engine/types.go
@@ -138,4 +138,5 @@ type NewPayloadResponse struct {
 	Status          string `json:"status"`
 	LatestValidHash string `json:"latestValidHash"`
 	ValidationError string `json:"validationError"`
+	CriticalError   string `json:"CriticalError"`
 }


### PR DESCRIPTION
# Description

This PR addresses https://polygon.atlassian.net/browse/POS-2890. 

- metrics interceptor to measure in/out bytes
- metrics that measure count and duration of rpcs calls in engine client

It integrates metrics into the engine client, with a prometheus metrics server.

Docker compose collects metrics with a prometheus server, and connects a grafana instance ( http://127.0.0.1:3000 ), allowing visualizations like this:

Metrics available are the standard `go_` metrics, and `heimdall_` 


![Screenshot 2025-03-17 at 10 17 32 AM](https://github.com/user-attachments/assets/801b9994-c8ac-48b7-82fb-5e87b892f412)


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Debugging:

- Start an erigon node 
- Configure an heimdall in engine mode to use the erigon EL, and start it 
- Go to http://127.0.0.1:2113 to see the metrics endpoint

Inspecting metrics:

- `docker compose up erigon-0 node0 prometheus graphana`
- navigate to grafana at: http://127.0.0.1:3000
- query for metrics like `heimdall_*`

# Additional comments

There are other things to do after this PR
- make it configurable (port, timeouts, etc)
- refactor the metrics server into it's own module, to be shared with the one in bridge
- dashboard configuration for graphana 
