### PR TITLE
Fix round type / verify remote genesis hash with flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,7 @@ jobs:
           sudo apt update
           sudo apt install build-essential
           curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
-          sudo snap install solc
-          sudo apt install python2 jq curl
-          sudo ln -sf /usr/bin/python2 /usr/bin/python
+          sudo apt install jq curl
 
       - uses: actions/setup-node@v4
         with:
@@ -104,6 +102,20 @@ jobs:
             matic-cli/devnet/code/contracts/package-lock.json
             matic-cli/devnet/code/genesis-contracts/package-lock.json
             matic-cli/devnet/code/genesis-contracts/matic-contracts/package-lock.json
+
+      - name: Install solc-select
+        run: |
+          sudo apt update
+          sudo apt install python3 python3-pip -y
+          sudo ln -sf /usr/bin/python3 /usr/bin/python
+          pip install solc-select
+
+      - name: Install Solidity Version
+        run: |
+          solc-select install 0.5.17
+          solc-select install 0.6.12
+          solc-select use 0.5.17
+          solc --version
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/packaging/templates/config/priv_validator_state.json
+++ b/packaging/templates/config/priv_validator_state.json
@@ -1,5 +1,5 @@
 {
   "height": "0",
-  "round": "0",
+  "round": 0,
   "step": 0
 }


### PR DESCRIPTION
# Description

In this PR we implement the following improvements:
1. Fix the `round` type in `priv_validator_state.json` template, since this is now an `int` while it used to be a `string` in `heimdall` v1.
2. Add a flag for the `migrate` command (set to `true` by default). This is helpful for testing purposes.
3. Install `solc-select` in the ci to make sure e2e-tests are working after the latest changes on genesis-contracts

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply