### PR TITLE
Fix block proposer tracking

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -515,5 +515,21 @@ func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 		}
 	}
 
+	// set the block proposer
+	addr, err := sdk.HexifyAddressBytes(req.ProposerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	account, err := sdk.AccAddressFromHex(addr)
+	if err != nil {
+		return nil, err
+	}
+	err = app.AccountKeeper.SetBlockProposer(ctx, account)
+	if err != nil {
+		app.Logger().Error("error while setting the block proposer", "error", err)
+		return nil, err
+	}
+
 	return app.ModuleManager.PreBlock(ctx)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -560,19 +560,6 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 
 // BeginBlocker application updates every begin block
 func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
-	if proposer, ok := app.AccountKeeper.GetBlockProposer(ctx); ok {
-		account, err := sdk.AccAddressFromHex(proposer.String())
-		if err != nil {
-			app.Logger().Error("error while converting the proposer from hex to account address", "error", err)
-			return sdk.BeginBlock{}, err
-		}
-		err = app.AccountKeeper.SetBlockProposer(ctx, account)
-		if err != nil {
-			app.Logger().Error("error while setting the block proposer", "error", err)
-			return sdk.BeginBlock{}, err
-		}
-	}
-
 	return app.ModuleManager.BeginBlock(ctx)
 }
 

--- a/app/test_utils.go
+++ b/app/test_utils.go
@@ -183,8 +183,9 @@ func requestFinalizeBlock(t *testing.T, app *HeimdallApp, height int64, validato
 	commitInfo, err := extCommitInfo.Marshal()
 	require.NoError(t, err)
 	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{
-		Txs:    [][]byte{commitInfo},
-		Height: height,
+		Txs:             [][]byte{commitInfo},
+		Height:          height,
+		ProposerAddress: common.Hex2Bytes(validators[0].Signer),
 	})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
# Description

This PR fixes setting of block proposer by moving it from `BeginBlocker` to `PreBlocker` because initially block proposer won't be set and reward distribution would be incorrect as a result 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

