### PR TITLE
Default Prune and Compaction Config

### DIFF
--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -119,6 +119,11 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
+			err = SanitizeConfig(serverCtx.Viper)
+			if err != nil {
+				return err
+			}
+
 			// Overwrite default server logger
 			logger, err := server.CreateSDKLogger(serverCtx, cmd.OutOrStdout())
 			if err != nil {

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -119,11 +119,6 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			err = SanitizeConfig(serverCtx.Viper)
-			if err != nil {
-				return err
-			}
-
 			// Overwrite default server logger
 			logger, err := server.CreateSDKLogger(serverCtx, cmd.OutOrStdout())
 			if err != nil {
@@ -143,6 +138,11 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 			helper.Logger = log.NewLogger(cmd.OutOrStdout(), log.LevelOption(logLevel))
+
+			err = helper.SanitizeConfig(serverCtx.Viper, serverCtx.Logger)
+			if err != nil {
+				return err
+			}
 
 			// Set server context
 			return server.SetCmdServerContext(cmd, serverCtx)

--- a/cmd/heimdalld/cmd/sanitize.go
+++ b/cmd/heimdalld/cmd/sanitize.go
@@ -3,9 +3,10 @@ package heimdalld
 import (
 	"fmt"
 
-	"github.com/0xPolygon/heimdall-v2/helper"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
 )
 
 func SanitizeConfig(rootViper *viper.Viper) error {

--- a/cmd/heimdalld/cmd/sanitize.go
+++ b/cmd/heimdalld/cmd/sanitize.go
@@ -1,0 +1,31 @@
+package heimdalld
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
+func SanitizeConfig(rootViper *viper.Viper) error {
+	var appCfg helper.CustomAppConfig
+	decodeHook := mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+	)
+	if err := rootViper.Unmarshal(&appCfg, viper.DecodeHook(decodeHook)); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+	if notes, kv := appCfg.Sanitize(); len(notes) > 0 {
+		fmt.Println("## Detected some configuration values to be sanitized")
+		for _, n := range notes {
+			fmt.Println("[config] adjusted:", n)
+		}
+		// write sanitized values back into Viper
+		for k, v := range kv {
+			rootViper.Set(k, v)
+		}
+	}
+	return nil
+}

--- a/helper/config.go
+++ b/helper/config.go
@@ -1156,8 +1156,8 @@ func GetBorGRPCClient() *borgrpc.BorGRPCClient {
 func (c *CustomAppConfig) Sanitize() (notes []string, kv map[string]any) {
 	kv = make(map[string]any)
 
-	if c.BaseConfig.MinRetainBlocks != 0 && c.BaseConfig.MinRetainBlocks < MinimunMinRetainBlocks {
-		c.BaseConfig.MinRetainBlocks = MinimunMinRetainBlocks
+	if c.MinRetainBlocks != 0 && c.MinRetainBlocks < MinimunMinRetainBlocks {
+		c.MinRetainBlocks = MinimunMinRetainBlocks
 		notes = append(notes, fmt.Sprintf("min-retain-blocks=%d (minimum enforced)", MinimunMinRetainBlocks))
 		kv["min-retain-blocks"] = MinimunMinRetainBlocks
 	}

--- a/helper/config.go
+++ b/helper/config.go
@@ -125,7 +125,7 @@ const (
 	// MaxStateSyncSize is the new max state sync size after SpanOverrideHeight hard fork
 	MaxStateSyncSize = 30000
 
-	MinimunMinRetainBlocks = 2500000
+	EnforcedMinRetainBlocks = 2500000
 )
 
 func init() {
@@ -1156,10 +1156,10 @@ func GetBorGRPCClient() *borgrpc.BorGRPCClient {
 func (c *CustomAppConfig) Sanitize() (notes []string, kv map[string]any) {
 	kv = make(map[string]any)
 
-	if c.MinRetainBlocks != 0 && c.MinRetainBlocks < MinimunMinRetainBlocks {
-		c.MinRetainBlocks = MinimunMinRetainBlocks
-		notes = append(notes, fmt.Sprintf("min-retain-blocks=%d (minimum enforced)", MinimunMinRetainBlocks))
-		kv["min-retain-blocks"] = MinimunMinRetainBlocks
+	if c.MinRetainBlocks != 0 && c.MinRetainBlocks < EnforcedMinRetainBlocks {
+		c.MinRetainBlocks = EnforcedMinRetainBlocks
+		notes = append(notes, fmt.Sprintf("min-retain-blocks=%d (minimum enforced)", EnforcedMinRetainBlocks))
+		kv["min-retain-blocks"] = EnforcedMinRetainBlocks
 	}
 
 	return notes, kv

--- a/helper/config.go
+++ b/helper/config.go
@@ -124,6 +124,8 @@ const (
 
 	// MaxStateSyncSize is the new max state sync size after SpanOverrideHeight hard fork
 	MaxStateSyncSize = 30000
+
+	MinimunMinRetainBlocks = 2500000
 )
 
 func init() {
@@ -1148,4 +1150,17 @@ func GetLogsWriter(logsWriterFile string) io.Writer {
 // GetBorGRPCClient returns bor gRPC client
 func GetBorGRPCClient() *borgrpc.BorGRPCClient {
 	return borGRPCClient
+}
+
+// Sanitize enforces minimums and returns notes and corrected key/values
+func (c *CustomAppConfig) Sanitize() (notes []string, kv map[string]any) {
+	kv = make(map[string]any)
+
+	if c.BaseConfig.MinRetainBlocks != 0 && c.BaseConfig.MinRetainBlocks < MinimunMinRetainBlocks {
+		c.BaseConfig.MinRetainBlocks = MinimunMinRetainBlocks
+		notes = append(notes, fmt.Sprintf("min-retain-blocks=%d (minimum enforced)", MinimunMinRetainBlocks))
+		kv["min-retain-blocks"] = MinimunMinRetainBlocks
+	}
+
+	return notes, kv
 }

--- a/helper/sanitize.go
+++ b/helper/sanitize.go
@@ -1,16 +1,15 @@
-package heimdalld
+package helper
 
 import (
 	"fmt"
 
+	"cosmossdk.io/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
-
-	"github.com/0xPolygon/heimdall-v2/helper"
 )
 
-func SanitizeConfig(rootViper *viper.Viper) error {
-	var appCfg helper.CustomAppConfig
+func SanitizeConfig(rootViper *viper.Viper, logger log.Logger) error {
+	var appCfg CustomAppConfig
 	decodeHook := mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
@@ -19,9 +18,9 @@ func SanitizeConfig(rootViper *viper.Viper) error {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 	if notes, kv := appCfg.Sanitize(); len(notes) > 0 {
-		fmt.Println("## Detected some configuration values to be sanitized")
+		logger.Warn("Detected some configuration values to be sanitized")
 		for _, n := range notes {
-			fmt.Println("[config] adjusted:", n)
+			logger.Warn("[config] adjusted:", n)
 		}
 		// write sanitized values back into Viper
 		for k, v := range kv {

--- a/packaging/templates/config/amoy/app.toml
+++ b/packaging/templates/config/amoy/app.toml
@@ -48,9 +48,11 @@ halt-time = 0
 # "pruning-*" configurations.
 #
 # Note: CometBFT block pruning is dependant on this parameter in conjunction
-# with the unbonding (safety threshold) period, state pruning and state sync
-# snapshot parameters to determine the correct minimum value of
+# with the unbonding (safety threshold) period, state pruning, state sync
+# snapshot parameters and evidence max age to determine the correct minimum value of
 # ResponseCommit.RetainHeight.
+# Since evidence.max_age_num_blocks is currently set on 100000, thats the minimum value
+# expected to be set
 min-retain-blocks = 0
 
 # InterBlockCache enables inter-block caching.

--- a/packaging/templates/config/amoy/app.toml
+++ b/packaging/templates/config/amoy/app.toml
@@ -51,8 +51,7 @@ halt-time = 0
 # with the unbonding (safety threshold) period, state pruning, state sync
 # snapshot parameters and evidence max age to determine the correct minimum value of
 # ResponseCommit.RetainHeight.
-# Since evidence.max_age_num_blocks is currently set on 100000, thats the minimum value
-# expected to be set
+# Minimum expected value of 2500000 (enforced by sanitization)
 min-retain-blocks = 0
 
 # InterBlockCache enables inter-block caching.

--- a/packaging/templates/config/amoy/config.toml
+++ b/packaging/templates/config/amoy/config.toml
@@ -458,6 +458,28 @@ peer_query_maj23_sleep_duration = "200ms"
 # reindex events in the command-line tool.
 discard_abci_responses = false
 
+# If set to true, CometBFT will force compaction to happen for databases that support this feature.
+# and save on storage space. Setting this to true is most benefits when used in combination
+# with pruning as it will phyisically delete the entries marked for deletion.
+# false by default (forcing compaction is disabled).
+compact = false
+
+# To avoid forcing compaction every time, this parameter instructs CometBFT to wait 
+# the given amount of blocks to be pruned before triggering compaction.
+# It should be tuned depending on the number of items. If your retain height is 1 block,
+# it is too much of an overhead to try compaction every block. But it should also not be a very
+# large multiple of your retain height as it might occur bigger overheads.
+compaction_interval = 1000
+
+[storage.pruning]
+
+# The time period between automated background pruning operations.
+interval = "10m0s"
+
+# Indexer pruning enabling. Note that this has not been tested in production
+# It should be enabled on full nodes to confirm it is not impacting performance. 
+indexer_pruning_enabled = false
+
 #######################################################
 ###   Transaction Indexer Configuration Options     ###
 #######################################################

--- a/packaging/templates/config/amoy/config.toml
+++ b/packaging/templates/config/amoy/config.toml
@@ -476,8 +476,7 @@ compaction_interval = 1000
 # The time period between automated background pruning operations.
 interval = "10m0s"
 
-# Indexer pruning enabling. Note that this has not been tested in production
-# It should be enabled on full nodes to confirm it is not impacting performance. 
+# Indexer pruning enabling.
 indexer_pruning_enabled = false
 
 #######################################################

--- a/packaging/templates/config/mainnet/app.toml
+++ b/packaging/templates/config/mainnet/app.toml
@@ -48,9 +48,11 @@ halt-time = 0
 # "pruning-*" configurations.
 #
 # Note: CometBFT block pruning is dependant on this parameter in conjunction
-# with the unbonding (safety threshold) period, state pruning and state sync
-# snapshot parameters to determine the correct minimum value of
+# with the unbonding (safety threshold) period, state pruning, state sync
+# snapshot parameters and evidence max age to determine the correct minimum value of
 # ResponseCommit.RetainHeight.
+# Since evidence.max_age_num_blocks is currently set on 100000, thats the minimum value
+# expected to be set
 min-retain-blocks = 0
 
 # InterBlockCache enables inter-block caching.

--- a/packaging/templates/config/mainnet/app.toml
+++ b/packaging/templates/config/mainnet/app.toml
@@ -51,8 +51,7 @@ halt-time = 0
 # with the unbonding (safety threshold) period, state pruning, state sync
 # snapshot parameters and evidence max age to determine the correct minimum value of
 # ResponseCommit.RetainHeight.
-# Since evidence.max_age_num_blocks is currently set on 100000, thats the minimum value
-# expected to be set
+# Minimum expected value of 2500000 (enforced by sanitization)
 min-retain-blocks = 0
 
 # InterBlockCache enables inter-block caching.

--- a/packaging/templates/config/mainnet/config.toml
+++ b/packaging/templates/config/mainnet/config.toml
@@ -458,6 +458,28 @@ peer_query_maj23_sleep_duration = "200ms"
 # reindex events in the command-line tool.
 discard_abci_responses = false
 
+# If set to true, CometBFT will force compaction to happen for databases that support this feature.
+# and save on storage space. Setting this to true is most benefits when used in combination
+# with pruning as it will phyisically delete the entries marked for deletion.
+# false by default (forcing compaction is disabled).
+compact = false
+
+# To avoid forcing compaction every time, this parameter instructs CometBFT to wait 
+# the given amount of blocks to be pruned before triggering compaction.
+# It should be tuned depending on the number of items. If your retain height is 1 block,
+# it is too much of an overhead to try compaction every block. But it should also not be a very
+# large multiple of your retain height as it might occur bigger overheads.
+compaction_interval = 1000
+
+[storage.pruning]
+
+# The time period between automated background pruning operations.
+interval = "10m0s"
+
+# Indexer pruning enabling. Note that this has not been tested in production
+# It should be enabled on full nodes to confirm it is not impacting performance. 
+indexer_pruning_enabled = false
+
 #######################################################
 ###   Transaction Indexer Configuration Options     ###
 #######################################################

--- a/packaging/templates/config/mainnet/config.toml
+++ b/packaging/templates/config/mainnet/config.toml
@@ -476,8 +476,7 @@ compaction_interval = 1000
 # The time period between automated background pruning operations.
 interval = "10m0s"
 
-# Indexer pruning enabling. Note that this has not been tested in production
-# It should be enabled on full nodes to confirm it is not impacting performance. 
+# Indexer pruning enabling.
 indexer_pruning_enabled = false
 
 #######################################################


### PR DESCRIPTION
# Description

Including new default prune and compaction flags to be inserted on Heimdall. These new configurations comes from the new introduced CometBFT features: https://github.com/0xPolygon/cometbft/pull/23 and https://github.com/0xPolygon/cometbft/pull/24

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
