### PR TITLE
Fix import-validator-key command

### DIFF
--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -19,6 +19,7 @@ import (
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto"
+	cmcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	"github.com/cometbft/cometbft/p2p"
@@ -482,6 +483,10 @@ func generateValidatorKey() *cobra.Command {
 // importValidatorKey imports validator private key from the given file path
 func importValidatorKey() *cobra.Command {
 	cdc := codec.NewLegacyAmino()
+	cdc.RegisterInterface((*cmcrypto.PubKey)(nil), nil)
+	cdc.RegisterInterface((*cmcrypto.PrivKey)(nil), nil)
+	cdc.RegisterConcrete(secp256k1.PubKey{}, "tendermint/PubKeySecp256k1", nil)
+	cdc.RegisterConcrete(secp256k1.PrivKey{}, "tendermint/PrivKeySecp256k1", nil)
 	return &cobra.Command{
 		Use:   "import-validator-key <private-key-file>",
 		Short: "Import private key from a private key stored in file (without 0x prefix)",
@@ -492,10 +497,8 @@ func importValidatorKey() *cobra.Command {
 			}
 
 			bz := ethcrypto.FromECDSA(pk)
-
 			// set the private object
-			var privKeyObject secp256k1.PrivKey
-			copy(privKeyObject[:], bz)
+			privKeyObject := secp256k1.PrivKey(bz)
 
 			// node key
 			nodeKey := privval.FilePVKey{

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -484,8 +484,8 @@ func importValidatorKey() *cobra.Command {
 	cdc := codec.NewLegacyAmino()
 	cdc.RegisterInterface((*crypto.PubKey)(nil), nil)
 	cdc.RegisterInterface((*crypto.PrivKey)(nil), nil)
-	cdc.RegisterConcrete(secp256k1.PubKey{}, "tendermint/PubKeySecp256k1", nil)
-	cdc.RegisterConcrete(secp256k1.PrivKey{}, "tendermint/PrivKeySecp256k1", nil)
+	cdc.RegisterConcrete(secp256k1.PubKey{}, "cometbft/PubKeySecp256k1eth", nil)
+	cdc.RegisterConcrete(secp256k1.PrivKey{}, "cometbft/PrivKeySecp256k1eth", nil)
 	return &cobra.Command{
 		Use:   "import-validator-key <private-key-file>",
 		Short: "Import private key from a private key stored in file (without 0x prefix)",

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -517,6 +517,7 @@ func importValidatorKey() *cobra.Command {
 				return err
 			}
 
+			fmt.Println("Private validator key saved to priv_validator_key.json")
 			return nil
 		},
 	}

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -19,7 +19,6 @@ import (
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto"
-	cmcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	"github.com/cometbft/cometbft/p2p"
@@ -483,8 +482,8 @@ func generateValidatorKey() *cobra.Command {
 // importValidatorKey imports validator private key from the given file path
 func importValidatorKey() *cobra.Command {
 	cdc := codec.NewLegacyAmino()
-	cdc.RegisterInterface((*cmcrypto.PubKey)(nil), nil)
-	cdc.RegisterInterface((*cmcrypto.PrivKey)(nil), nil)
+	cdc.RegisterInterface((*crypto.PubKey)(nil), nil)
+	cdc.RegisterInterface((*crypto.PrivKey)(nil), nil)
 	cdc.RegisterConcrete(secp256k1.PubKey{}, "tendermint/PubKeySecp256k1", nil)
 	cdc.RegisterConcrete(secp256k1.PrivKey{}, "tendermint/PrivKeySecp256k1", nil)
 	return &cobra.Command{


### PR DESCRIPTION
# Description

This PR fixes the `import-validator-key` command by properly registering the crypto types prior to importing. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply



## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

