### PR TITLE
Set voting power and valset check heights for amoy

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -439,7 +439,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		tallyFixHeight = 13143851
 		disableVPCheckHeight = 10618199
 		disableValSetCheckHeight = 10618299
-		initialHeight = 0
+		initialHeight = 8788501
 	default:
 		veblopHeight = 0
 		tallyFixHeight = 0

--- a/helper/config.go
+++ b/helper/config.go
@@ -437,8 +437,8 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	case AmoyChain:
 		veblopHeight = 0
 		tallyFixHeight = 13143851
-		disableVPCheckHeight = 10618199 // TODO: confirm with team
-		disableValSetCheckHeight = 0    // TODO: confirm with team
+		disableVPCheckHeight = 10618199
+		disableValSetCheckHeight = 10618299
 		initialHeight = 0
 	default:
 		veblopHeight = 0

--- a/helper/config.go
+++ b/helper/config.go
@@ -436,9 +436,9 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		initialHeight = 0
 	case AmoyChain:
 		veblopHeight = 0
-		tallyFixHeight = 0           // TODO: TBD
-		disableVPCheckHeight = 0     // TODO: confirm with team
-		disableValSetCheckHeight = 0 // TODO: confirm with team
+		tallyFixHeight = 13143851
+		disableVPCheckHeight = 10618199 // TODO: confirm with team
+		disableValSetCheckHeight = 0    // TODO: confirm with team
 		initialHeight = 0
 	default:
 		veblopHeight = 0


### PR DESCRIPTION
# Description

This PR sets `tallyFixHeight`, `disableVPCheckHeight` and `disableValSetCheckHeight` for amoy network. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli
