### PR TITLE
Dedup init of client context

### DIFF
--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -152,6 +152,7 @@ func initRootCmd(
 	hApp *app.HeimdallApp,
 	keyring keyring.Keyring,
 	keyringDir string,
+	initClientCtx client.Context,
 ) {
 	ctx := server.NewDefaultContext()
 
@@ -195,6 +196,7 @@ func initRootCmd(
 				return err
 			}
 
+			fmt.Println("KEYRING DIR IN INITCLIENTCTX:", initClientCtx.KeyringDir)
 			clientCtx = clientCtx.
 				WithKeyring(keyring).
 				WithKeyringDir(keyringDir).

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -149,7 +149,6 @@ func initRootCmd(
 	_ client.TxConfig,
 	basicManager module.BasicManager,
 	hApp *app.HeimdallApp,
-	initClientCtx client.Context,
 ) {
 	ctx := server.NewDefaultContext()
 

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -193,7 +193,6 @@ func initRootCmd(
 				return err
 			}
 
-			fmt.Println("KEYRING DIR IN INITCLIENTCTX:", initClientCtx.KeyringDir)
 			clientCtx = clientCtx.
 				WithChainID(chainParam.ChainParams.HeimdallChainId)
 

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -198,8 +198,8 @@ func initRootCmd(
 
 			fmt.Println("KEYRING DIR IN INITCLIENTCTX:", initClientCtx.KeyringDir)
 			clientCtx = clientCtx.
-				WithKeyring(keyring).
-				WithKeyringDir(keyringDir).
+				// WithKeyring(keyring).
+				// WithKeyringDir(keyringDir).
 				WithChainID(chainParam.ChainParams.HeimdallChainId)
 
 			// start bridge

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/server/types"
@@ -150,8 +149,6 @@ func initRootCmd(
 	_ client.TxConfig,
 	basicManager module.BasicManager,
 	hApp *app.HeimdallApp,
-	keyring keyring.Keyring,
-	keyringDir string,
 	initClientCtx client.Context,
 ) {
 	ctx := server.NewDefaultContext()
@@ -198,8 +195,6 @@ func initRootCmd(
 
 			fmt.Println("KEYRING DIR IN INITCLIENTCTX:", initClientCtx.KeyringDir)
 			clientCtx = clientCtx.
-				// WithKeyring(keyring).
-				// WithKeyringDir(keyringDir).
 				WithChainID(chainParam.ChainParams.HeimdallChainId)
 
 			// start bridge

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -1,6 +1,7 @@
 package heimdalld
 
 import (
+	"fmt"
 	"os"
 
 	"cosmossdk.io/log"
@@ -73,10 +74,7 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
-			if err != nil {
-				return err
-			}
+			fmt.Println("HOME AFTER!!:", initClientCtx.HomeDir)
 
 			// This needs to go after ReadFromClientConfig, as that function
 			// sets the RPC client needed for SIGN_MODE_TEXTUAL. This sign mode
@@ -155,7 +153,8 @@ func NewRootCmd() *cobra.Command {
 
 	initClientCtx, _ = config.ReadFromClientConfig(initClientCtx)
 
-	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx.Keyring, initClientCtx.KeyringDir)
+	fmt.Println("KEYRING DIR BEFORE initRootCmd:", initClientCtx.KeyringDir)
+	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx.Keyring, initClientCtx.KeyringDir, initClientCtx)
 
 	// add keyring to autocli opts
 	autoCliOpts := tempApp.AutoCliOpts()

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -153,7 +153,7 @@ func NewRootCmd() *cobra.Command {
 	helper.DecorateWithHeimdallFlags(rootCmd, viper.GetViper(), logger, "main")
 	helper.DecorateWithCometBFTFlags(rootCmd, viper.GetViper(), logger, "main")
 
-	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx)
+	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp)
 
 	// add keyring to autocli opts
 	autoCliOpts := tempApp.AutoCliOpts()

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cometbft/cometbft/cmd/cometbft/commands"
 	db "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -151,10 +150,8 @@ func NewRootCmd() *cobra.Command {
 	helper.DecorateWithHeimdallFlags(rootCmd, viper.GetViper(), logger, "main")
 	helper.DecorateWithCometBFTFlags(rootCmd, viper.GetViper(), logger, "main")
 
-	initClientCtx, _ = config.ReadFromClientConfig(initClientCtx)
-
 	fmt.Println("KEYRING DIR BEFORE initRootCmd:", initClientCtx.KeyringDir)
-	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx.Keyring, initClientCtx.KeyringDir, initClientCtx)
+	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx)
 
 	// add keyring to autocli opts
 	autoCliOpts := tempApp.AutoCliOpts()

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -1,13 +1,13 @@
 package heimdalld
 
 import (
-	"fmt"
 	"os"
 
 	"cosmossdk.io/log"
 	"github.com/cometbft/cometbft/cmd/cometbft/commands"
 	db "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -73,7 +73,10 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println("HOME AFTER!!:", initClientCtx.HomeDir)
+			initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
+			if err != nil {
+				return err
+			}
 
 			// This needs to go after ReadFromClientConfig, as that function
 			// sets the RPC client needed for SIGN_MODE_TEXTUAL. This sign mode
@@ -150,7 +153,6 @@ func NewRootCmd() *cobra.Command {
 	helper.DecorateWithHeimdallFlags(rootCmd, viper.GetViper(), logger, "main")
 	helper.DecorateWithCometBFTFlags(rootCmd, viper.GetViper(), logger, "main")
 
-	fmt.Println("KEYRING DIR BEFORE initRootCmd:", initClientCtx.KeyringDir)
 	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.BasicManager, tempApp, initClientCtx)
 
 	// add keyring to autocli opts


### PR DESCRIPTION
# Description

This PR dedups initalization of `initClientCtx` that results in creation of default heimdall home dir (`/var/lib/heimdall`) while running `init` despite providing a custom home path. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on the local environment
- [x] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

