### PR TITLE
chore: side msg and abci handler metrics

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/0xPolygon/heimdall-v2/common/strutil"
 	"github.com/0xPolygon/heimdall-v2/helper"
-	metrics "github.com/0xPolygon/heimdall-v2/metrics"
+	"github.com/0xPolygon/heimdall-v2/metrics"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
 	"github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
@@ -33,6 +33,9 @@ const (
 // NewPrepareProposalHandler prepares the proposal after validating the vote extensions
 func (app *HeimdallApp) NewPrepareProposalHandler() sdk.PrepareProposalHandler {
 	return func(ctx sdk.Context, req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
+		startTime := time.Now()
+		defer metrics.RecordABCIHandlerDuration(metrics.PrepareProposalDuration, startTime)
+
 		logger := app.Logger()
 
 		if err := ValidateVoteExtensions(ctx, req.Height, req.LocalLastCommit.Votes, req.LocalLastCommit.Round, app.StakeKeeper, app.MilestoneKeeper); err != nil {
@@ -115,6 +118,9 @@ func (app *HeimdallApp) NewPrepareProposalHandler() sdk.PrepareProposalHandler {
 // there's no majority. It is implemented by all the validators.
 func (app *HeimdallApp) NewProcessProposalHandler() sdk.ProcessProposalHandler {
 	return func(ctx sdk.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+		startTime := time.Now()
+		defer metrics.RecordABCIHandlerDuration(metrics.ProcessProposalDuration, startTime)
+
 		logger := app.Logger()
 
 		// check if there are any txs in the request
@@ -187,6 +193,9 @@ func (app *HeimdallApp) NewProcessProposalHandler() sdk.ProcessProposalHandler {
 // ExtendVoteHandler extends pre-commit vote
 func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 	return func(ctx sdk.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
+		startTime := time.Now()
+		defer metrics.RecordABCIHandlerDuration(metrics.ExtendVoteDuration, startTime)
+
 		logger := app.Logger()
 		logger.Debug("Extending Vote!", "height", ctx.BlockHeight())
 		defer func() {
@@ -332,6 +341,9 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 // VerifyVoteExtensionHandler performs some sanity checks on the VE received from other validators
 func (app *HeimdallApp) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHandler {
 	return func(ctx sdk.Context, req *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
+		startTime := time.Now()
+		defer metrics.RecordABCIHandlerDuration(metrics.VerifyVoteExtensionDuration, startTime)
+
 		logger := app.Logger()
 		logger.Debug("Verifying vote extension", "height", ctx.BlockHeight())
 
@@ -547,7 +559,7 @@ func (app *HeimdallApp) checkAndRotateCurrentSpan(ctx sdk.Context) error {
 // PreBlocker application updates every pre block
 func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
 	startTime := time.Now()
-	defer metrics.RecordPreBlockerDuration(startTime)
+	defer metrics.RecordABCIHandlerDuration(metrics.PreBlockerDuration, startTime)
 
 	logger := app.Logger()
 

--- a/app/abci.go
+++ b/app/abci.go
@@ -547,7 +547,7 @@ func (app *HeimdallApp) checkAndRotateCurrentSpan(ctx sdk.Context) error {
 // PreBlocker application updates every pre block
 func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
 	startTime := time.Now()
-	defer metrics.PreBlockerTimer.UpdateSince(startTime)
+	defer metrics.RecordPreBlockerDuration(startTime)
 
 	logger := app.Logger()
 

--- a/app/abci.go
+++ b/app/abci.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtTypes "github.com/cometbft/cometbft/types"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/0xPolygon/heimdall-v2/common/strutil"
 	"github.com/0xPolygon/heimdall-v2/helper"
+	metrics "github.com/0xPolygon/heimdall-v2/metrics"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
 	"github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
@@ -544,6 +546,9 @@ func (app *HeimdallApp) checkAndRotateCurrentSpan(ctx sdk.Context) error {
 
 // PreBlocker application updates every pre block
 func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
+	startTime := time.Now()
+	defer metrics.PreBlockerTimer.UpdateSince(startTime)
+
 	logger := app.Logger()
 
 	// handle the case when the VEs are disabled starting from the next block

--- a/app/app.go
+++ b/app/app.go
@@ -598,7 +598,7 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 // BeginBlocker application updates every begin block
 func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
 	startTime := time.Now()
-	defer metrics.RecordBeginBlockerDuration(startTime)
+	defer metrics.RecordABCIHandlerDuration(metrics.BeginBlockerDuration, startTime)
 
 	return app.ModuleManager.BeginBlock(ctx)
 }
@@ -606,7 +606,7 @@ func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
 // EndBlocker application updates every end block
 func (app *HeimdallApp) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 	startTime := time.Now()
-	defer metrics.RecordEndBlockerDuration(startTime)
+	defer metrics.RecordABCIHandlerDuration(metrics.EndBlockerDuration, startTime)
 
 	// transfer fees to current proposer
 	if proposer, ok := app.AccountKeeper.GetBlockProposer(ctx); ok {

--- a/app/app.go
+++ b/app/app.go
@@ -598,7 +598,7 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 // BeginBlocker application updates every begin block
 func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
 	startTime := time.Now()
-	defer metrics.BeginBlockerTimer.UpdateSince(startTime)
+	defer metrics.RecordBeginBlockerDuration(startTime)
 
 	return app.ModuleManager.BeginBlock(ctx)
 }
@@ -606,7 +606,7 @@ func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
 // EndBlocker application updates every end block
 func (app *HeimdallApp) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 	startTime := time.Now()
-	defer metrics.EndBlockerTimer.UpdateSince(startTime)
+	defer metrics.RecordEndBlockerDuration(startTime)
 
 	// transfer fees to current proposer
 	if proposer, ok := app.AccountKeeper.GetBlockProposer(ctx); ok {

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
@@ -596,11 +597,17 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 
 // BeginBlocker application updates every begin block
 func (app *HeimdallApp) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
+	startTime := time.Now()
+	defer metrics.BeginBlockerTimer.UpdateSince(startTime)
+
 	return app.ModuleManager.BeginBlock(ctx)
 }
 
 // EndBlocker application updates every end block
 func (app *HeimdallApp) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
+	startTime := time.Now()
+	defer metrics.EndBlockerTimer.UpdateSince(startTime)
+
 	// transfer fees to current proposer
 	if proposer, ok := app.AccountKeeper.GetBlockProposer(ctx); ok {
 		moduleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)

--- a/app/vote_ext_utils.go
+++ b/app/vote_ext_utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/0xPolygon/heimdall-v2/metrics/consensus"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	chainManagerKeeper "github.com/0xPolygon/heimdall-v2/x/chainmanager/keeper"
 	checkpointKeeper "github.com/0xPolygon/heimdall-v2/x/checkpoint/keeper"
@@ -204,19 +205,19 @@ func tallyVotes(extVoteInfo []abciTypes.ExtendedVoteInfo, logger log.Logger, tot
 		if voteMap[sidetxs.Vote_VOTE_YES] > majorityVP {
 			// approved
 			logger.Debug("Approved side-tx", "txHash", txHash)
-
+			consensus.RecordConsensusApproved()
 			// append to approved tx slice
 			approvedTxs = append(approvedTxs, common.FromHex(txHash))
 		} else if voteMap[sidetxs.Vote_VOTE_NO] > majorityVP {
 			// rejected
 			logger.Debug("Rejected side-tx", "txHash", txHash)
-
+			consensus.RecordConsensusRejected()
 			// append to rejected tx slice
 			rejectedTxs = append(rejectedTxs, common.FromHex(txHash))
 		} else {
-			// skipped
+			// skipped - 2/3 consensus not reached.
 			logger.Debug("Skipped side-tx", "txHash", txHash)
-
+			consensus.RecordConsensusFailure()
 			// append to rejected tx slice
 			skippedTxs = append(skippedTxs, common.FromHex(txHash))
 		}

--- a/metrics/abci.go
+++ b/metrics/abci.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	// PreBlockerDuration tracks the time taken by PreBlocker function.
 	PreBlockerDuration = promauto.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: Namespace,
@@ -15,13 +16,14 @@ var (
 			Name:      "pre_blocker_duration_seconds",
 			Help:      "Time taken by PreBlocker function in seconds",
 			Objectives: map[float64]float64{
-				0.50: 0.05,  // 50th percentile +/-5% error
-				0.90: 0.01,  // 90th percentile +/-1% error
-				0.99: 0.001, // 99th percentile +/-0.1% error
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
 			},
 		},
 	)
 
+	// BeginBlockerDuration tracks the time taken by BeginBlocker function.
 	BeginBlockerDuration = promauto.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: Namespace,
@@ -29,13 +31,14 @@ var (
 			Name:      "begin_blocker_duration_seconds",
 			Help:      "Time taken by BeginBlocker function in seconds",
 			Objectives: map[float64]float64{
-				0.50: 0.05,  // 50th percentile +/-5% error
-				0.90: 0.01,  // 90th percentile +/-1% error
-				0.99: 0.001, // 99th percentile +/-0.1% error
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
 			},
 		},
 	)
 
+	// EndBlockerDuration tracks the time taken by EndBlocker function.
 	EndBlockerDuration = promauto.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: Namespace,
@@ -43,25 +46,76 @@ var (
 			Name:      "end_blocker_duration_seconds",
 			Help:      "Time taken by EndBlocker function in seconds",
 			Objectives: map[float64]float64{
-				0.50: 0.05,  // 50th percentile +/-5% error
-				0.90: 0.01,  // 90th percentile +/-1% error
-				0.99: 0.001, // 99th percentile +/-0.1% error
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
+			},
+		},
+	)
+
+	// PrepareProposalDuration tracks the time taken by PrepareProposal handler.
+	PrepareProposalDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "prepare_proposal_duration_seconds",
+			Help:      "Time taken by PrepareProposal handler in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
+			},
+		},
+	)
+
+	// ProcessProposalDuration tracks the time taken by ProcessProposal handler.
+	ProcessProposalDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "process_proposal_duration_seconds",
+			Help:      "Time taken by ProcessProposal handler in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
+			},
+		},
+	)
+
+	// ExtendVoteDuration tracks the time taken by ExtendVote handler.
+	ExtendVoteDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "extend_vote_duration_seconds",
+			Help:      "Time taken by ExtendVote handler in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
+			},
+		},
+	)
+
+	// VerifyVoteExtensionDuration tracks the time taken by VerifyVoteExtension handler.
+	VerifyVoteExtensionDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "verify_vote_extension_duration_seconds",
+			Help:      "Time taken by VerifyVoteExtension handler in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,
+				0.90: 0.01,
+				0.99: 0.001,
 			},
 		},
 	)
 )
 
-func RecordPreBlockerDuration(start time.Time) {
+// RecordABCIHandlerDuration records the time taken for any ABCI handler.
+func RecordABCIHandlerDuration(metric prometheus.Summary, start time.Time) {
 	duration := time.Since(start)
-	PreBlockerDuration.Observe(duration.Seconds())
-}
-
-func RecordBeginBlockerDuration(start time.Time) {
-	duration := time.Since(start)
-	BeginBlockerDuration.Observe(duration.Seconds())
-}
-
-func RecordEndBlockerDuration(start time.Time) {
-	duration := time.Since(start)
-	EndBlockerDuration.Observe(duration.Seconds())
+	metric.Observe(duration.Seconds())
 }

--- a/metrics/abci.go
+++ b/metrics/abci.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	// PreBlockerTimer tracks the time taken by PreBlocker function.
+	PreBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/preblocker", nil)
+
+	// BeginBlockerTimer tracks the time taken by BeginBlocker function.
+	BeginBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/beginblocker", nil)
+
+	// EndBlockerTimer tracks the time taken by EndBlocker function.
+	EndBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/endblocker", nil)
+)

--- a/metrics/abci.go
+++ b/metrics/abci.go
@@ -1,16 +1,67 @@
 package metrics
 
 import (
-	"github.com/ethereum/go-ethereum/metrics"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	// PreBlockerTimer tracks the time taken by PreBlocker function.
-	PreBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/preblocker", nil)
+	PreBlockerDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "pre_blocker_duration_seconds",
+			Help:      "Time taken by PreBlocker function in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,  // 50th percentile +/-5% error
+				0.90: 0.01,  // 90th percentile +/-1% error
+				0.99: 0.001, // 99th percentile +/-0.1% error
+			},
+		},
+	)
 
-	// BeginBlockerTimer tracks the time taken by BeginBlocker function.
-	BeginBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/beginblocker", nil)
+	BeginBlockerDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "begin_blocker_duration_seconds",
+			Help:      "Time taken by BeginBlocker function in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,  // 50th percentile +/-5% error
+				0.90: 0.01,  // 90th percentile +/-1% error
+				0.99: 0.001, // 99th percentile +/-0.1% error
+			},
+		},
+	)
 
-	// EndBlockerTimer tracks the time taken by EndBlocker function.
-	EndBlockerTimer = metrics.NewRegisteredTimer("heimdallv2/abci/endblocker", nil)
+	EndBlockerDuration = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "end_blocker_duration_seconds",
+			Help:      "Time taken by EndBlocker function in seconds",
+			Objectives: map[float64]float64{
+				0.50: 0.05,  // 50th percentile +/-5% error
+				0.90: 0.01,  // 90th percentile +/-1% error
+				0.99: 0.001, // 99th percentile +/-0.1% error
+			},
+		},
+	)
 )
+
+func RecordPreBlockerDuration(start time.Time) {
+	duration := time.Since(start)
+	PreBlockerDuration.Observe(duration.Seconds())
+}
+
+func RecordBeginBlockerDuration(start time.Time) {
+	duration := time.Since(start)
+	BeginBlockerDuration.Observe(duration.Seconds())
+}
+
+func RecordEndBlockerDuration(start time.Time) {
+	duration := time.Since(start)
+	EndBlockerDuration.Observe(duration.Seconds())
+}

