### PR TITLE
Dockerfile: use multi-stage build optimisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,41 @@
-FROM golang:latest
+# ─── BUILDER STAGE ───────────────────────────────────────────────────────────────
+FROM golang:1.24-alpine AS builder
 
-ARG HEIMDALL_DIR=/var/lib/heimdall
-ENV HEIMDALL_DIR=$HEIMDALL_DIR
+ARG HEIMDALL_DIR=/var/lib/heimdall/
+ENV HEIMDALL_DIR=${HEIMDALL_DIR}
 
-RUN apt-get update -y && apt-get upgrade -y \
-    && apt install build-essential git -y \
-    && mkdir -p $HEIMDALL_DIR
+RUN apk add --no-cache build-base git linux-headers
 
 WORKDIR ${HEIMDALL_DIR}
 
-# Copy go.mod and go.sum and download first to leverage Docker's cache
 COPY go.mod go.sum ./
-RUN go mod download
+
+RUN --mount=type=ssh \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
-RUN make build && cp build/heimdalld /usr/local/bin/
+RUN --mount=type=ssh \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make build
 
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+# ─── RUNTIME STAGE ────────────────────────────────────────────────────────────────
+FROM alpine:3.22
 
-ENV SHELL /bin/bash
+ARG HEIMDALL_DIR=/var/lib/heimdall/
+ENV HEIMDALL_DIR=${HEIMDALL_DIR}
+
+RUN apk add --no-cache ca-certificates && \
+    mkdir -p ${HEIMDALL_DIR}
+
+WORKDIR ${HEIMDALL_DIR}
+
+COPY --from=builder ${HEIMDALL_DIR}/build/heimdalld /usr/local/bin/heimdalld
+COPY --from=builder ${HEIMDALL_DIR}/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 EXPOSE 1317 26656 26657
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM alpine:3.22
 ARG HEIMDALL_DIR=/var/lib/heimdall/
 ENV HEIMDALL_DIR=${HEIMDALL_DIR}
 
-RUN apk add --no-cache ca-certificates && \
+RUN apk add --no-cache bash ca-certificates && \
     mkdir -p ${HEIMDALL_DIR}
 
 WORKDIR ${HEIMDALL_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=ssh \
     make build
 
 # ─── RUNTIME STAGE ────────────────────────────────────────────────────────────────
-FROM alpine:3.22
+FROM alpine:latest
 
 ARG HEIMDALL_DIR=/var/lib/heimdall/
 ENV HEIMDALL_DIR=${HEIMDALL_DIR}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/0xPolygon/heimdall-v2
 
+// Note: Change the go image version in Dockerfile if you change this.
 go 1.24.4
 
 require (


### PR DESCRIPTION
# Description

Switched to Go 1.24‑alpine & Alpine 3.22; adopted a two‑stage build with SSH+cache mounts for go mod download and make build, then copied only the heimdalld binary and sh entrypoint into a minimal Alpine runtime (just certs, no Bash)—trimming the final image from hundreds of megabytes down to mere megabytes.