### PR TITLE
go mod dowload step cached on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN apt-get update -y && apt-get upgrade -y \
     && mkdir -p $HEIMDALL_DIR
 
 WORKDIR ${HEIMDALL_DIR}
+
+# Copy go.mod and go.sum and download first to leverage Docker's cache
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 
 RUN make build && cp build/heimdalld /usr/local/bin/


### PR DESCRIPTION
# Description

By first calling `go mod download` with just `go.mod` and `go.sum` copied, if no changes were found on `go.mod` it Docker caches this step. In general, the download step takes around 200s whiles the build itself take less than 40s.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
