### PR TITLE
Update packager and fix jsonObjectsCount

### DIFF
--- a/.github/workflows/amoy_deb_profiles.yml
+++ b/.github/workflows/amoy_deb_profiles.yml
@@ -177,7 +177,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.GIT_TAG }}
-          prerelease: true
+          make_latest: false
           files: |
             packaging/deb/heimdall-amoy-**.deb
             packaging/deb/heimdall-amoy-**.deb.checksum

--- a/.github/workflows/mainnet_deb_profiles.yml
+++ b/.github/workflows/mainnet_deb_profiles.yml
@@ -189,7 +189,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.GIT_TAG }}
-          prerelease: true
+          make_latest: false
           files: |
             packaging/deb/heimdall-mainnet-**.deb
             packaging/deb/heimdall-mainnet-**.deb.checksum

--- a/.github/workflows/packager_deb.yml
+++ b/.github/workflows/packager_deb.yml
@@ -120,7 +120,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.GIT_TAG }}
-          prerelease: true
+          make_latest: false
           files: |
             packaging/deb/heimdall**.deb
             packaging/deb/heimdall**.deb.checksum

--- a/cmd/heimdalld/cmd/migration/verify/verify.go
+++ b/cmd/heimdalld/cmd/migration/verify/verify.go
@@ -696,6 +696,7 @@ func getGenesisAppState(hv2GenesisPath string) (heimdallApp.GenesisState, error)
 }
 
 // countJSONArrayEntries streams through a genesis file to count entries in a nested array.
+// If the array is not found, it assumes zero entries instead of returning an error.
 func countJSONArrayEntries(path, module, key string) (int, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -736,7 +737,8 @@ func countJSONArrayEntries(path, module, key string) (int, error) {
 				}
 				delim, ok := t.(json.Delim)
 				if !ok || delim != '[' {
-					return 0, fmt.Errorf("expected array for %s.%s", module, key)
+					// Key found, but not an array → treat as empty
+					return 0, nil
 				}
 				count := 0
 				for dec.More() {
@@ -772,7 +774,8 @@ func countJSONArrayEntries(path, module, key string) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("array %s.%s not found", module, key)
+	// Array not found → treat as zero entries
+	return 0, nil
 }
 
 // getValidatorBasicInfo extracts the basic info of a validator from the genesis file


### PR DESCRIPTION
# Description

Update the packager to fix the bug in pre-release workflow (as done in v1).
Also fix the `countJSONArrayEntries` to assume 0 entries if an array doesn't exist (e.g. no state-syncs)

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes