### PR TITLE
Change milestone fast forward calculation

### DIFF
--- a/x/milestone/abci/abci.go
+++ b/x/milestone/abci/abci.go
@@ -52,7 +52,7 @@ func GenMilestoneProposition(ctx sdk.Context, borKeeper *borKeeper.Keeper, miles
 		}
 
 		if isFastForwardMilestone(latestHeader.Number.Uint64(), milestone.EndBlock, params.FfMilestoneThreshold) {
-			propStartBlock = getFastForwardMilestoneStartBlock(latestHeader.Number.Uint64(), milestone.EndBlock, params.FfMilestoneBlockInterval)
+			propStartBlock = getFastForwardMilestoneStartBlock(milestone.EndBlock, params.FfMilestoneBlockInterval)
 		}
 
 		lastMilestoneHash = milestone.Hash
@@ -112,9 +112,8 @@ func isFastForwardMilestone(latestHeaderNumber, latestMilestoneEndBlock, ffMiles
 	return latestHeaderNumber > latestMilestoneEndBlock && latestHeaderNumber-latestMilestoneEndBlock > ffMilestoneThreshold
 }
 
-func getFastForwardMilestoneStartBlock(latestHeaderNumber, latestMilestoneEndBlock, ffMilestoneBlockInterval uint64) uint64 {
-	latestHeaderMilestoneDistanceInBlocks := ((latestHeaderNumber - latestMilestoneEndBlock) / ffMilestoneBlockInterval) * ffMilestoneBlockInterval
-	return latestMilestoneEndBlock + latestHeaderMilestoneDistanceInBlocks + 1
+func getFastForwardMilestoneStartBlock(latestMilestoneEndBlock, ffMilestoneBlockInterval uint64) uint64 {
+	return latestMilestoneEndBlock + ffMilestoneBlockInterval
 }
 
 func GetMajorityMilestoneProposition(

--- a/x/milestone/abci/abci_test.go
+++ b/x/milestone/abci/abci_test.go
@@ -87,45 +87,16 @@ func TestGetFastForwardMilestoneStartBlock(t *testing.T) {
 		expected                 uint64
 	}{
 		{
-			name:                     "Exact multiple",
-			latestHeaderNumber:       150,
+			name:                     "Interval is 10",
 			latestMilestoneEndBlock:  100,
 			ffMilestoneBlockInterval: 10,
-			expected:                 151, // (150-100)/10=5*10=50, then 100+50+1 = 151
-		},
-		{
-			name:                     "Not an exact multiple",
-			latestHeaderNumber:       153,
-			latestMilestoneEndBlock:  100,
-			ffMilestoneBlockInterval: 10,
-			expected:                 151, // (153-100)=53/10=5*10=50, then 100+50+1 = 151
-		},
-		{
-			name:                     "Zero difference",
-			latestHeaderNumber:       100,
-			latestMilestoneEndBlock:  100,
-			ffMilestoneBlockInterval: 10,
-			expected:                 101, // 0/10=0, then 100+0+1 = 101
-		},
-		{
-			name:                     "Interval equals 1",
-			latestHeaderNumber:       150,
-			latestMilestoneEndBlock:  100,
-			ffMilestoneBlockInterval: 1,
-			expected:                 151, // every block counts; 150-100=50, then 100+50+1 = 151
-		},
-		{
-			name:                     "Interval larger than difference",
-			latestHeaderNumber:       105,
-			latestMilestoneEndBlock:  100,
-			ffMilestoneBlockInterval: 10,
-			expected:                 101, // (5/10=0) then 100+0+1 = 101
+			expected:                 110, // 100+10=110
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := getFastForwardMilestoneStartBlock(tc.latestHeaderNumber, tc.latestMilestoneEndBlock, tc.ffMilestoneBlockInterval)
+			result := getFastForwardMilestoneStartBlock(tc.latestMilestoneEndBlock, tc.ffMilestoneBlockInterval)
 			if result != tc.expected {
 				t.Errorf("getFastForwardMilestoneStartBlock(%d, %d, %d) = %d; expected %d",
 					tc.latestHeaderNumber, tc.latestMilestoneEndBlock, tc.ffMilestoneBlockInterval, result, tc.expected)


### PR DESCRIPTION
# Description

When difference between current bor tip and last finalized milestone block is more than `ff_milestone_threshold` (currently 1000) we gonna start proposing milestones at `ff_milestone_block_interval` (currently 100)