### PR TITLE
Fix milestone event missing fields

### DIFF
--- a/x/milestone/README.md
+++ b/x/milestone/README.md
@@ -79,6 +79,7 @@ message Milestone {
   string bor_chain_id = 5 [ (amino.dont_omitempty) = true ];
   string milestone_id = 6 [ (amino.dont_omitempty) = true ];
   uint64 timestamp = 7 [ (amino.dont_omitempty) = true ];
+  uint64 total_difficulty = 8 [ (amino.dont_omitempty) = true ];
 }
 ```
 

--- a/x/milestone/types/events.go
+++ b/x/milestone/types/events.go
@@ -21,5 +21,6 @@ func NewMilestoneEvent(milestone Milestone, milestoneNumber uint64) sdk.Event {
 		sdk.NewAttribute("milestone_id", milestone.MilestoneId),
 		sdk.NewAttribute("timestamp", strconv.FormatUint(milestone.Timestamp, 10)),
 		sdk.NewAttribute("number", strconv.FormatUint(milestoneNumber, 10)),
+		sdk.NewAttribute("total_difficulty", strconv.FormatUint(milestone.TotalDifficulty, 10)),
 	)
 }


### PR DESCRIPTION
# Description

Fixing milestone missing `total_difficulty` field on ws subscription.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Node audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it
(e.g., by adding a flag with a default value...)

# Checklist

- [ ] I have added at least two reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross-repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
