### PR TITLE
IF-FINDING-009

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -345,14 +345,6 @@ func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 
 	extVoteInfo := extCommitInfo.Votes
 
-	if req.Height <= retrieveVoteExtensionsEnableHeight(ctx) {
-		if len(extVoteInfo) != 0 {
-			logger.Error("Unexpected behavior, non-empty VEs found in the initial height's pre-blocker", "height", req.Height)
-			return nil, errors.New("non-empty VEs found in the initial height's pre-blocker")
-		}
-		return app.ModuleManager.PreBlock(ctx)
-	}
-
 	// Fetch txs from block n-1 so that we can match them with the approved txs in block n to execute sideTxs
 	lastBlockTxs, err := app.StakeKeeper.GetLastBlockTxs(ctx)
 	if err != nil {


### PR DESCRIPTION
# Description

Add comments to better clarify code for IF-FINDING-009

When applied the recommendation, I got consensus failure on initial block with ve enabled, if I remove that second check
```
May 12 15:23:56 mardizzone-009-bor-1 heimdalld[40031]: 3:23PM INF finalizing commit of block hash=5C7A4F155C168A3414EA373B3B4C0619E9E1A89DD00AD539671C421006DA339B height=1 module=consensus num_txs=1 root=E3B0C44298FC1C149AFBF4>
May 12 15:23:56 mardizzone-009-bor-1 heimdalld[40031]: 3:23PM ERR CONSENSUS FAILURE!!! err="runtime error: slice bounds out of range [1:0]" module=consensus stack="goroutine 258 [running]:\nruntime/debug.Stack()\n\t/home/ubunt>
May 12 15:23:56 mardizzone-009-bor-1 heimdalld[40031]: 3:23PM INF service stop impl=baseWAL module=consensus msg="Stopping baseWAL service" wal=/var/lib/heimdall/data/cs.wal/wal
May 12 15:23:56 mardizzone-009-bor-1 heimdalld[40031]: 3:23PM INF service stop impl=Group module=consensus msg="Stopping Group service" wal=/var/lib/heimdall/data/cs.wal/wal
May 12 15:23:57 mardizzone-009-bor-1 heimdalld[40031]: 3:23PM INF Timed out dur=1200 height=1 module=consensus round=1 step=RoundStepPropose
```
If I try a restart
```
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: panic: runtime error: slice bounds out of range [1:0]
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: goroutine 1 [running]:
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/0xPolygon/heimdall-v2/app.(*HeimdallApp).PreBlocker(_, {{0x3d91bd0, 0x5a4cd00}, {0x3daf2a0, 0xc000669100}, {{0x0, 0x0}, {0xc001104750, 0xd}, 0x1, ...}, ...}, ..>
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/matic-cli/devnet/code/heimdall/app/abci.go:459 +0x2594
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).preBlock(0xc001f64248, 0xc000932600)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/baseapp/baseapp.go:711 +0x165
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).internalFinalizeBlock(0xc001f64248, {0x3d91bd0, 0x5a4cd00}, 0xc000932600)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/baseapp/abci.go:756 +0xdda
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).FinalizeBlock(0xc001f64248, 0xc000932600)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/baseapp/abci.go:887 +0x16c
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.cometABCIWrapper.FinalizeBlock(...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/cmt_abci.go:44
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/abci/client.(*localClient).FinalizeBlock(0xe00000000000022?, {0x3d91e38?, 0x5a4cd00?}, 0xc0?)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/abci/client/local_client.go:185 +0xc8
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/proxy.(*appConnConsensus).FinalizeBlock(0xc000145620, {0x3d91e38, 0x5a4cd00}, 0xc000932600)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/proxy/app_conn.go:104 +0x157
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/state.(*BlockExecutor).applyBlock(_, {{{0xb, 0x0}, {0xc001e5a230, 0x7}}, {0xc001e5a240, 0xd}, 0x1, 0x0, {{0x0, ...}, ...}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/state/execution.go:224 +0x519
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0xc001e5a230, 0x7}}, {0xc001e5a240, 0xd}, 0x1, 0x0, {{0x0, ...}, ...}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/state/execution.go:219 +0x1d9
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/consensus.(*Handshaker).replayBlock(_, {{{0xb, 0x0}, {0xc001e5a230, 0x7}}, {0xc001e5a240, 0xd}, 0x1, 0x0, {{0x0, ...}, ...}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/consensus/replay.go:536 +0x246
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/consensus.(*Handshaker).ReplayBlocksWithContext(_, {_, _}, {{{0xb, 0x0}, {0xc001e5a230, 0x7}}, {0xc001e5a240, 0xd}, 0x1, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/consensus/replay.go:435 +0x75a
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/consensus.(*Handshaker).HandshakeWithContext(0xc000afba28, {0x3d91d90, 0xc000c7b6d0}, {0x3db5e00, 0xc0023a6000})
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/consensus/replay.go:276 +0x425
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/node.doHandshake({_, _}, {_, _}, {{{0xb, 0x0}, {0xc001e5a230, 0x7}}, {0xc001e5a240, 0xd}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/node/setup.go:186 +0x18b
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cometbft/cometbft/node.NewNodeWithContext({0x3d91d90, 0xc000c7b6d0}, 0xc000513400, {0x3d78b80, 0xc0012680a0}, 0xc000ddccd0, {0x3d5f500, 0xc001076210}, 0xc00108e>
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cometbft@v0.1.4-beta-polygon/node/node.go:360 +0x62e
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.startCmtNode({0x3d91d90, 0xc000c7b6d0}, 0xc000513400, {0x3dd2050, 0xc00028ea08}, 0xc0005cfb80)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:378 +0x3dd
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{{0x0, 0x0}, 0x0, {0xc0013ca2b8, 0x7}, {0x3152337, 0x1}, {0x3152337, 0x1}, ...}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:324 +0x17a
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.start(_, {{0x0, 0x0, 0x0}, {0x3db9ff8, 0xc001c49710}, 0x0, {0x0, 0x0}, {0x3dd1f88, ...}, ...}, ...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:241 +0x2c7
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.StartCmdWithOptions.func2.1()
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:199 +0x63
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.wrapCPUProfile(0xc0005cfb80, 0xc00108f9f8)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:571 +0x1b2
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server.StartCmdWithOptions.func2(0xc001b2b808, {0xc0011f5180?, 0x0?, 0x8?})
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/start.go:198 +0x212
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/spf13/cobra.(*Command).execute(0xc001b2b808, {0xc0011f5100, 0x8, 0x8})
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/spf13/cobra.(*Command).ExecuteC(0xc000665208)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/spf13/cobra.(*Command).Execute(...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/spf13/cobra.(*Command).ExecuteContext(...)
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: github.com/cosmos/cosmos-sdk/server/cmd.Execute(0xc000665208, {0x30ed1cb, 0x2}, {0xc000ff6be0, 0x1d})
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/go/pkg/mod/github.com/0x!polygon/cosmos-sdk@v0.1.16-beta-polygon/server/cmd/execute.go:34 +0x187
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]: main.main()
May 12 15:29:30 mardizzone-009-bor-1 heimdalld[40622]:         /home/ubuntu/matic-cli/devnet/code/heimdall/cmd/heimdalld/main.go:17 +0x45
May 12 15:29:30 mardizzone-009-bor-1 systemd[1]: heimdalld.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
May 12 15:29:30 mardizzone-009-bor-1 systemd[1]: heimdalld.service: Failed with result 'exit-code'.
```