### PR TITLE
chore: add max offset check to prevent large offset reqs

### DIFF
--- a/x/bor/keeper/grpc_query.go
+++ b/x/bor/keeper/grpc_query.go
@@ -12,7 +12,10 @@ import (
 	staketypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
-const MaxSpanListLimit = 1000
+const (
+	MaxSpanListLimit   = 1_000
+	MaxSpanOffsetLimit = 1_000
+)
 
 var _ types.QueryServer = queryServer{}
 
@@ -165,6 +168,9 @@ func (q queryServer) GetSpanList(ctx context.Context, req *types.QuerySpanListRe
 
 	if isPaginationEmpty(req.Pagination) {
 		return nil, status.Errorf(codes.InvalidArgument, "pagination request is empty (at least one argument must be set)")
+	}
+	if req.Pagination.Offset > MaxSpanOffsetLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "offset cannot be greater than %d", MaxSpanOffsetLimit)
 	}
 	if req.Pagination.Limit == 0 || req.Pagination.Limit > MaxSpanListLimit {
 		return nil, status.Errorf(codes.InvalidArgument, "limit cannot be 0 or greater than %d", MaxSpanListLimit)

--- a/x/checkpoint/keeper/grpc_query.go
+++ b/x/checkpoint/keeper/grpc_query.go
@@ -12,7 +12,10 @@ import (
 	"github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
 )
 
-const MaxCheckpointListLimit = 10000 // In erigon, CheckpointsFetchLimit is 10000.
+const (
+	MaxCheckpointListLimit   = 10_000 // In erigon, CheckpointsFetchLimit is 10_000.
+	MaxCheckpointOffsetLimit = 1_000
+)
 
 var _ types.QueryServer = queryServer{}
 
@@ -174,7 +177,7 @@ func (q queryServer) GetNextCheckpoint(ctx context.Context, req *types.QueryNext
 	return &types.QueryNextCheckpointResponse{Checkpoint: checkpointMsg}, nil
 }
 
-// GetCheckpointList returns the list of checkpoints
+// GetCheckpointList returns the list of checkpoints.
 func (q queryServer) GetCheckpointList(ctx context.Context, req *types.QueryCheckpointListRequest) (*types.QueryCheckpointListResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
@@ -182,6 +185,9 @@ func (q queryServer) GetCheckpointList(ctx context.Context, req *types.QueryChec
 
 	if isPaginationEmpty(req.Pagination) {
 		return nil, status.Errorf(codes.InvalidArgument, "pagination request is empty (at least one of offset, key or limit must be set)")
+	}
+	if req.Pagination.Offset > MaxCheckpointOffsetLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "offset cannot be greater than %d", MaxCheckpointOffsetLimit)
 	}
 	if req.Pagination.Limit == 0 || req.Pagination.Limit > MaxCheckpointListLimit {
 		return nil, status.Errorf(codes.InvalidArgument, "limit cannot be 0 or greater than %d", MaxCheckpointListLimit)

--- a/x/clerk/keeper/grpc_query.go
+++ b/x/clerk/keeper/grpc_query.go
@@ -20,7 +20,7 @@ const (
 	MaxRecordListLimit = 50
 
 	// MaxRecordListOffset is the maximum record list offset for queries.
-	MaxRecordListOffset = 1000
+	MaxRecordListOffset = 1_000
 )
 
 var _ types.QueryServer = queryServer{}
@@ -77,11 +77,11 @@ func (q queryServer) GetRecordListWithTime(ctx context.Context, request *types.R
 	if isPaginationEmpty(request.Pagination) {
 		return nil, status.Errorf(codes.InvalidArgument, "pagination request is empty (at least one argument must be set)")
 	}
-	if request.Pagination.Limit == 0 || request.Pagination.Limit > MaxRecordListLimit {
-		return nil, status.Errorf(codes.InvalidArgument, "limit cannot be 0 or greater than %d", MaxRecordListLimit)
-	}
 	if request.Pagination.Offset > MaxRecordListOffset {
 		return nil, status.Errorf(codes.InvalidArgument, "offset cannot be greater than %d", MaxRecordListOffset)
+	}
+	if request.Pagination.Limit == 0 || request.Pagination.Limit > MaxRecordListLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "limit cannot be 0 or greater than %d", MaxRecordListLimit)
 	}
 	if request.FromId < 1 {
 		return nil, status.Errorf(codes.InvalidArgument, "fromId cannot be less than 1")


### PR DESCRIPTION
# Description

Adds a check for offset to prevent requests than can have large offsets and can potentially use large amounts of time and memory.