### PR TITLE
fix releaser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER := $(shell which docker)
 
 PACKAGE_NAME := github.com/0xPolygon/heimdall-v2
 HTTPS_GIT := https://$(PACKAGE_NAME).git
-GOLANG_CROSS_VERSION  ?= v1.24.9
+GOLANG_CROSS_VERSION  ?= v1.24.1
 
 # Fetch git latest tag
 LATEST_GIT_TAG:=$(shell git describe --tags $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
# Description

goreleaser does not have any minor version on the original repo. On our local one we pointed 1.24 to 1.24.1, so until we use 1.24.x we keep 1.24.1 in the Makefile

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Node audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it
(e.g., by adding a flag with a default value...)

# Checklist

- [ ] I have added at least two reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross-repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