--- a/metrics/api/bor.go
+++ b/metrics/api/bor.go
@@ -16,4 +16,12 @@ const (
 	BorUpdateParamsMethod = "UpdateParams"
 	BackfillSpansMethod   = "BackfillSpans"
 	VoteProducersMethod   = "VoteProducers"
+
+	// Side message handler methods.
+	SideHandleMsgSpanMethod          = "SideHandleMsgSpan"
+	SideHandleMsgBackfillSpansMethod = "SideHandleMsgBackfillSpans"
+
+	// Post message handler methods.
+	PostHandleMsgSpanMethod          = "PostHandleMsgSpan"
+	PostHandleMsgBackfillSpansMethod = "PostHandleMsgBackfillSpans"
 )

--- a/metrics/api/checkpoint.go
+++ b/metrics/api/checkpoint.go
@@ -18,4 +18,12 @@ const (
 	CheckpointAckMethod          = "CheckpointAck"
 	CheckpointNoAckMethod        = "CheckpointNoAck"
 	CheckpointUpdateParamsMethod = "UpdateParams"
+
+	// Side message handler methods.
+	SideHandleMsgCheckpointMethod    = "SideHandleMsgCheckpoint"
+	SideHandleMsgCheckpointAckMethod = "SideHandleMsgCheckpointAck"
+
+	// Post message handler methods.
+	PostHandleMsgCheckpointMethod    = "PostHandleMsgCheckpoint"
+	PostHandleMsgCheckpointAckMethod = "PostHandleMsgCheckpointAck"
 )

--- a/metrics/api/clerk.go
+++ b/metrics/api/clerk.go
@@ -12,4 +12,10 @@ const (
 
 	// Transaction API methods.
 	HandleMsgEventRecordMethod = "HandleMsgEventRecord"
+
+	// Side message handler methods.
+	SideHandleMsgEventRecordMethod = "SideHandleMsgEventRecord"
+
+	// Post message handler methods.
+	PostHandleMsgEventRecordMethod = "PostHandleMsgEventRecord"
 )

--- a/metrics/api/common.go
+++ b/metrics/api/common.go
@@ -16,6 +16,10 @@ const (
 	QueryType = "query"
 	// TxType is the type of API call.
 	TxType = "tx"
+	// SideType is the type of side handler call.
+	SideType = "side"
+	// PostType is the type of post handler call.
+	PostType = "post"
 
 	// Module subsystems.
 	BorSubsystem        = "bor"
@@ -85,6 +89,8 @@ func GetModuleMetrics(subsystem string) *ModuleMetrics {
 					0.90: 0.01,  // 90th percentile +/-1% error
 					0.99: 0.001, // 99th percentile +/-0.1% error
 				},
+				MaxAge:     24 * time.Hour,
+				AgeBuckets: 6,
 			},
 			[]string{"method", "type"},
 		),

--- a/metrics/api/common.go
+++ b/metrics/api/common.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/0xPolygon/heimdall-v2/metrics"
 )
 
 const (
-	// Namespace for all metrics.
-	Namespace = "heimdallv2"
-
 	// QueryType is the type of API call.
 	QueryType = "query"
 	// TxType is the type of API call.
@@ -62,7 +61,7 @@ func GetModuleMetrics(subsystem string) *ModuleMetrics {
 	moduleMetrics[subsystem] = &ModuleMetrics{
 		TotalCalls: promauto.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: Namespace,
+				Namespace: metrics.Namespace,
 				Subsystem: subsystem,
 				Name:      "api_calls_total",
 				Help:      "Total number of API calls to " + subsystem + " module",
@@ -71,7 +70,7 @@ func GetModuleMetrics(subsystem string) *ModuleMetrics {
 		),
 		SuccessCalls: promauto.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: Namespace,
+				Namespace: metrics.Namespace,
 				Subsystem: subsystem,
 				Name:      "api_calls_success_total",
 				Help:      "Total number of successful API calls to " + subsystem + " module",
@@ -80,7 +79,7 @@ func GetModuleMetrics(subsystem string) *ModuleMetrics {
 		),
 		ResponseTime: promauto.NewSummaryVec(
 			prometheus.SummaryOpts{
-				Namespace: Namespace,
+				Namespace: metrics.Namespace,
 				Subsystem: subsystem,
 				Name:      "api_response_time_seconds",
 				Help:      "Response time of API calls to " + subsystem + " module in seconds",

--- a/metrics/api/stake.go
+++ b/metrics/api/stake.go
@@ -16,4 +16,16 @@ const (
 	StakeUpdateMethod   = "StakeUpdate"
 	SignerUpdateMethod  = "SignerUpdate"
 	ValidatorExitMethod = "ValidatorExit"
+
+	// Side message handler methods.
+	SideHandleMsgValidatorJoinMethod = "SideHandleMsgValidatorJoin"
+	SideHandleMsgStakeUpdateMethod   = "SideHandleMsgStakeUpdate"
+	SideHandleMsgSignerUpdateMethod  = "SideHandleMsgSignerUpdate"
+	SideHandleMsgValidatorExitMethod = "SideHandleMsgValidatorExit"
+
+	// Post message handler methods.
+	PostHandleMsgValidatorJoinMethod = "PostHandleMsgValidatorJoin"
+	PostHandleMsgStakeUpdateMethod   = "PostHandleMsgStakeUpdate"
+	PostHandleMsgSignerUpdateMethod  = "PostHandleMsgSignerUpdate"
+	PostHandleMsgValidatorExitMethod = "PostHandleMsgValidatorExit"
 )

--- a/metrics/api/topup.go
+++ b/metrics/api/topup.go
@@ -12,4 +12,10 @@ const (
 	// Transaction API methods.
 	HandleTopupTxMethod = "HandleTopupTx"
 	WithdrawFeeTxMethod = "WithdrawFeeTx"
+
+	// Side message handler methods.
+	SideHandleTopupTxMethod = "SideHandleTopupTx"
+
+	// Post message handler methods.
+	PostHandleTopupTxMethod = "PostHandleTopupTx"
 )

--- a/metrics/consensus/consensus.go
+++ b/metrics/consensus/consensus.go
@@ -1,0 +1,55 @@
+package consensus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// Namespace is the prefix for all metrics.
+	Namespace = "heimdallv2"
+)
+
+var (
+	// SideTxConsensusApproved tracks when side transactions reach 2/3 YES votes.
+	SideTxConsensusApproved = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "sidetx_consensus_approved_total",
+			Help:      "Total number of side transactions that reached 2/3 YES consensus",
+		},
+	)
+
+	// SideTxConsensusRejected tracks when side transactions reach 2/3 NO votes.
+	SideTxConsensusRejected = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "sidetx_consensus_rejected_total",
+			Help:      "Total number of side transactions that reached 2/3 NO consensus",
+		},
+	)
+
+	// SideTxConsensusFailures tracks when we cannot reach 2/3 agreement on side transactions.
+	SideTxConsensusFailures = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "sidetx_consensus_failures_total",
+			Help:      "Total number of side transactions that failed to reach 2/3 consensus",
+		},
+	)
+)
+
+// RecordConsensusFailure records when a side transaction fails to reach 2/3 consensus.
+func RecordConsensusFailure() {
+	SideTxConsensusFailures.Inc()
+}
+
+// RecordConsensusApproved records when a side transaction reaches 2/3 YES consensus.
+func RecordConsensusApproved() {
+	SideTxConsensusApproved.Inc()
+}
+
+// RecordConsensusRejected records when a side transaction reaches 2/3 NO consensus.
+func RecordConsensusRejected() {
+	SideTxConsensusRejected.Inc()
+}

--- a/metrics/consensus/consensus.go
+++ b/metrics/consensus/consensus.go
@@ -3,18 +3,15 @@ package consensus
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-)
 
-const (
-	// Namespace is the prefix for all metrics.
-	Namespace = "heimdallv2"
+	"github.com/0xPolygon/heimdall-v2/metrics"
 )
 
 var (
 	// SideTxConsensusApproved tracks when side transactions reach 2/3 YES votes.
 	SideTxConsensusApproved = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Namespace: Namespace,
+			Namespace: metrics.Namespace,
 			Name:      "sidetx_consensus_approved_total",
 			Help:      "Total number of side transactions that reached 2/3 YES consensus",
 		},
@@ -23,7 +20,7 @@ var (
 	// SideTxConsensusRejected tracks when side transactions reach 2/3 NO votes.
 	SideTxConsensusRejected = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Namespace: Namespace,
+			Namespace: metrics.Namespace,
 			Name:      "sidetx_consensus_rejected_total",
 			Help:      "Total number of side transactions that reached 2/3 NO consensus",
 		},
@@ -32,7 +29,7 @@ var (
 	// SideTxConsensusFailures tracks when we cannot reach 2/3 agreement on side transactions.
 	SideTxConsensusFailures = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Namespace: Namespace,
+			Namespace: metrics.Namespace,
 			Name:      "sidetx_consensus_failures_total",
 			Help:      "Total number of side transactions that failed to reach 2/3 consensus",
 		},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,11 @@ import (
 	"github.com/0xPolygon/heimdall-v2/version"
 )
 
+const (
+	// Namespace is the prefix for all metrics.
+	Namespace = "heimdallv2"
+)
+
 func InitMetrics() {
 	// Update Heimdallv2 Version Info gauge.
 	UpdateHeimdallV2Info(version.Version, version.Commit)

--- a/metrics/version.go
+++ b/metrics/version.go
@@ -7,7 +7,7 @@ import (
 
 // heimdallV2InfoGauge stores the HeimdallV2 version and commit details.
 var heimdallV2InfoGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Namespace: "heimdallv2",
+	Namespace: Namespace,
 	Name:      "info",
 	Help:      "HeimdallV2 version and commit details",
 }, []string{"version", "commit"})

--- a/metrics/version.go
+++ b/metrics/version.go
@@ -5,14 +5,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	// Namespace is the prefix for all metrics.
-	Namespace = "heimdallv2"
-)
-
 // heimdallV2InfoGauge stores the HeimdallV2 version and commit details.
 var heimdallV2InfoGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Namespace: Namespace,
+	Namespace: "heimdallv2",
 	Name:      "info",
 	Help:      "HeimdallV2 version and commit details",
 }, []string{"version", "commit"})

--- a/x/bor/keeper/side_msg_server.go
+++ b/x/bor/keeper/side_msg_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	cmttypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,6 +13,7 @@ import (
 
 	util "github.com/0xPolygon/heimdall-v2/common/hex"
 	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/0xPolygon/heimdall-v2/metrics/api"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	heimdallTypes "github.com/0xPolygon/heimdall-v2/types"
 	"github.com/0xPolygon/heimdall-v2/x/bor/types"
@@ -47,6 +49,10 @@ func (s sideMsgServer) SideTxHandler(methodName string) sidetxs.SideTxHandler {
 
 // SideHandleMsgSpan validates external calls required for processing the proposed span
 func (s sideMsgServer) SideHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg) sidetxs.Vote {
+	var err error
+	start := time.Now()
+	defer recordBorMetric(api.SideHandleMsgSpanMethod, api.SideType, start, &err)
+
 	logger := s.k.Logger(ctx)
 
 	msg, ok := msgI.(*types.MsgProposeSpan)
@@ -161,13 +167,16 @@ func (s sideMsgServer) SideHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg) sidetxs.
 }
 
 func (s sideMsgServer) SideHandleMsgBackfillSpans(ctx sdk.Context, msgI sdk.Msg) sidetxs.Vote {
+	var err error
+	start := time.Now()
+	defer recordBorMetric(api.SideHandleMsgBackfillSpansMethod, api.SideType, start, &err)
+
 	logger := s.k.Logger(ctx)
 
 	msg, ok := msgI.(*types.MsgBackfillSpans)
 	if !ok {
 		logger.Error("MsgFillMissingSpans type mismatch", "msg type received", msgI)
 		return sidetxs.Vote_UNSPECIFIED
-
 	}
 
 	if helper.IsVeblop(msg.LatestSpanId) {
@@ -225,11 +234,15 @@ func (s sideMsgServer) PostTxHandler(methodName string) sidetxs.PostTxHandler {
 
 // PostHandleMsgSpan handles state persisting span msg
 func (s sideMsgServer) PostHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	start := time.Now()
+	defer recordBorMetric(api.PostHandleMsgSpanMethod, api.PostType, start, &err)
+
 	logger := s.k.Logger(ctx)
 
 	msg, ok := msgI.(*types.MsgProposeSpan)
 	if !ok {
-		err := errors.New("MsgProposeSpan type mismatch")
+		err = errors.New("MsgProposeSpan type mismatch")
 		logger.Error(err.Error(), "msg type received", msg)
 		return err
 	}
@@ -246,7 +259,7 @@ func (s sideMsgServer) PostHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg, sideTxRe
 	}
 
 	// check for replay
-	ok, err := s.k.HasSpan(ctx, msg.SpanId)
+	ok, err = s.k.HasSpan(ctx, msg.SpanId)
 	if err != nil {
 		logger.Error("error occurred while checking for span", "span id", msg.SpanId, "error", err)
 		return err
@@ -292,11 +305,15 @@ func (s sideMsgServer) PostHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg, sideTxRe
 }
 
 func (s sideMsgServer) PostHandleMsgBackfillSpans(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	start := time.Now()
+	defer recordBorMetric(api.PostHandleMsgBackfillSpansMethod, api.PostType, start, &err)
+
 	logger := s.k.Logger(ctx)
 
 	msg, ok := msgI.(*types.MsgBackfillSpans)
 	if !ok {
-		err := errors.New("MsgBackfillSpans type mismatch")
+		err = errors.New("MsgBackfillSpans type mismatch")
 		logger.Error(err.Error(), "msg type received", msg)
 		return err
 	}
@@ -360,4 +377,10 @@ func (s sideMsgServer) PostHandleMsgBackfillSpans(ctx sdk.Context, msgI sdk.Msg,
 	})
 
 	return nil
+}
+
+// recordBorMetric records metrics for side and post handlers.
+func recordBorMetric(method string, apiType string, start time.Time, err *error) {
+	success := *err == nil
+	api.RecordAPICallWithStart(api.BorSubsystem, method, apiType, success, start)
 }

--- a/x/clerk/keeper/side_msg_server.go
+++ b/x/clerk/keeper/side_msg_server.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/0xPolygon/heimdall-v2/metrics/api"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	heimdallTypes "github.com/0xPolygon/heimdall-v2/types"
 	"github.com/0xPolygon/heimdall-v2/x/clerk/types"
@@ -50,6 +52,10 @@ func (srv *sideMsgServer) PostTxHandler(methodName string) sidetxs.PostTxHandler
 }
 
 func (srv *sideMsgServer) SideHandleMsgEventRecord(ctx sdk.Context, _msg sdk.Msg) (result sidetxs.Vote) {
+	var err error
+	startTime := time.Now()
+	defer recordClerkMetric(api.SideHandleMsgEventRecordMethod, api.SideType, startTime, &err)
+
 	msg, ok := _msg.(*types.MsgEventRecord)
 	if !ok {
 		srv.Logger(ctx).Error("type mismatch for MsgEventRecord")
@@ -139,6 +145,10 @@ func (srv *sideMsgServer) SideHandleMsgEventRecord(ctx sdk.Context, _msg sdk.Msg
 }
 
 func (srv *sideMsgServer) PostHandleMsgEventRecord(ctx sdk.Context, _msg sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	startTime := time.Now()
+	defer recordClerkMetric(api.PostHandleMsgEventRecordMethod, api.PostType, startTime, &err)
+
 	logger := srv.Logger(ctx)
 
 	msg, ok := _msg.(*types.MsgEventRecord)
@@ -205,4 +215,10 @@ func (srv *sideMsgServer) PostHandleMsgEventRecord(ctx sdk.Context, _msg sdk.Msg
 	})
 
 	return nil
+}
+
+// recordClerkMetric records metrics for side and post handlers.
+func recordClerkMetric(method string, apiType string, start time.Time, err *error) {
+	success := *err == nil
+	api.RecordAPICallWithStart(api.ClerkSubsystem, method, apiType, success, start)
 }

--- a/x/stake/keeper/side_msg_server.go
+++ b/x/stake/keeper/side_msg_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"time"
 
 	addrCodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -15,6 +16,7 @@ import (
 
 	util "github.com/0xPolygon/heimdall-v2/common/hex"
 	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/0xPolygon/heimdall-v2/metrics/api"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	hmTypes "github.com/0xPolygon/heimdall-v2/types"
 	"github.com/0xPolygon/heimdall-v2/x/stake/types"
@@ -71,6 +73,10 @@ func (s *sideMsgServer) PostTxHandler(methodName string) sidetxs.PostTxHandler {
 
 // SideHandleMsgValidatorJoin is a side handler for validator join msg
 func (s *sideMsgServer) SideHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg) (result sidetxs.Vote) {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.SideHandleMsgValidatorJoinMethod, api.SideType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgValidatorJoin)
 	if !ok {
 		s.k.Logger(ctx).Error("type mismatch for MsgValidatorJoin")
@@ -83,7 +89,7 @@ func (s *sideMsgServer) SideHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg
 		"blockNumber", msg.BlockNumber,
 	)
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate MsgValidatorJoin", "error", err)
 		return sidetxs.Vote_VOTE_NO
@@ -212,6 +218,10 @@ func (s *sideMsgServer) SideHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg
 
 // SideHandleMsgStakeUpdate handles stake update message
 func (s *sideMsgServer) SideHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg) (result sidetxs.Vote) {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.SideHandleMsgStakeUpdateMethod, api.SideType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgStakeUpdate)
 	if !ok {
 		s.k.Logger(ctx).Error("type mismatch for MsgStakeUpdate")
@@ -224,7 +234,7 @@ func (s *sideMsgServer) SideHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg) 
 		"blockNumber", msg.BlockNumber,
 	)
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate MsgStakeUpdate", "error", err)
 		return sidetxs.Vote_VOTE_NO
@@ -290,6 +300,10 @@ func (s *sideMsgServer) SideHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg) 
 
 // SideHandleMsgSignerUpdate handles signer update message
 func (s *sideMsgServer) SideHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg) (result sidetxs.Vote) {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.SideHandleMsgSignerUpdateMethod, api.SideType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgSignerUpdate)
 	if !ok {
 		s.k.Logger(ctx).Error("type mismatch for MsgSignerUpdate")
@@ -302,7 +316,7 @@ func (s *sideMsgServer) SideHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg)
 		"blockNumber", msg.BlockNumber,
 	)
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate MsgSignerUpdate", "error", err)
 		return sidetxs.Vote_VOTE_NO
@@ -384,6 +398,10 @@ func (s *sideMsgServer) SideHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg)
 
 // SideHandleMsgValidatorExit handles side msg validator exit
 func (s *sideMsgServer) SideHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg) (result sidetxs.Vote) {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.SideHandleMsgValidatorExitMethod, api.SideType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgValidatorExit)
 	if !ok {
 		s.k.Logger(ctx).Error("type mismatch for MsgValidatorExit")
@@ -396,7 +414,7 @@ func (s *sideMsgServer) SideHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg
 		"blockNumber", msg.BlockNumber,
 	)
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate MsgValidatorExit", "error", err)
 		return sidetxs.Vote_VOTE_NO
@@ -455,6 +473,10 @@ func (s *sideMsgServer) SideHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg
 
 // PostHandleMsgValidatorJoin handles validator join message
 func (s *sideMsgServer) PostHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.PostHandleMsgValidatorJoinMethod, api.PostType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgValidatorJoin)
 	if !ok {
 		err := errors.New("type mismatch for MsgValidatorJoin")
@@ -468,7 +490,7 @@ func (s *sideMsgServer) PostHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg
 		return errors.New("side-tx didn't get yes votes")
 	}
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate msg", "error", err)
 		return errors.New("invalid side-tx msg for MsgValidatorJoin")
@@ -555,6 +577,10 @@ func (s *sideMsgServer) PostHandleMsgValidatorJoin(ctx sdk.Context, msgI sdk.Msg
 
 // PostHandleMsgStakeUpdate handles stake update message
 func (s *sideMsgServer) PostHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.PostHandleMsgStakeUpdateMethod, api.PostType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgStakeUpdate)
 	if !ok {
 		err := errors.New("type mismatch for MsgStakeUpdate")
@@ -568,7 +594,7 @@ func (s *sideMsgServer) PostHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg, 
 		return errors.New("side-tx didn't get yes votes")
 	}
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate msg", "error", err)
 		return errors.New("invalid side-tx msg for MsgStakeUpdate")
@@ -643,6 +669,10 @@ func (s *sideMsgServer) PostHandleMsgStakeUpdate(ctx sdk.Context, msgI sdk.Msg, 
 
 // PostHandleMsgSignerUpdate handles signer update message
 func (s *sideMsgServer) PostHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.PostHandleMsgSignerUpdateMethod, api.PostType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgSignerUpdate)
 	if !ok {
 		err := errors.New("type mismatch for MsgSignerUpdate")
@@ -656,7 +686,7 @@ func (s *sideMsgServer) PostHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg,
 		return errors.New("side-tx didn't get yes votes")
 	}
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate msg", "error", err)
 		return errors.New("invalid side-tx msg for MsgSignerUpdate")
@@ -799,6 +829,10 @@ func (s *sideMsgServer) PostHandleMsgSignerUpdate(ctx sdk.Context, msgI sdk.Msg,
 
 // PostHandleMsgValidatorExit handles msg validator exit
 func (s *sideMsgServer) PostHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg, sideTxResult sidetxs.Vote) error {
+	var err error
+	startTime := time.Now()
+	defer recordStakeMetric(api.PostHandleMsgValidatorExitMethod, api.PostType, startTime, &err)
+
 	msg, ok := msgI.(*types.MsgValidatorExit)
 	if !ok {
 		err := errors.New("type mismatch for MsgValidatorExit")
@@ -812,7 +846,7 @@ func (s *sideMsgServer) PostHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg
 		return errors.New("side-tx didn't get yes votes")
 	}
 
-	err := msg.ValidateBasic()
+	err = msg.ValidateBasic()
 	if err != nil {
 		s.k.Logger(ctx).Error("failed to validate msg", "error", err)
 		return errors.New("invalid side-tx msg for MsgValidatorExit")
@@ -875,4 +909,10 @@ func (s *sideMsgServer) PostHandleMsgValidatorExit(ctx sdk.Context, msgI sdk.Msg
 	})
 
 	return nil
+}
+
+// recordStakeMetric records metrics for side and post handlers.
+func recordStakeMetric(method string, apiType string, start time.Time, err *error) {
+	success := *err == nil
+	api.RecordAPICallWithStart(api.StakeSubsystem, method, apiType, success, start)
 }


### PR DESCRIPTION
# Description

This PR extends the metrics for side and post-transaction handlers for each module. Also adds a `countervec` for approved, rejected, and failure to reach a 2/3rd agreement for side txs.

Also, it adds summaryvec for abci handlers.