### PR TITLE
Add span range check

### DIFF
--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -412,25 +412,44 @@ func appExport(
 	return hApp.ExportAppStateAndValidators(false, nil, modulesToExport)
 }
 
-// generateKeystore generate the keystore file from the private key
+// generateKeystore generate the keystore file from the private key or generates a new key
 func generateKeystore() *cobra.Command {
+	var generateNew bool
+
 	cmd := &cobra.Command{
-		Use:   "generate-keystore",
-		Short: "Generates keystore file",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			pk, err := ethcrypto.GenerateKey()
-			if err != nil {
-				return err
+		Use: "generate-keystore [private-key] or generate-keystore --generate-new",
+		Short: `Generates a keystore file from a private key, or generates a new key. If --generate-new is set, a new key will be created.
+		If [private-key] is provided, it will be used instead of generating a new key. If both are provided, the private key will be used.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var pk *ecdsa.PrivateKey
+			var err error
+
+			if len(args) > 0 {
+				s := strings.ReplaceAll(args[0], "0x", "")
+				pk, err = ethcrypto.HexToECDSA(s)
+				if err != nil {
+					return fmt.Errorf("invalid private key: %w", err)
+				}
+			} else if generateNew {
+				pk, err = ethcrypto.GenerateKey()
+				if err != nil {
+					return fmt.Errorf("failed to generate key: %w", err)
+				}
+			} else {
+				return fmt.Errorf("must provide a private key or use --generate-new flag")
 			}
 
 			if err = createKeyStore(pk); err != nil {
-				return err
+				return fmt.Errorf("failed to create keystore: %w", err)
 			}
 
+			fmt.Println("Keystore generated successfully.")
 			return nil
 		},
 	}
 
+	cmd.Flags().BoolVar(&generateNew, "generate-new", false, "Generate a new private key")
 	return cmd
 }
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -1092,11 +1092,12 @@ func InitTestHeimdallConfig(chain string) {
 		Custom: GetDefaultHeimdallConfig(),
 	}
 
-	if chain == MumbaiChain {
+	switch chain {
+	case MumbaiChain:
 		customAppConf.Custom.Chain = MumbaiChain
-	} else if chain == AmoyChain {
+	case AmoyChain:
 		customAppConf.Custom.Chain = AmoyChain
-	} else if chain == MainChain {
+	case MainChain:
 		customAppConf.Custom.Chain = MainChain
 	}
 

--- a/x/bor/keeper/side_msg_server.go
+++ b/x/bor/keeper/side_msg_server.go
@@ -68,6 +68,21 @@ func (s sideMsgServer) SideHandleMsgSpan(ctx sdk.Context, msgI sdk.Msg) sidetxs.
 		"seed", msg.Seed,
 	)
 
+	params, err := s.k.GetParams(ctx)
+	if err != nil {
+		logger.Error("error fetching params", "error", err)
+		return sidetxs.Vote_VOTE_NO
+	}
+
+	if params.SpanDuration != (msg.EndBlock - msg.StartBlock + 1) {
+		logger.Error("span duration of proposed span is wrong",
+			"proposedSpanDuration", msg.EndBlock-msg.StartBlock+1,
+			"paramsSpanDuration", params.SpanDuration,
+		)
+
+		return sidetxs.Vote_VOTE_NO
+	}
+
 	// calculate next span seed locally
 	nextSpanSeed, nextSpanSeedAuthor, err := s.k.FetchNextSpanSeed(ctx, msg.SpanId)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR adds a check to verify the proposed span length. Also cherry-picks the fix for  `generate-keystore` command. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [x] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

