### PR TITLE
fix(cmd): ignore IAVL log output and version command

### DIFF
--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -40,7 +40,9 @@ func NewRootCmd() *cobra.Command {
 	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
 	// note, this is not necessary when using app wiring, as depInject can be directly used (see root_v2.go)
 
-	tempApp := app.NewHeimdallApp(logger, db.NewMemDB(), nil, true, simtestutil.NewAppOptionsWithFlagHome(tempDir()))
+	// Since this is only a temp app, we don't need info logs, only warn and error logs.
+	tempLogger := log.NewLogger(os.Stdout, log.LevelOption(zerolog.WarnLevel))
+	tempApp := app.NewHeimdallApp(tempLogger, db.NewMemDB(), nil, true, simtestutil.NewAppOptionsWithFlagHome(tempDir()))
 	encodingConfig := EncodingConfig{
 		InterfaceRegistry: tempApp.InterfaceRegistry(),
 		Codec:             tempApp.AppCodec(),

--- a/version/command.go
+++ b/version/command.go
@@ -10,10 +10,11 @@ import (
 
 const flagLong = "long"
 const flagOutput = "output"
+const outputJSON = "json"
 
 func init() {
 	Cmd.Flags().BoolP(flagLong, "l", false, "Print long version information")
-	Cmd.Flags().StringP(flagOutput, "o", "text", "Output format (text|json)")
+	Cmd.Flags().StringP(flagOutput, "o", "text", "Output format (text|"+outputJSON+")")
 }
 
 // Cmd prints out the application's version information passed via build flags.
@@ -37,7 +38,7 @@ var Cmd = &cobra.Command{
 		if !longFormat {
 			// For short format, just return version string or JSON with version only.
 			switch outputFormat {
-			case "json":
+			case outputJSON:
 				shortInfo := map[string]string{"version": verInfo.Version}
 				bz, err = json.MarshalIndent(shortInfo, "", "  ")
 			default:
@@ -47,7 +48,7 @@ var Cmd = &cobra.Command{
 		} else {
 			// For long format, return the full info.
 			switch outputFormat {
-			case "json":
+			case outputJSON:
 				bz, err = json.MarshalIndent(verInfo, "", "  ")
 			default:
 				bz, err = yaml.Marshal(&verInfo)

--- a/version/command.go
+++ b/version/command.go
@@ -4,47 +4,61 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cometbft/cometbft/libs/cli"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
 const flagLong = "long"
+const flagOutput = "output"
 
 func init() {
-	Cmd.Flags().Bool(flagLong, false, "Print long version information")
+	Cmd.Flags().BoolP(flagLong, "l", false, "Print long version information")
+	Cmd.Flags().StringP(flagOutput, "o", "text", "Output format (text|json)")
 }
 
 // Cmd prints out the application's version information passed via build flags.
 var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the app version",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		verInfo := NewInfo()
-
-		if !viper.GetBool(flagLong) {
-			fmt.Println()
-			fmt.Println(verInfo.Version)
-			return nil
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		longFormat, err := cmd.Flags().GetBool(flagLong)
+		if err != nil {
+			return err
+		}
+		outputFormat, err := cmd.Flags().GetString(flagOutput)
+		if err != nil {
+			return err
 		}
 
-		var bz []byte
-		var err error
+		verInfo := NewInfo()
 
-		switch viper.GetString(cli.OutputFlag) {
-		case "json":
-			bz, err = json.Marshal(verInfo)
-		default:
-			bz, err = yaml.Marshal(&verInfo)
+		var bz []byte
+
+		if !longFormat {
+			// For short format, just return version string or JSON with version only.
+			switch outputFormat {
+			case "json":
+				shortInfo := map[string]string{"version": verInfo.Version}
+				bz, err = json.MarshalIndent(shortInfo, "", "  ")
+			default:
+				fmt.Println(verInfo.Version)
+				return nil
+			}
+		} else {
+			// For long format, return the full info.
+			switch outputFormat {
+			case "json":
+				bz, err = json.MarshalIndent(verInfo, "", "  ")
+			default:
+				bz, err = yaml.Marshal(&verInfo)
+			}
 		}
 
 		if err != nil {
 			return err
 		}
 
-		fmt.Println()
-		_, err = fmt.Println(string(bz))
+		_, err = fmt.Print(string(bz))
 		return err
 	},
 }


### PR DESCRIPTION
# Description

Fixes #322 

Also:
- Missing JSON Support. Code had JSON logic but no --output flag.
- JSON Only Worked for --long.

Output:
```bash
build/heimdalld version -o json
{
  "version": "0.2.5-12-ge608d8cc"
}
```
```bash
build/heimdalld version --long --output json       
{
  "name": "heimdall",
  "server_name": "heimdalld",
  "client_name": "heimdalld",
  "version": "0.2.5-13-g5b9da490",
  "commit": "5b9da490316c3dd2eae1fd6dcc0c69720dcee2fa",
  "go": "go version go1.24.4 darwin/arm64"
}
```