### PR TITLE
fix action release

### DIFF
--- a/.github/workflows/amoy_deb_profiles.yml
+++ b/.github/workflows/amoy_deb_profiles.yml
@@ -174,7 +174,7 @@ jobs:
         run: ls -ltr packaging/deb/ | grep heimdall
 
       - name: Release heimdall Packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: ${{ env.GIT_TAG }}
           make_latest: false

--- a/.github/workflows/mainnet_deb_profiles.yml
+++ b/.github/workflows/mainnet_deb_profiles.yml
@@ -186,7 +186,7 @@ jobs:
         run: ls -ltr packaging/deb/ | grep heimdall
 
       - name: Release heimdall Packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: ${{ env.GIT_TAG }}
           make_latest: false

--- a/.github/workflows/packager_deb.yml
+++ b/.github/workflows/packager_deb.yml
@@ -117,7 +117,7 @@ jobs:
           ARCH: arm64
 
       - name: Release heimdall Packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: ${{ env.GIT_TAG }}
           make_latest: false


### PR DESCRIPTION
# Description

There is a workflow issue from the use of on of the workflow action `softprops/action-gh-release@v2`. 
This action had a recent update which broke smth (see (this)[https://github.com/softprops/action-gh-release/issues/628])
Using v2.2.2

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
