### PR TITLE
Query blocks for milestone up to latest bor block

### DIFF
--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -524,6 +524,11 @@ func TestExtendVoteHandler(t *testing.T) {
 
 	mockCaller := new(helpermocks.IContractCaller)
 	mockCaller.
+		On("GetBorChainBlock", mock.Anything, mock.Anything).
+		Return(&ethTypes.Header{
+			Number: big.NewInt(10),
+		}, nil)
+	mockCaller.
 		On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 		Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)
 
@@ -662,6 +667,11 @@ func TestVerifyVoteExtensionHandler(t *testing.T) {
 	require.NotEmpty(t, respPrep.Txs)
 
 	mockCaller := new(helpermocks.IContractCaller)
+	mockCaller.
+		On("GetBorChainBlock", mock.Anything, mock.Anything).
+		Return(&ethTypes.Header{
+			Number: big.NewInt(10),
+		}, nil)
 	mockCaller.
 		On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 		Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)
@@ -823,6 +833,11 @@ func TestSidetxsHappyPath(t *testing.T) {
 	}
 
 	mockCaller := new(helpermocks.IContractCaller)
+	mockCaller.
+		On("GetBorChainBlock", mock.Anything, mock.Anything).
+		Return(&ethTypes.Header{
+			Number: big.NewInt(10),
+		}, nil)
 	mockCaller.
 		On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 		Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)
@@ -1377,7 +1392,11 @@ func TestAllUnhappyPathClerkSideTxs(t *testing.T) {
 		)
 
 		mockCaller.On("GetConfirmedTxReceipt", mock.Anything, mock.Anything).Return(nil, nil).Once()
-
+		mockCaller.
+			On("GetBorChainBlock", mock.Anything, mock.Anything).
+			Return(&ethTypes.Header{
+				Number: big.NewInt(1),
+			}, nil)
 		mockCaller.
 			On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 			Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)
@@ -1780,7 +1799,11 @@ func TestAllUnhappyPathTopupSideTxs(t *testing.T) {
 
 		mockCaller.On("GetConfirmedTxReceipt", mock.Anything, mock.Anything).Return(nil, nil).Once()
 		mockCaller.On("DecodeStateSyncedEvent", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
-
+		mockCaller.
+			On("GetBorChainBlock", mock.Anything, mock.Anything).
+			Return(&ethTypes.Header{
+				Number: big.NewInt(10),
+			}, nil)
 		mockCaller.
 			On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 			Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)
@@ -2361,6 +2384,11 @@ func TestPrepareProposal(t *testing.T) {
 	ctx = ctx.WithConsensusParams(params)
 
 	mockCaller := new(helpermocks.IContractCaller)
+	mockCaller.
+		On("GetBorChainBlock", mock.Anything, mock.Anything).
+		Return(&ethTypes.Header{
+			Number: big.NewInt(1),
+		}, nil)
 	mockCaller.
 		On("GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).
 		Return([]*ethTypes.Header{}, []uint64{}, []common.Address{}, nil)

--- a/x/milestone/abci/abci.go
+++ b/x/milestone/abci/abci.go
@@ -407,7 +407,17 @@ func GetMajorityMilestoneProposition(
 var ErrNoHeadersFound = errors.New("no header found")
 
 func getBlockInfo(ctx sdk.Context, startBlock, maxBlocksInProposition uint64, lastMilestoneHash []byte, lastMilestoneBlock uint64, contractCaller helper.IContractCaller) ([]byte, [][]byte, []uint64, []common.Address, error) {
-	headers, tds, authors, err := contractCaller.GetBorChainBlockInfoInBatch(ctx, int64(startBlock), int64(startBlock+maxBlocksInProposition-1))
+	lastestBlock, err := contractCaller.GetBorChainBlock(ctx, nil)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to get latest block: %w", err)
+	}
+
+	milestoneEnd := int64(startBlock + maxBlocksInProposition - 1)
+	if lastestBlock.Number.Int64() > int64(startBlock) && lastestBlock.Number.Int64() < milestoneEnd {
+		milestoneEnd = lastestBlock.Number.Int64()
+	}
+
+	headers, tds, authors, err := contractCaller.GetBorChainBlockInfoInBatch(ctx, int64(startBlock), milestoneEnd)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get headers: %w", err)
 	}

--- a/x/milestone/abci/abci.go
+++ b/x/milestone/abci/abci.go
@@ -408,7 +408,7 @@ var ErrNoHeadersFound = errors.New("no header found")
 
 func getBlockInfo(ctx sdk.Context, startBlock, maxBlocksInProposition uint64, lastMilestoneHash []byte, lastMilestoneBlock uint64, contractCaller helper.IContractCaller) ([]byte, [][]byte, []uint64, []common.Address, error) {
 	lastestBlock, err := contractCaller.GetBorChainBlock(ctx, nil)
-	if err != nil {
+	if err != nil || lastestBlock == nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get latest block: %w", err)
 	}
 

--- a/x/milestone/abci/abci.go
+++ b/x/milestone/abci/abci.go
@@ -407,14 +407,14 @@ func GetMajorityMilestoneProposition(
 var ErrNoHeadersFound = errors.New("no header found")
 
 func getBlockInfo(ctx sdk.Context, startBlock, maxBlocksInProposition uint64, lastMilestoneHash []byte, lastMilestoneBlock uint64, contractCaller helper.IContractCaller) ([]byte, [][]byte, []uint64, []common.Address, error) {
-	lastestBlock, err := contractCaller.GetBorChainBlock(ctx, nil)
-	if err != nil || lastestBlock == nil {
+	latestBlock, err := contractCaller.GetBorChainBlock(ctx, nil)
+	if err != nil || latestBlock == nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get latest block: %w", err)
 	}
 
 	milestoneEnd := int64(startBlock + maxBlocksInProposition - 1)
-	if lastestBlock.Number.Int64() > int64(startBlock) && lastestBlock.Number.Int64() < milestoneEnd {
-		milestoneEnd = lastestBlock.Number.Int64()
+	if latestBlock.Number.Int64() > int64(startBlock) && latestBlock.Number.Int64() < milestoneEnd {
+		milestoneEnd = latestBlock.Number.Int64()
 	}
 
 	headers, tds, authors, err := contractCaller.GetBorChainBlockInfoInBatch(ctx, int64(startBlock), milestoneEnd)


### PR DESCRIPTION
# Description

Query blocks for milestone up to latest bor block, instead of max miestone length to reduce load on bor
