### PR TITLE
[bugfix] make the length of a new span strictly equal to SpanDuration

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -434,7 +434,7 @@ func (app *HeimdallApp) checkAndAddFutureSpan(ctx sdk.Context, majorityMilestone
 			return err
 		}
 
-		endBlock := lastSpan.EndBlock + params.SpanDuration - 1
+		endBlock := lastSpan.EndBlock + params.SpanDuration
 
 		currentProducer, err := app.BorKeeper.FindCurrentProducerID(ctx, lastSpan.EndBlock)
 		if err != nil {


### PR DESCRIPTION
# Description

Fix a bug where new span in veblop had 1 block less than the SpanDuration defined in the protocol, e.g. 6399 instead of 6400.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least two reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross-repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli
