### PR TITLE
chore: add auto-configure option in send-ack command

### DIFF
--- a/x/checkpoint/README.md
+++ b/x/checkpoint/README.md
@@ -2,12 +2,12 @@
 
 ## Table of Contents
 
-* [Overview](#overview)
-* [Interact with the Node](#interact-with-the-node)
-  * [Tx Commands](#tx-commands)
-  * [CLI Query Commands](#cli-query-commands)
-  * [GRPC Endpoints](#grpc-endpoints)
-  * [REST Endpoints](#rest-endpoints)
+- [Overview](#overview)
+- [Interact with the Node](#interact-with-the-node)
+  - [Tx Commands](#tx-commands)
+  - [CLI Query Commands](#cli-query-commands)
+  - [GRPC Endpoints](#grpc-endpoints)
+  - [REST Endpoints](#rest-endpoints)
 
 ## Overview
 
@@ -15,48 +15,56 @@ Heimdall selects the next proposer using Peppermint’s leader selection algorit
 The multi-stage checkpoint process is crucial due to potential failures when submitting checkpoints on the Ethereum chain caused by factors like gas limit, network traffic, or high gas fees.
 Each checkpoint has a validator as the proposer.  
 The outcome of a checkpoint on the Ethereum chain (success or failure) triggers an ack (acknowledgment) or no-ack (no acknowledgment) transaction,  
-altering the proposer for the next checkpoint on Heimdall. 
+altering the proposer for the next checkpoint on Heimdall.
 
 ![Checkpoint Flow.png](checkpoint_flow.png)
 
 ## Flow
 
 ### Checkpoint Proposal
+
 A checkpoint proposal is initiated by a proposer, a validator with POL tokens staked on the L1 Ethereum root chain.  
-The checkpointing process is managed by the `bridge processor` which generates a `MsgCheckpoint` and broadcasts it as a transaction.  
-- The proposer derives the root hash from the Bor chain contract.  
-- Due to Bor’s finality time, the root hash may not always reflect the latest Bor tip.  
+The checkpointing process is managed by the `bridge processor` which generates a `MsgCheckpoint` and broadcasts it as a transaction.
+
+- The proposer derives the root hash from the Bor chain contract.
+- Due to Bor’s finality time, the root hash may not always reflect the latest Bor tip.
 
 ### Checkpoint Processing in Heimdall
+
 Once the checkpoint message is included in a Heimdall block,
 it undergoes processing through the message handling system.  
 Each validator node independently verifies the checkpoint
-by checking the Bor root hash provided in the message against its local Bor chain.  
+by checking the Bor root hash provided in the message against its local Bor chain.
 
 ### ABCI++ Processing Flow for the checkpoint submission on Heimdall
+
 - `Prepare Proposal`: During the proposal phase, the checkpoint message `MsgCheckpoint` is included in the proposed block only if dry-running this tx does not return any errors.
-- `Process Proposal`: The proposal is validated to ensure correctness.  
+- `Process Proposal`: The proposal is validated to ensure correctness.
 - `Pre-Commit`: As part of the voting process, validators execute a side transaction to verify the checkpoint against their local Bor data.
-If the checkpoint is valid, validators include a vote extension confirming their approval.  
+  If the checkpoint is valid, validators include a vote extension confirming their approval.
 - `Verify Vote`: Injected votes are verified.  
-• `Next block - Finalize`: In the next block, the finalized votes are processed, and the checkpoint is considered approved if a sufficient majority supports it.  
-The `preBlocker` triggers post-tx handlers performing the Heimdall state changes when the checkpoint is finally saved in the checkpoint buffer as the checkpoint that needs to be further bridged to the Ethereum L1 root chain.
+  • `Next block - Finalize`: In the next block, the finalized votes are processed, and the checkpoint is considered approved if a sufficient majority supports it.  
+  The `preBlocker` triggers post-tx handlers performing the Heimdall state changes when the checkpoint is finally saved in the checkpoint buffer as the checkpoint that needs to be further bridged to the Ethereum L1 root chain.
 
 ### Submission to Ethereum (L1)
-Once approved, the checkpoint is added to a checkpoint buffer and an event is emitted. The bridge system, which listens for these events, submits the checkpoint data along with validator signatures to the Ethereum root chain.  
+
+Once approved, the checkpoint is added to a checkpoint buffer and an event is emitted. The bridge system, which listens for these events, submits the checkpoint data along with validator signatures to the Ethereum root chain.
 
 ### Acknowledgment from Ethereum (L1)
+
 After the checkpoint is successfully included on the Ethereum chain, an acknowledgment `MsgCpAck` is sent back to Heimdall from the bridge processor.  
 This acknowledgment, once processed through the ABCI++ flow with side and post-tx handlers: updates the state, flushes processed checkpoints from the buffer, and increments the number of ACK counters to track confirmations of checkpoints.  
-Additionally, the selection of the next checkpoint proposer is adjusted based on the updated state.  
+Additionally, the selection of the next checkpoint proposer is adjusted based on the updated state.
 
 ### Missing Checkpoint Acknowledgment from Ethereum (L1)
+
 The `MsgCpNoAck` message is broadcast by the bridge processor to indicate that a checkpoint was potentially transferred to the Ethereum chain but has not received an acknowledgment.  
-A background routine periodically checks for time elapsed and publishes the No-ACK signal. No-ACK is sent if a sufficient amount of time has passed since:  
+A background routine periodically checks for time elapsed and publishes the No-ACK signal. No-ACK is sent if a sufficient amount of time has passed since:
+
 - the last checkpoint was created on the Heimdall v2 chain and
 - the last No-ACK was issued.  
-To conclude, the No-ACKs are triggered only when a checkpoint acknowledgment is overdue, ensuring they are not sent too frequently.  
-This message is broadcasted only by the proposer. This entire flow ensures that checkpoints are securely proposed, verified, and finalized across the Heimdall and Ethereum chains in a decentralized manner.  
+  To conclude, the No-ACKs are triggered only when a checkpoint acknowledgment is overdue, ensuring they are not sent too frequently.  
+  This message is broadcasted only by the proposer. This entire flow ensures that checkpoints are securely proposed, verified, and finalized across the Heimdall and Ethereum chains in a decentralized manner.
 
 ![Checkpoint ABCI diagram.png](checkpoint_diagram.png)
 
@@ -134,14 +142,15 @@ message MsgCpNoAck {
 ### Tx Commands
 
 #### Send checkpoint
+
 ```bash
-heimdalld tx checkpoint send-checkpoint --proposer=<proposer-address> --start-block=<start-block-number> --end-block=<end-block-number> --root-hash=<root-hash> --account-root=<account-root> --bor-chain-id=<bor-chain-id> --chain-id=<chain-id> --auto-configure=true/false
+heimdalld tx checkpoint send-checkpoint --proposer=<proposer-address> --start-block=<start-block-number> --end-block=<end-block-number> --root-hash=<root-hash> --account-root=<account-root> --bor-chain-id=<bor-chain-id> --auto-configure=true/false
 ```
 
 #### Send checkpoint ack
 
 ```bash
-heimdalld tx checkpoint send-ack --tx-hash=<checkpoint-tx-hash> --log-index=<log-index> --header=<header> --proposer=<proposer-address> --chain-id=<heimdall-chainid>
+heimdalld tx checkpoint send-ack --tx-hash=<checkpoint-tx-hash> --log-index=<log-index> --header=<header> --proposer=<proposer-address> --auto-configure=true/false
 ```
 
 #### Send checkpoint no-ack
@@ -154,17 +163,17 @@ heimdalld tx checkpoint checkpoint-no-ack --from <from>
 
 One can run the following query commands from the checkpoint module:
 
-* `get-params` - Get checkpoint params
-* `get-overview` - Get checkpoint overview
-* `get-ack-count` - Get checkpoint ack count
-* `get-checkpoint` - Get checkpoint based on its number
-* `get-checkpoint-latest` - Get the latest checkpoint
-* `get-checkpoint-buffer` - Get the checkpoint buffer
-* `get-last-no-ack` - Get the last no ack
-* `get-next-checkpoint` - Get the next checkpoint
-* `get-current-proposer` - Get the current proposer
-* `get-proposers` - Get the proposers
-* `get-checkpoint-list` - Get the list of checkpoints
+- `get-params` - Get checkpoint params
+- `get-overview` - Get checkpoint overview
+- `get-ack-count` - Get checkpoint ack count
+- `get-checkpoint` - Get checkpoint based on its number
+- `get-checkpoint-latest` - Get the latest checkpoint
+- `get-checkpoint-buffer` - Get the checkpoint buffer
+- `get-last-no-ack` - Get the last no ack
+- `get-next-checkpoint` - Get the next checkpoint
+- `get-current-proposer` - Get the current proposer
+- `get-proposers` - Get the proposers
+- `get-checkpoint-list` - Get the list of checkpoints
 
 ```bash
 heimdalld query checkpoint get-params
@@ -268,46 +277,37 @@ grpcurl -plaintext -d '{"number": <>}' localhost:9090 heimdallv2.checkpoint.Quer
 The endpoints and the params are defined in the [checkpoint/query.proto](/proto/heimdallv2/checkpoint/query.proto) file.
 Please refer to them for more information about the optional params.
 
-
 ```bash
 curl localhost:1317/checkpoints/params
 ```
-
 
 ```bash
 curl localhost:1317/checkpoints/overview
 ```
 
-
 ```bash
 curl localhost:1317/checkpoints/count
 ```
-
 
 ```bash
 curl localhost:1317/checkpoints/latest
 ```
 
-
 ```bash
 curl localhost:1317/checkpoints/buffer
 ```
-
 
 ```bash
 curl localhost:1317/checkpoints/last-no-ack
 ```
 
-
 ```bash
 curl localhost:1317/checkpoints/prepare-next
 ```
 
-
 ```bash
 curl localhost:1317/checkpoint/proposers/current
 ```
-
 
 ```bash
 curl localhost:1317/checkpoint/proposers/{times}

--- a/x/checkpoint/client/cli/flags.go
+++ b/x/checkpoint/client/cli/flags.go
@@ -11,4 +11,5 @@ const (
 	FlagCheckpointTxHash   = "tx-hash"
 	FlagCheckpointLogIndex = "log-index"
 	FlagAutoConfigure      = "auto-configure"
+	FlagCheckpointNumber   = "checkpoint-number"
 )

--- a/x/checkpoint/client/cli/tx.go
+++ b/x/checkpoint/client/cli/tx.go
@@ -202,7 +202,7 @@ func SendCheckpointAckCmd() *cobra.Command {
 					return fmt.Errorf("failed to get current header block number: %w", err)
 				}
 
-				block, err := rootChainInstance.HeaderBlocks(nil, big.NewInt(int64(blockNum-1)))
+				block, err := rootChainInstance.HeaderBlocks(nil, big.NewInt(int64(blockNum*checkpointParams.Params.ChildChainBlockInterval)))
 				if err != nil {
 					return fmt.Errorf("failed to get header block: %w", err)
 				}

--- a/x/checkpoint/client/cli/tx.go
+++ b/x/checkpoint/client/cli/tx.go
@@ -184,7 +184,6 @@ func SendCheckpointAckCmd() *cobra.Command {
 					return fmt.Errorf("failed to fetch chain manager params: %w", err)
 				}
 
-				fmt.Printf("Using Root Chain Address: %s\n", chainManagerParams.Params.ChainParams.RootChainAddress)
 				rootChainInstance, err := contractCaller.GetRootChainInstance(chainManagerParams.Params.ChainParams.RootChainAddress)
 				if err != nil {
 					return fmt.Errorf("failed to get root chain instance: %w", err)
@@ -196,7 +195,6 @@ func SendCheckpointAckCmd() *cobra.Command {
 					return fmt.Errorf("failed to fetch checkpoint params: %w", err)
 				}
 
-				fmt.Printf("Using Child Chain Block Interval: %d\n", checkpointParams.Params.ChildChainBlockInterval)
 				blockNum, err := contractCaller.CurrentHeaderBlock(rootChainInstance, checkpointParams.Params.ChildChainBlockInterval)
 				if err != nil {
 					return fmt.Errorf("failed to get current header block number: %w", err)
@@ -206,13 +204,11 @@ func SendCheckpointAckCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to get header block: %w", err)
 				}
-				fmt.Printf("Current header block: %v\n", block)
 
 				proposerAddress, err := helper.GetAddressString()
 				if err != nil {
 					return fmt.Errorf("failed to get proposer address: %w", err)
 				}
-				fmt.Printf("Using Proposer Address: %s\n", proposerAddress)
 
 				msg := types.NewMsgCpAck(
 					proposerAddress,
@@ -222,12 +218,6 @@ func SendCheckpointAckCmd() *cobra.Command {
 					block.End.Uint64(),
 					block.Root[:],
 				)
-				fmt.Printf("Proposer Address: %v\n", proposerAddress)
-				fmt.Printf("Header Block Number: %v\n", blockNum)
-				fmt.Printf("Checkpoint Proposer: %v\n", block.Proposer.Hex())
-				fmt.Printf("Checkpoint Start: %v\n", block.Start.Uint64())
-				fmt.Printf("Checkpoint End: %v\n", block.End.Uint64())
-				fmt.Printf("Checkpoint Root: %v\n", common.Bytes2Hex(block.Root[:]))
 
 				return cli.BroadcastMsg(clientCtx, proposerAddress, &msg, logger)
 			}

--- a/x/checkpoint/client/cli/tx.go
+++ b/x/checkpoint/client/cli/tx.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 	"strconv"
 
 	"cosmossdk.io/core/address"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	codec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
@@ -17,6 +17,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/helper"
 	chainmanagerTypes "github.com/0xPolygon/heimdall-v2/x/chainmanager/types"
 	"github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
+	checkpointTypes "github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
 	stakeTypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
@@ -26,76 +27,82 @@ var logger = helper.Logger.With("module", "checkpoint/client/cli")
 func NewTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      "Checkpoint module commands",
+		Short:                      "Commands for the Checkpoint module",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
 
-	ac := codec.NewHexCodec()
+	addressCodec := codec.NewHexCodec()
 
 	txCmd.AddCommand(
-		SendCheckpointCmd(ac),
+		SendCheckpointCmd(addressCodec),
 		SendCheckpointAckCmd(),
 	)
 
 	return txCmd
 }
 
-// SendCheckpointCmd returns a CLI command handler to create a `MsgCheckpoint` transaction.
-func SendCheckpointCmd(ac address.Codec) *cobra.Command {
+// SendCheckpointCmd returns a CLI command handler for creating a MsgCheckpoint transaction.
+func SendCheckpointCmd(addressCodec address.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send-checkpoint",
-		Short: "send checkpoint to cometBFT and ethereum",
+		Short: "Send a checkpoint to CometBFT and Ethereum",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			// bor chain id
+			// Bor ChainID
 			borChainID := viper.GetString(FlagBorChainID)
 			if borChainID == "" {
-				return fmt.Errorf("bor chain id cannot be empty")
+				return fmt.Errorf("bor chain ID cannot be empty")
 			}
 
 			if viper.GetBool(FlagAutoConfigure) {
 				stakeQueryClient := stakeTypes.NewQueryClient(clientCtx)
 				checkpointQueryClient := types.NewQueryClient(clientCtx)
-				proposer, err := stakeQueryClient.GetCurrentProposer(cmd.Context(), &stakeTypes.QueryCurrentProposerRequest{})
+				proposerResponse, err := stakeQueryClient.GetCurrentProposer(cmd.Context(), &stakeTypes.QueryCurrentProposerRequest{})
 				if err != nil {
 					return err
 				}
 
-				signerBytes, err := ac.StringToBytes(proposer.Validator.Signer)
+				signerBytes, err := addressCodec.StringToBytes(proposerResponse.Validator.Signer)
 				if err != nil {
-					return fmt.Errorf("the validator signer address is invalid: %w", err)
+					return fmt.Errorf("invalid validator signer address: %w", err)
 				}
 
 				if !bytes.Equal(signerBytes, helper.GetAddress()) {
-					return fmt.Errorf("please wait for your turn to propose checkpoint. Checkpoint proposer: %v", proposer.Validator.Signer)
+					return fmt.Errorf("please wait for your turn to propose a checkpoint. Current proposer: %v", proposerResponse.Validator.Signer)
 				}
 
-				nextCheckpoint, err := checkpointQueryClient.GetNextCheckpoint(cmd.Context(), &types.QueryNextCheckpointRequest{})
+				nextCheckpointResponse, err := checkpointQueryClient.GetNextCheckpoint(cmd.Context(), &types.QueryNextCheckpointRequest{})
 				if err != nil {
 					return err
 				}
 
-				msg := types.NewMsgCheckpointBlock(proposer.Validator.Signer, nextCheckpoint.Checkpoint.StartBlock, nextCheckpoint.Checkpoint.EndBlock, nextCheckpoint.Checkpoint.RootHash, nextCheckpoint.Checkpoint.AccountRootHash, borChainID)
+				msg := types.NewMsgCheckpointBlock(
+					proposerResponse.Validator.Signer,
+					nextCheckpointResponse.Checkpoint.StartBlock,
+					nextCheckpointResponse.Checkpoint.EndBlock,
+					nextCheckpointResponse.Checkpoint.RootHash,
+					nextCheckpointResponse.Checkpoint.AccountRootHash,
+					borChainID,
+				)
 
-				return cli.BroadcastMsg(clientCtx, proposer.Validator.Signer, msg, logger)
+				return cli.BroadcastMsg(clientCtx, proposerResponse.Validator.Signer, msg, logger)
 			}
 
-			// get and check the proposer
-			proposer := viper.GetString(FlagProposerAddress)
-			if proposer == "" {
-				proposer, err = helper.GetAddressString()
+			proposerAddress := viper.GetString(FlagProposerAddress)
+			if proposerAddress == "" {
+				proposerAddress, err = helper.GetAddressString()
 				if err != nil {
-					return fmt.Errorf("the proposer address is invalid: %w", err)
+					return fmt.Errorf("invalid proposer address: %w", err)
 				}
 			}
 
-			//	start block
+			// Start Block
 			startBlockStr := viper.GetString(FlagStartBlock)
 			if startBlockStr == "" {
 				return fmt.Errorf("start block cannot be empty")
@@ -106,7 +113,7 @@ func SendCheckpointCmd(ac address.Codec) *cobra.Command {
 				return err
 			}
 
-			//	end block
+			// End Block
 			endBlockStr := viper.GetString(FlagEndBlock)
 			if endBlockStr == "" {
 				return fmt.Errorf("end block cannot be empty")
@@ -117,21 +124,28 @@ func SendCheckpointCmd(ac address.Codec) *cobra.Command {
 				return err
 			}
 
-			// root hash
+			// Root Hash
 			rootHashStr := viper.GetString(FlagRootHash)
 			if rootHashStr == "" {
 				return fmt.Errorf("root hash cannot be empty")
 			}
 
-			// account Root Hash
+			// Account Root Hash
 			accountRootHashStr := viper.GetString(FlagAccountRootHash)
 			if accountRootHashStr == "" {
 				return fmt.Errorf("account root hash cannot be empty")
 			}
 
-			msg := types.NewMsgCheckpointBlock(proposer, startBlock, endBlock, common.FromHex(rootHashStr), common.FromHex(accountRootHashStr), borChainID)
+			msg := types.NewMsgCheckpointBlock(
+				proposerAddress,
+				startBlock,
+				endBlock,
+				common.FromHex(rootHashStr),
+				common.FromHex(accountRootHashStr),
+				borChainID,
+			)
 
-			return cli.BroadcastMsg(clientCtx, proposer, msg, logger)
+			return cli.BroadcastMsg(clientCtx, proposerAddress, msg, logger)
 		},
 	}
 
@@ -141,7 +155,6 @@ func SendCheckpointCmd(ac address.Codec) *cobra.Command {
 	cmd.Flags().StringP(FlagRootHash, "r", "", "--root-hash=<root-hash>")
 	cmd.Flags().String(FlagAccountRootHash, "", "--account-root=<account-root>")
 	cmd.Flags().String(FlagBorChainID, "", "--bor-chain-id=<bor-chain-id>")
-	cmd.Flags().String(flags.FlagChainID, "", "--chain-id=<chain-id>")
 	cmd.Flags().Bool(FlagAutoConfigure, false, "--auto-configure=true/false")
 
 	return cmd
@@ -151,19 +164,74 @@ func SendCheckpointCmd(ac address.Codec) *cobra.Command {
 func SendCheckpointAckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send-ack",
-		Short: "send acknowledgement for checkpoint in buffer",
+		Short: "Send an acknowledgment for a checkpoint in the buffer",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			// get and check the proposer
-			proposer := viper.GetString(FlagProposerAddress)
-			if proposer == "" {
-				proposer, err = helper.GetAddressString()
+			if viper.GetBool(FlagAutoConfigure) {
+				// Auto-configure mode
+				contractCaller, err := helper.NewContractCaller()
 				if err != nil {
-					return fmt.Errorf("the proposer address is invalid: %w", err)
+					return err
+				}
+
+				queryClient := chainmanagerTypes.NewQueryClient(clientCtx)
+				chainManagerParams, err := queryClient.GetChainManagerParams(cmd.Context(), &chainmanagerTypes.QueryParamsRequest{})
+				if err != nil {
+					return fmt.Errorf("failed to fetch chain manager params: %w", err)
+				}
+
+				fmt.Printf("Using Root Chain Address: %s\n", chainManagerParams.Params.ChainParams.RootChainAddress)
+				rootChainInstance, err := contractCaller.GetRootChainInstance(chainManagerParams.Params.ChainParams.RootChainAddress)
+				if err != nil {
+					return fmt.Errorf("failed to get root chain instance: %w", err)
+				}
+
+				checkpointQueryClient := checkpointTypes.NewQueryClient(clientCtx)
+				checkpointParams, err := checkpointQueryClient.GetCheckpointParams(cmd.Context(), &checkpointTypes.QueryParamsRequest{})
+				if err != nil {
+					return fmt.Errorf("failed to fetch checkpoint params: %w", err)
+				}
+
+				fmt.Printf("Using Child Chain Block Interval: %d\n", checkpointParams.Params.ChildChainBlockInterval)
+				blockNum, err := contractCaller.CurrentHeaderBlock(rootChainInstance, checkpointParams.Params.ChildChainBlockInterval)
+				if err != nil {
+					return fmt.Errorf("failed to get current header block number: %w", err)
+				}
+
+				block, err := rootChainInstance.HeaderBlocks(nil, big.NewInt(int64(blockNum)))
+				if err != nil {
+					return fmt.Errorf("failed to get header block: %w", err)
+				}
+				fmt.Printf("Current header block: %v\n", block)
+
+				proposerAddress, err := helper.GetAddressString()
+				if err != nil {
+					return fmt.Errorf("failed to get proposer address: %w", err)
+				}
+				fmt.Printf("Using Proposer Address: %s\n", proposerAddress)
+
+				msg := types.NewMsgCpAck(
+					proposerAddress,
+					blockNum,
+					block.Proposer.Hex(),
+					block.Start.Uint64(),
+					block.End.Uint64(),
+					block.Root[:],
+				)
+				fmt.Printf("Checkpoint Ack Message: %s\n", msg.String())
+
+				return cli.BroadcastMsg(clientCtx, proposerAddress, &msg, logger)
+			}
+
+			proposerAddress := viper.GetString(FlagProposerAddress)
+			if proposerAddress == "" {
+				proposerAddress, err = helper.GetAddressString()
+				if err != nil {
+					return fmt.Errorf("invalid proposer address: %w", err)
 				}
 			}
 
@@ -179,43 +247,53 @@ func SendCheckpointAckCmd() *cobra.Command {
 
 			txHashStr := viper.GetString(FlagCheckpointTxHash)
 			if txHashStr == "" {
-				return fmt.Errorf("checkpoint tx hash cannot be empty")
+				return fmt.Errorf("checkpoint transaction hash cannot be empty")
 			}
 
 			txHash := common.HexToHash(txHashStr)
 
-			// get header block details
+			// Get header block details
 			contractCaller, err := helper.NewContractCaller()
 			if err != nil {
 				return err
 			}
 
-			// fetch params
+			// Fetch params
 			queryClient := chainmanagerTypes.NewQueryClient(clientCtx)
-			cmParams, err := queryClient.GetChainManagerParams(cmd.Context(), &chainmanagerTypes.QueryParamsRequest{})
+			chainManagerParams, err := queryClient.GetChainManagerParams(cmd.Context(), &chainmanagerTypes.QueryParamsRequest{})
 			if err != nil {
 				return err
 			}
 
-			// get main tx receipt
-			receipt, err := contractCaller.GetConfirmedTxReceipt(txHash, cmParams.Params.MainChainTxConfirmations)
+			receipt, err := contractCaller.GetConfirmedTxReceipt(txHash, chainManagerParams.Params.MainChainTxConfirmations)
 			if err != nil || receipt == nil {
-				return fmt.Errorf("transaction %s is not confirmed yet, please wait for some time and try again", txHash)
+				return fmt.Errorf("transaction %s is not confirmed yet, please wait and try again later", txHash)
 			}
 
-			// decode the new header block event
-			res, err := contractCaller.DecodeNewHeaderBlockEvent(
-				cmParams.Params.ChainParams.RootChainAddress,
+			logIndex := viper.GetInt64(FlagCheckpointLogIndex)
+			if logIndex < 0 {
+				return fmt.Errorf("log index must be a non-negative integer")
+			}
+
+			decodedEvent, err := contractCaller.DecodeNewHeaderBlockEvent(
+				chainManagerParams.Params.ChainParams.RootChainAddress,
 				receipt,
-				uint64(viper.GetInt64(FlagCheckpointLogIndex)),
+				uint64(logIndex),
 			)
 			if err != nil {
-				return fmt.Errorf("invalid transaction for header block. Error: %w", err)
+				return fmt.Errorf("invalid transaction for header block. error: %w", err)
 			}
 
-			msg := types.NewMsgCpAck(proposer, headerBlock, res.Proposer.String(), res.Start.Uint64(), res.End.Uint64(), res.Root[:])
+			msg := types.NewMsgCpAck(
+				proposerAddress,
+				headerBlock,
+				decodedEvent.Proposer.String(),
+				decodedEvent.Start.Uint64(),
+				decodedEvent.End.Uint64(),
+				decodedEvent.Root[:],
+			)
 
-			return cli.BroadcastMsg(clientCtx, proposer, &msg, logger)
+			return cli.BroadcastMsg(clientCtx, proposerAddress, &msg, logger)
 		},
 	}
 
@@ -223,19 +301,7 @@ func SendCheckpointAckCmd() *cobra.Command {
 	cmd.Flags().String(FlagHeaderNumber, "", "--header=<header-index>")
 	cmd.Flags().StringP(FlagCheckpointTxHash, "t", "", "--txhash=<checkpoint-txhash>")
 	cmd.Flags().String(FlagCheckpointLogIndex, "", "--log-index=<log-index>")
-	cmd.Flags().String(flags.FlagChainID, "", "--chain-id=<chain-id>")
-
-	if err := cmd.MarkFlagRequired(FlagHeaderNumber); err != nil {
-		logger.Error("SendCheckpointACKTx | MarkFlagRequired | FlagHeaderNumber", "Error", err)
-	}
-
-	if err := cmd.MarkFlagRequired(FlagCheckpointTxHash); err != nil {
-		logger.Error("SendCheckpointACKTx | MarkFlagRequired | FlagCheckpointTxHash", "Error", err)
-	}
-
-	if err := cmd.MarkFlagRequired(FlagCheckpointLogIndex); err != nil {
-		logger.Error("SendCheckpointACKTx | MarkFlagRequired | FlagCheckpointLogIndex", "Error", err)
-	}
+	cmd.Flags().Bool(FlagAutoConfigure, false, "--auto-configure=true/false")
 
 	return cmd
 }

--- a/x/checkpoint/client/cli/tx.go
+++ b/x/checkpoint/client/cli/tx.go
@@ -202,7 +202,7 @@ func SendCheckpointAckCmd() *cobra.Command {
 					return fmt.Errorf("failed to get current header block number: %w", err)
 				}
 
-				block, err := rootChainInstance.HeaderBlocks(nil, big.NewInt(int64(blockNum)))
+				block, err := rootChainInstance.HeaderBlocks(nil, big.NewInt(int64(blockNum-1)))
 				if err != nil {
 					return fmt.Errorf("failed to get header block: %w", err)
 				}
@@ -222,7 +222,12 @@ func SendCheckpointAckCmd() *cobra.Command {
 					block.End.Uint64(),
 					block.Root[:],
 				)
-				fmt.Printf("Checkpoint Ack Message: %s\n", msg.String())
+				fmt.Printf("Proposer Address: %v\n", proposerAddress)
+				fmt.Printf("Header Block Number: %v\n", blockNum)
+				fmt.Printf("Checkpoint Proposer: %v\n", block.Proposer.Hex())
+				fmt.Printf("Checkpoint Start: %v\n", block.Start.Uint64())
+				fmt.Printf("Checkpoint End: %v\n", block.End.Uint64())
+				fmt.Printf("Checkpoint Root: %v\n", common.Bytes2Hex(block.Root[:]))
 
 				return cli.BroadcastMsg(clientCtx, proposerAddress, &msg, logger)
 			}


### PR DESCRIPTION
# Description
```bash
heimdalld tx checkpoint send-ack --auto-configure=true --home /var/lib/heimdall/

11:14AM INF Tx with hash 9AEB25F3D41A71104F1617D0448F90574111E907D6BD87A7EC56EA55C0B36EF4 broadcasted successfully. module=checkpoint/client/cli
```

- README formatting
- Removed the unused `--chain-id` flag from both the commands
- Added FlagAutoConfigure in SendCheckpointAckCmd