### PR TITLE
fix: wire `--log_no_color` flag to all loggers

### DIFF
--- a/bridge/broadcaster/broadcaster.go
+++ b/bridge/broadcaster/broadcaster.go
@@ -3,7 +3,6 @@ package broadcaster
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -55,7 +54,7 @@ func NewTxBroadcaster(
 	}
 	fromAddr := sdk.MustAccAddressFromHex(addrHex)
 
-	logger := log.NewLogger(os.Stdout).With("module", "txBroadcaster")
+	logger := helper.Logger.With("module", "bridge/broadcaster")
 
 	var account sdk.AccountI
 	if accRetriever != nil {

--- a/bridge/processor/base.go
+++ b/bridge/processor/base.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	"cosmossdk.io/log"
@@ -91,7 +90,7 @@ func NewBaseProcessor(cdc codec.Codec, queueConnector *queue.Connector, httpClie
 	}
 
 	if logger == nil {
-		logger = log.NewLogger(os.Stdout)
+		logger = helper.Logger.With("module", "bridge/processor")
 	}
 
 	// creating the syncer object

--- a/bridge/queue/connector.go
+++ b/bridge/queue/connector.go
@@ -1,12 +1,12 @@
 package queue
 
 import (
-	"os"
-
 	"cosmossdk.io/log"
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
 )
 
 // The Connector is used to connect to the queue
@@ -45,7 +45,7 @@ func NewQueueConnector(dialer string) *Connector {
 	}
 
 	connector := Connector{
-		logger: log.NewLogger(os.Stdout).With("module", "QueueConnector"),
+		logger: helper.Logger.With("module", "bridge/queue"),
 		Server: server,
 	}
 

--- a/bridge/service/bridge.go
+++ b/bridge/service/bridge.go
@@ -42,7 +42,7 @@ const (
 	logsTypeKey   = "logs-type"
 )
 
-var logger = helper.Logger.With("module", "bridge/service/")
+var logger = helper.Logger.With("module", "bridge/service")
 
 // AdjustDBValue sets/normalizes viper-config for bridge runtime based on flags present on root/start cmd
 func AdjustDBValue(cmd *cobra.Command) {

--- a/bridge/service/bridge.go
+++ b/bridge/service/bridge.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"cosmossdk.io/log"
 	"cosmossdk.io/x/tx/signing"
 	common "github.com/cometbft/cometbft/libs/service"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
@@ -42,7 +43,7 @@ const (
 	logsTypeKey   = "logs-type"
 )
 
-var logger = helper.Logger.With("module", "bridge/service")
+func logger() log.Logger { return helper.Logger.With("module", "bridge/service") }
 
 // AdjustDBValue sets/normalizes viper-config for bridge runtime based on flags present on root/start cmd
 func AdjustDBValue(cmd *cobra.Command) {
@@ -88,14 +89,14 @@ func StartWithCtx(ctx context.Context, clientCtx client.Context) error {
 
 	httpClient, err := createAndStartRPC(helper.GetConfig().CometBFTRPCUrl)
 	if err != nil {
-		logger.Error("Error connecting to server", "err", err)
+		logger().Error("Error connecting to server", "err", err)
 		return err
 	}
 
 	// set chain ID
 	chainID, err := resolveChainID(ctx, clientCtx)
 	if err != nil {
-		logger.Error("Error while determining chain ID", "err", err)
+		logger().Error("Error while determining chain ID", "err", err)
 		return err
 	}
 	clientCtx = clientCtx.WithChainID(chainID)
@@ -165,11 +166,11 @@ func createAndStartRPC(rpcURL string) (*rpchttp.HTTP, error) {
 // resolveChainID retrieves the chain ID from the client context or node status.
 func resolveChainID(ctx context.Context, clientCtx client.Context) (string, error) {
 	if cid := clientCtx.ChainID; cid != "" {
-		logger.Info("ChainID set in clientCtx", "chainId", cid)
+		logger().Info("ChainID set in clientCtx", "chainId", cid)
 		return cid, nil
 	}
 
-	logger.Info("ChainID is empty in clientCtx at bridge startup, fetching from node status")
+	logger().Info("ChainID is empty in clientCtx at bridge startup, fetching from node status")
 
 	nodeStatus, err := helper.GetNodeStatus(clientCtx) //nolint:contextcheck
 	if err != nil {
@@ -179,7 +180,7 @@ func resolveChainID(ctx context.Context, clientCtx client.Context) (string, erro
 		return "", errors.New("network is empty in node status, cannot determine chain ID")
 	}
 
-	logger.Info("ChainID fetched from node status", "chainId", nodeStatus.NodeInfo.Network)
+	logger().Info("ChainID fetched from node status", "chainId", nodeStatus.NodeInfo.Network)
 	return nodeStatus.NodeInfo.Network, nil
 }
 
@@ -191,10 +192,10 @@ func waitUntilSynced(ctx context.Context, clientCtx client.Context, d time.Durat
 			return ctx.Err()
 		case <-time.After(d):
 			if !util.IsCatchingUp(clientCtx, ctx) {
-				logger.Info("Node up to date, starting bridge services")
+				logger().Info("Node up to date, starting bridge services")
 				return nil
 			}
-			logger.Info("Waiting for heimdall to be synced")
+			logger().Info("Waiting for heimdall to be synced")
 		}
 	}
 }
@@ -208,7 +209,7 @@ func runServices(ctx context.Context, services []common.Service, httpClient *rpc
 		s := svc
 		g.Go(func() error {
 			if err := s.Start(); err != nil {
-				logger.Error("service.Start failed", "err", err)
+				logger().Error("service.Start failed", "err", err)
 				return err
 			}
 			<-s.Quit()
@@ -219,13 +220,13 @@ func runServices(ctx context.Context, services []common.Service, httpClient *rpc
 	// shutdown controller
 	g.Go(func() error {
 		<-ctx.Done()
-		logger.Info("Received stop signal - Stopping all heimdall bridge services")
+		logger().Info("Received stop signal - Stopping all heimdall bridge services")
 
 		// stop services
 		for _, s := range services {
 			if s.IsRunning() {
 				if err := s.Stop(); err != nil {
-					logger.Error("service.Stop failed", "err", err)
+					logger().Error("service.Stop failed", "err", err)
 					return err
 				}
 			}
@@ -233,7 +234,7 @@ func runServices(ctx context.Context, services []common.Service, httpClient *rpc
 
 		// stop comet client
 		if err := httpClient.Stop(); err != nil {
-			logger.Error("httpClient.Stop failed", "err", err)
+			logger().Error("httpClient.Stop failed", "err", err)
 			return err
 		}
 
@@ -243,7 +244,7 @@ func runServices(ctx context.Context, services []common.Service, httpClient *rpc
 	})
 
 	if err := g.Wait(); err != nil {
-		logger.Error("Bridge stopped", "err", err)
+		logger().Error("Bridge stopped", "err", err)
 		return err
 	}
 	return nil

--- a/bridge/util/common.go
+++ b/bridge/util/common.go
@@ -73,7 +73,7 @@ const (
 
 // Logger returns logger singleton instance
 func Logger() log.Logger {
-	return helper.Logger.With("module", "bridge")
+	return helper.Logger.With("module", "bridge/util")
 }
 
 // IsProposer checks if the current is the proposer

--- a/cmd/heimdalld/cmd/migration/verify/verify_test.go
+++ b/cmd/heimdalld/cmd/migration/verify/verify_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRunMigrationVerification(t *testing.T) {
-	logger := helper.Logger.With("module", "cmd/heimdalld")
+	logger := helper.Logger.With("module", "cmd/heimdalld/cmd/migration/verify")
 
 	genesisFilePath, err := filepath.Abs("../../testdata/dump-genesis.json")
 	require.NoError(t, err, "Failed to resolve path for dump-genesis.json")

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -2,6 +2,7 @@ package heimdalld
 
 import (
 	"os"
+	"time"
 
 	"cosmossdk.io/log"
 	"github.com/cometbft/cometbft/cmd/cometbft/commands"
@@ -119,26 +120,31 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			// Overwrite default server logger
-			logger, err := server.CreateSDKLogger(serverCtx, cmd.OutOrStdout())
-			if err != nil {
-				return err
-			}
-			serverCtx.Logger = logger.With(log.ModuleKey, "server")
-
 			// Get log_level from serverCtx.Viper
 			logLevelStr := serverCtx.Viper.GetString(flags.FlagLogLevel)
 
 			// Set log_level value to viper
 			viper.Set(flags.FlagLogLevel, logLevelStr)
 
-			// Overwrite default heimdall logger
 			logLevel, err := zerolog.ParseLevel(logLevelStr)
 			if err != nil {
 				return err
 			}
+
 			logNoColor := serverCtx.Viper.GetBool(flags.FlagLogNoColor)
-			helper.Logger = log.NewLogger(cmd.OutOrStdout(), log.LevelOption(logLevel), log.ColorOption(!logNoColor))
+			var logOpts []log.Option
+			if serverCtx.Viper.GetString(flags.FlagLogFormat) == flags.OutputFormatJSON {
+				logOpts = append(logOpts, log.OutputJSONOption())
+			} else {
+				logOpts = append(logOpts, log.ColorOption(!logNoColor))
+			}
+			logOpts = append(logOpts,
+				log.LevelOption(logLevel),
+				log.TimeFormatOption(time.RFC3339Nano),
+			)
+
+			serverCtx.Logger = log.NewLogger(cmd.OutOrStdout(), logOpts...).With(log.ModuleKey, "server")
+			helper.Logger = log.NewLogger(cmd.OutOrStdout(), logOpts...)
 
 			err = helper.SanitizeConfig(serverCtx.Viper, serverCtx.Logger)
 			if err != nil {

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -137,7 +137,8 @@ func NewRootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			helper.Logger = log.NewLogger(cmd.OutOrStdout(), log.LevelOption(logLevel))
+			logNoColor := serverCtx.Viper.GetBool(flags.FlagLogNoColor)
+			helper.Logger = log.NewLogger(cmd.OutOrStdout(), log.LevelOption(logLevel), log.ColorOption(!logNoColor))
 
 			err = helper.SanitizeConfig(serverCtx.Viper, serverCtx.Logger)
 			if err != nil {

--- a/helper/config.go
+++ b/helper/config.go
@@ -357,11 +357,12 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		// Default to info in case of error
 		logLevel = zerolog.InfoLevel
 	}
+	logNoColor := viper.GetBool(flags.FlagLogNoColor)
 	if conf.Custom.LogsType == "json" {
 		Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logger.LevelOption(logLevel), logger.OutputJSONOption())
 	} else {
 		// default fallback
-		Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logger.LevelOption(logLevel))
+		Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logger.LevelOption(logLevel), logger.ColorOption(!logNoColor))
 	}
 
 	// perform checks for timeout

--- a/helper/config.go
+++ b/helper/config.go
@@ -350,20 +350,25 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		log.Fatalln("unable to read flag values. Check log for details.", "Error", err)
 	}
 
-	// perform check for json logging
 	logLevelStr := viper.GetString(flags.FlagLogLevel)
 	logLevel, err := zerolog.ParseLevel(logLevelStr)
 	if err != nil {
-		// Default to info in case of error
 		logLevel = zerolog.InfoLevel
 	}
+
 	logNoColor := viper.GetBool(flags.FlagLogNoColor)
+	var logOpts []logger.Option
 	if conf.Custom.LogsType == "json" {
-		Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logger.LevelOption(logLevel), logger.OutputJSONOption())
+		logOpts = append(logOpts, logger.OutputJSONOption())
 	} else {
-		// default fallback
-		Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logger.LevelOption(logLevel), logger.ColorOption(!logNoColor))
+		logOpts = append(logOpts, logger.ColorOption(!logNoColor))
 	}
+	logOpts = append(logOpts,
+		logger.LevelOption(logLevel),
+		logger.TimeFormatOption(time.RFC3339Nano),
+	)
+
+	Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logOpts...)
 
 	// perform checks for timeout
 	if conf.Custom.EthRPCTimeout == 0 {

--- a/x/bor/client/cli/tx.go
+++ b/x/bor/client/cli/tx.go
@@ -18,7 +18,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/x/bor/types"
 )
 
-var logger = helper.Logger.With("module", "bor/client/cli")
+var logger = helper.Logger.With("module", "x/bor/cli")
 
 // NewTxCmd returns a root CLI command handler for all x/bor transaction commands.
 func NewTxCmd() *cobra.Command {

--- a/x/checkpoint/client/cli/tx.go
+++ b/x/checkpoint/client/cli/tx.go
@@ -20,7 +20,7 @@ import (
 	stakeTypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
-var logger = helper.Logger.With("module", "checkpoint/client/cli")
+var logger = helper.Logger.With("module", "x/checkpoint/cli")
 
 // NewTxCmd returns a root CLI command handler for all x/checkpoint transaction commands.
 func NewTxCmd() *cobra.Command {

--- a/x/checkpoint/types/merkle.go
+++ b/x/checkpoint/types/merkle.go
@@ -31,7 +31,7 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 
 	if !exists || err != nil {
 		if err != nil {
-			helper.Logger.Debug("Blocks existence not found in cache, querying contract",
+			helper.Logger.With("module", "x/checkpoint/types").Debug("Blocks existence not found in cache, querying contract",
 				"end", end,
 				"confirmations", confirmations,
 				"existsKey", existsKey,
@@ -53,7 +53,7 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 	rootKey := fmt.Sprintf("%d-%d-%d", start, end, checkpointLength)
 	root, err := rootCache.Get(rootKey)
 	if err != nil {
-		helper.Logger.Debug("Root hash not found in cache, querying contract",
+		helper.Logger.With("module", "x/checkpoint/types").Debug("Root hash not found in cache, querying contract",
 			"start", start,
 			"end", end,
 			"checkpointLength", checkpointLength,

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -20,7 +20,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
-var logger = helper.Logger.With("module", "stake/client/cli")
+var logger = helper.Logger.With("module", "x/stake/cli")
 
 // NewTxCmd returns a root CLI command handler for all x/stake transaction commands.
 func NewTxCmd() *cobra.Command {


### PR DESCRIPTION
# Description

Fixed the `--log_no_color` flag to disable ANSI colour codes in heimdall-v2 logs properly. The flag was defined but not wired to the loggers, resulting in coloured output even when set.

Added ColorOption to logger initialisation in `helper/config.go` and `cmd/heimdalld/cmd/root.go`. Updated bridge services (broadcaster, queue/connector, processor/base) to use `helper.Logger.With()` instead of creating standalone loggers, ensuring they inherit the colour settings. Also standardised module names to follow the path-style convention (e.g., `bridge/broadcaster` instead of `txBroadcaster`) and removed the trailing slash from `bridge/service/`.

Changed `var logger` to `func logger()` in `bridge/service/bridge.go` so it returns a fresh logger from `helper.Logger` at call time, ensuring `--log_no_color` flag is respected.