### PR TITLE
update readme and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ heimdalld start
 Instructions on how to import your validator private key into the keyring and use it to sign transactions.
 
 Get your `base64` encoded private key from:  
-`cat /var/lib/heimdall/config/priv_validator_key.json`
+`/var/lib/heimdall/config/priv_validator_key.json`
 
 Convert the `base64` encoded key to the hex encoded key:  
 `echo "<PRIVATE_KEY_BASE64_ENCODED>" | base64 -d | xxd -p -c 256`

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -343,6 +343,7 @@ func AddCommandsWithStartCmdOptions(rootCmd *cobra.Command, defaultNodeHome stri
 		server.VersionCmd(),
 		cmtcmd.ResetAllCmd,
 		cmtcmd.ResetStateCmd,
+		cmtcmd.GenNodeKeyCmd,
 		server.BootstrapStateCmd(appCreator),
 	)
 


### PR DESCRIPTION
# Description

- Remove `cat` from priv files docs in README, to let the operator decide how to fetch the string. 
- Add heimdalld command to generate node id from comet