### PR TITLE
revert: rio height to 256

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -473,7 +473,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	default:
 		milestoneDeletionHeight = 0
 		faultyMilestoneNumber = -1
-		rioHeight = 0 // Rio height for local devnet.
+		rioHeight = 256 // Rio height for local devnet.
 		tallyFixHeight = 0
 		disableVPCheckHeight = 0
 		disableValSetCheckHeight = 0


### PR DESCRIPTION
# Description

It isn't simple to just revert Rio to 0 for now. Erigon has issues with this, and sometimes Bor too. Reverting for now.