### PR TITLE
cmd: increase rpc server timeout during startup to 1 hour

### DIFF
--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -176,7 +176,7 @@ func initRootCmd(
 
 			// wait for the rest server to start
 			resultChan := make(chan string)
-			timeout := time.After(60 * time.Second)
+			timeout := time.After(60 * time.Minute)
 
 			go checkServerStatus(clientCtx, helper.GetHeimdallServerEndpoint(util.AccountParamsURL), resultChan)
 


### PR DESCRIPTION
# Description

This PR bumps the timeout for the REST server to become operational during the node startup to 1 hour. This is generally to prevent the node from crashing, especially observed when heimdall-v2 was started just after migration in amoy. We can later reduce it once nodes are migrated and the network is in stable condition. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [x] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

