### PR TITLE
helper(tx): add EIP-1559 dynamic gas pricing for L1 transactions

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.2.7
+          ref: hv2/tx-eip1559-gas-price-configs
           path: kurtosis-pos
 
       - name: Pre kurtosis run

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.2.7
+          ref: hv2/tx-eip1559-gas-price-configs
           path: kurtosis-pos
 
       - name: Pre kurtosis run

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,6 +1,5 @@
 # cmd
 
-
 The `cmd` package is responsible for starting the heimdall application and provides the CLI framework (based on [cobra](https://github.com/spf13/cobra)).
 
 ## heimdalld
@@ -68,8 +67,8 @@ Flags:
       --log_level string                  The logging level (trace|debug|info|warn|error|fatal|panic|disabled) (default "info")
       --log_no_color                      Disable colored logs
       --logs_writer_file string           Set logs writer file, Default is os.Stdout
-      --main_chain_gas_limit uint         Set main chain gas limit
-      --main_chain_max_gas_price int      Set main chain max gas limit
+      --main_chain_gas_fee_cap int        Set main chain max gas fee cap for EIP-1559 transactions (in wei)
+      --main_chain_gas_tip_cap int        Set main chain max priority fee (tip) for EIP-1559 transactions (in wei)
       --milestone_poll_interval string    Set milestone interval (default "30s")
       --no_ack_wait_time string           Set time ack service waits to clear buffer and elect new proposer
       --noack_poll_interval string        Set no acknowledge pull interval

--- a/helper/config.go
+++ b/helper/config.go
@@ -59,8 +59,9 @@ const (
 	ClerkPollIntervalFlag        = "clerk_poll_interval"
 	SpanPollIntervalFlag         = "span_poll_interval"
 	MilestonePollIntervalFlag    = "milestone_poll_interval"
-	MainChainGasLimitFlag        = "main_chain_gas_limit"
-	MainChainMaxGasPriceFlag     = "main_chain_max_gas_price"
+
+	MainChainGasFeeCapFlag = "main_chain_gas_fee_cap"
+	MainChainGasTipCapFlag = "main_chain_gas_tip_cap"
 
 	NoACKWaitTimeFlag = "no_ack_wait_time"
 	ChainFlag         = "chain"
@@ -98,9 +99,8 @@ const (
 	DefaultSHCheckpointAckInterval = 30 * time.Minute
 	DefaultSHMaxDepthDuration      = 24 * time.Hour
 
-	DefaultMainChainGasLimit = uint64(5000000)
-
-	DefaultMainChainMaxGasPrice = 400000000000 // 400 Gwei
+	DefaultMainChainGasFeeCap = 500000000000 // 500 Gwei
+	DefaultMainChainGasTipCap = 10000000000  // 10 Gwei
 
 	DefaultBorChainID      = "15001"
 	DefaultHeimdallChainID = "heimdall-15001"
@@ -147,9 +147,8 @@ type CustomConfig struct {
 
 	AmqpURL string `mapstructure:"amqp_url"` // amqp url
 
-	MainChainGasLimit uint64 `mapstructure:"main_chain_gas_limit"` // gas-limit for main chain txs, e.g., submit checkpoint
-
-	MainChainMaxGasPrice int64 `mapstructure:"main_chain_max_gas_price"` // max-gas-price for main chain txs
+	MainChainGasFeeCap int64 `mapstructure:"main_chain_gas_fee_cap"` // max fee per gas for EIP-1559 txs (in wei)
+	MainChainGasTipCap int64 `mapstructure:"main_chain_gas_tip_cap"` // max priority fee per gas for EIP-1559 txs (in wei)
 
 	// config related to bridge
 	CheckpointPollInterval  time.Duration `mapstructure:"checkpoint_poll_interval"` // Poll interval for checkpointer service to send new checkpoints or missing ACK
@@ -517,9 +516,8 @@ func GetDefaultHeimdallConfig() CustomConfig {
 
 		AmqpURL: DefaultAmqpURL,
 
-		MainChainGasLimit: DefaultMainChainGasLimit,
-
-		MainChainMaxGasPrice: DefaultMainChainMaxGasPrice,
+		MainChainGasFeeCap: DefaultMainChainGasFeeCap,
+		MainChainGasTipCap: DefaultMainChainGasTipCap,
 
 		CheckpointPollInterval:  DefaultCheckpointPollInterval,
 		SyncerPollInterval:      DefaultSyncerPollInterval,
@@ -878,26 +876,26 @@ func DecorateWithHeimdallFlags(cmd *cobra.Command, v *viper.Viper, loggerInstanc
 		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, MilestonePollIntervalFlag), "Error", err)
 	}
 
-	// add MainChainGasLimitFlag flag
-	cmd.PersistentFlags().Uint64(
-		MainChainGasLimitFlag,
+	// add MainChainGasFeeCapFlag flag
+	cmd.PersistentFlags().Int64(
+		MainChainGasFeeCapFlag,
 		0,
-		"Set main chain gas limit",
+		"Set main chain max gas fee cap for EIP-1559 transactions (in wei)",
 	)
 
-	if err := v.BindPFlag(MainChainGasLimitFlag, cmd.PersistentFlags().Lookup(MainChainGasLimitFlag)); err != nil {
-		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, MainChainGasLimitFlag), "Error", err)
+	if err := v.BindPFlag(MainChainGasFeeCapFlag, cmd.PersistentFlags().Lookup(MainChainGasFeeCapFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, MainChainGasFeeCapFlag), "Error", err)
 	}
 
-	// add MainChainMaxGasPriceFlag flag
+	// add MainChainGasTipCapFlag flag
 	cmd.PersistentFlags().Int64(
-		MainChainMaxGasPriceFlag,
+		MainChainGasTipCapFlag,
 		0,
-		"Set main chain max gas limit",
+		"Set main chain max priority fee (tip) for EIP-1559 transactions (in wei)",
 	)
 
-	if err := v.BindPFlag(MainChainMaxGasPriceFlag, cmd.PersistentFlags().Lookup(MainChainMaxGasPriceFlag)); err != nil {
-		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, MainChainMaxGasPriceFlag), "Error", err)
+	if err := v.BindPFlag(MainChainGasTipCapFlag, cmd.PersistentFlags().Lookup(MainChainGasTipCapFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, MainChainGasTipCapFlag), "Error", err)
 	}
 
 	// add NoACKWaitTimeFlag flag
@@ -1064,16 +1062,16 @@ func (c *CustomAppConfig) UpdateWithFlags(v *viper.Viper, loggerInstance logger.
 		}
 	}
 
-	// get mainChain gas limit from viper/cobra
-	uint64ConfigValue := v.GetUint64(MainChainGasLimitFlag)
-	if uint64ConfigValue != 0 {
-		c.Custom.MainChainGasLimit = uint64ConfigValue
+	// get mainChain gas fee cap from viper/cobra. if it is greater than zero, set it as a configuration parameter
+	int64ConfigValue := v.GetInt64(MainChainGasFeeCapFlag)
+	if int64ConfigValue > 0 {
+		c.Custom.MainChainGasFeeCap = int64ConfigValue
 	}
 
-	// get mainChain max gas price from viper/cobra. if it is greater than zero, set it as a configuration parameter
-	int64ConfigValue := v.GetInt64(MainChainMaxGasPriceFlag)
+	// get mainChain gas tip cap from viper/cobra
+	int64ConfigValue = v.GetInt64(MainChainGasTipCapFlag)
 	if int64ConfigValue > 0 {
-		c.Custom.MainChainMaxGasPrice = int64ConfigValue
+		c.Custom.MainChainGasTipCap = int64ConfigValue
 	}
 
 	// get chain from viper/cobra flag
@@ -1121,12 +1119,12 @@ func (c *CustomAppConfig) Merge(cc *CustomConfig) {
 		c.Custom.AmqpURL = cc.AmqpURL
 	}
 
-	if cc.MainChainGasLimit != 0 {
-		c.Custom.MainChainGasLimit = cc.MainChainGasLimit
+	if cc.MainChainGasFeeCap != 0 {
+		c.Custom.MainChainGasFeeCap = cc.MainChainGasFeeCap
 	}
 
-	if cc.MainChainMaxGasPrice != 0 {
-		c.Custom.MainChainMaxGasPrice = cc.MainChainMaxGasPrice
+	if cc.MainChainGasTipCap != 0 {
+		c.Custom.MainChainGasTipCap = cc.MainChainGasTipCap
 	}
 
 	if cc.CheckpointPollInterval != 0 {

--- a/helper/config.go
+++ b/helper/config.go
@@ -406,14 +406,22 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		conf.Custom.SHMaxDepthDuration = DefaultSHMaxDepthDuration
 	}
 
+	// validate EIP-1559 gas config: tip cap must not exceed fee cap
+	if conf.Custom.MainChainGasTipCap > conf.Custom.MainChainGasFeeCap {
+		log.Fatal("invalid gas config: main_chain_gas_tip_cap must not exceed main_chain_gas_fee_cap",
+			"tip_cap", conf.Custom.MainChainGasTipCap,
+			"fee_cap", conf.Custom.MainChainGasFeeCap,
+		)
+	}
+
 	if mainRPCClient, err = rpc.Dial(conf.Custom.EthRPCUrl); err != nil {
-		log.Fatalln("Unable to dial via ethClient", "URL", conf.Custom.EthRPCUrl, "chain", "eth", "error", err)
+		log.Fatal("unable to dial main chain RPC client", "URL", conf.Custom.EthRPCUrl, "error", err)
 	}
 
 	mainChainClient = ethclient.NewClient(mainRPCClient)
 
 	if borRPCClient, err = rpc.Dial(conf.Custom.BorRPCUrl); err != nil {
-		log.Fatal(err)
+		log.Fatal("unable to dial bor chain RPC client", "URL", conf.Custom.BorRPCUrl, "error", err)
 	}
 
 	borClient = ethclient.NewClient(borRPCClient)
@@ -421,7 +429,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	if conf.Custom.BorGRPCFlag && conf.Custom.BorGRPCUrl != "" {
 		client, err := borgrpc.NewBorGRPCClient(conf.Custom.BorGRPCUrl, Logger)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal("unable to create bor gRPC client", "URL", conf.Custom.BorGRPCUrl, "error", err)
 		}
 		borGRPCClient = client
 	}

--- a/helper/toml.go
+++ b/helper/toml.go
@@ -50,11 +50,9 @@ sh_stake_update_interval = "{{ .Custom.SHStakeUpdateInterval }}"
 sh_checkpoint_ack_interval = "{{ .Custom.SHCheckpointAckInterval }}"
 sh_max_depth_duration = "{{ .Custom.SHMaxDepthDuration }}"
 
-#### gas limits ####
-main_chain_gas_limit = "{{ .Custom.MainChainGasLimit }}"
-
-#### gas price ####
-main_chain_max_gas_price = "{{ .Custom.MainChainMaxGasPrice }}"
+#### gas price configs (EIP-1559) ####
+main_chain_gas_fee_cap = "{{ .Custom.MainChainGasFeeCap }}"
+main_chain_gas_tip_cap = "{{ .Custom.MainChainGasTipCap }}"
 
 ##### Timeout Config #####
 no_ack_wait_time = "{{ .Custom.NoACKWaitTime }}"

--- a/helper/tx_test.go
+++ b/helper/tx_test.go
@@ -1,0 +1,313 @@
+package helper
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockEthClient implements EthClient interface for testing.
+type mockEthClient struct {
+	blockByNumberFn    func(ctx context.Context, number *big.Int) (*types.Block, error)
+	suggestGasTipCapFn func(ctx context.Context) (*big.Int, error)
+	pendingNonceAtFn   func(ctx context.Context, account common.Address) (uint64, error)
+	estimateGasFn      func(ctx context.Context, call ethereum.CallMsg) (uint64, error)
+	chainIDFn          func(ctx context.Context) (*big.Int, error)
+}
+
+func (m *mockEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	if m.blockByNumberFn != nil {
+		return m.blockByNumberFn(ctx, number)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockEthClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	if m.suggestGasTipCapFn != nil {
+		return m.suggestGasTipCapFn(ctx)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockEthClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	if m.pendingNonceAtFn != nil {
+		return m.pendingNonceAtFn(ctx, account)
+	}
+	return 0, errors.New("not implemented")
+}
+
+func (m *mockEthClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+	if m.estimateGasFn != nil {
+		return m.estimateGasFn(ctx, call)
+	}
+	return 0, errors.New("not implemented")
+}
+
+func (m *mockEthClient) ChainID(ctx context.Context) (*big.Int, error) {
+	if m.chainIDFn != nil {
+		return m.chainIDFn(ctx)
+	}
+	return nil, errors.New("not implemented")
+}
+
+// mockClientParams holds parameters for creating a mock client.
+type mockClientParams struct {
+	blockNumber  int64
+	baseFee      *big.Int
+	suggestedTip *big.Int
+	nonce        uint64
+	gasLimit     uint64
+	chainID      int64
+}
+
+// setupMockClient creates a mock client with the specified parameters.
+func setupMockClient(params mockClientParams) *mockEthClient {
+	return &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			return types.NewBlockWithHeader(
+				&types.Header{
+					Number:  big.NewInt(params.blockNumber),
+					BaseFee: params.baseFee,
+				},
+			), nil
+		},
+		suggestGasTipCapFn: func(ctx context.Context) (*big.Int, error) {
+			return params.suggestedTip, nil
+		},
+		pendingNonceAtFn: func(ctx context.Context, account common.Address) (uint64, error) {
+			return params.nonce, nil
+		},
+		estimateGasFn: func(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+			return params.gasLimit, nil
+		},
+		chainIDFn: func(ctx context.Context) (*big.Int, error) {
+			return big.NewInt(params.chainID), nil
+		},
+	}
+}
+
+func TestGenerateAuthObj_NormalEIP1559Flow(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	baseFee := big.NewInt(20000000000)     // 20 Gwei
+	suggestedTip := big.NewInt(1000000000) // 1 Gwei
+
+	mockClient := setupMockClient(mockClientParams{
+		blockNumber:  1000,
+		baseFee:      baseFee,
+		suggestedTip: suggestedTip,
+		nonce:        5,
+		gasLimit:     21000,
+		chainID:      1,
+	})
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// Verify EIP-1559 fields are set.
+	assert.NotNil(t, auth.GasFeeCap, "GasFeeCap should be set")
+	assert.NotNil(t, auth.GasTipCap, "GasTipCap should be set")
+	assert.Nil(t, auth.GasPrice, "GasPrice should be nil for EIP-1559")
+
+	// Verify gas fee cap calculation: (baseFee * 2) + tipCap = (20 * 2) + 1 = 41 Gwei.
+	expectedFeeCap := new(big.Int).Mul(baseFee, big.NewInt(2))
+	expectedFeeCap.Add(expectedFeeCap, suggestedTip)
+	assert.Equal(t, expectedFeeCap, auth.GasFeeCap, "GasFeeCap should be (baseFee * 2) + tipCap")
+
+	// Verify tip cap is the suggested tip (since it's below config max).
+	assert.Equal(t, suggestedTip, auth.GasTipCap, "GasTipCap should be the suggested tip")
+
+	// Verify other fields.
+	assert.Equal(t, uint64(21000), auth.GasLimit, "GasLimit should match estimated gas")
+	assert.Equal(t, big.NewInt(5), auth.Nonce, "Nonce should match pending nonce")
+}
+
+func TestGenerateAuthObj_BaseFeeNil(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	mockClient := &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			// Return a block with nil baseFee (pre-EIP-1559 chain).
+			return types.NewBlockWithHeader(
+				&types.Header{
+					Number:  big.NewInt(1000),
+					BaseFee: nil,
+				},
+			), nil
+		},
+	}
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+
+	assert.Error(t, err, "Should return error when baseFee is nil")
+	assert.Nil(t, auth, "Auth should be nil when baseFee is nil")
+	assert.Contains(t, err.Error(), "baseFee is nil", "Error message should mention baseFee")
+}
+
+func TestGenerateAuthObj_FeeCapExceedsConfiguredMaximum(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	// Set a very high base fee that will cause calculated fee cap to exceed config.
+	baseFee := big.NewInt(300000000000)    // 300 Gwei - this will result in 600+ Gwei fee cap
+	suggestedTip := big.NewInt(1000000000) // 1 Gwei
+
+	mockClient := setupMockClient(mockClientParams{
+		blockNumber:  1000,
+		baseFee:      baseFee,
+		suggestedTip: suggestedTip,
+		nonce:        5,
+		gasLimit:     21000,
+		chainID:      1,
+	})
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// The calculated fee cap would be (300 * 2) + 1 = 601 Gwei.
+	// But it should be capped to configured maximum (500 Gwei = DefaultMainChainGasFeeCap).
+	configuredMax := big.NewInt(DefaultMainChainGasFeeCap)
+	assert.Equal(t, configuredMax, auth.GasFeeCap, "GasFeeCap should be capped to configured maximum")
+}
+
+func TestGenerateAuthObj_TipCapExceedsConfiguredMaximum(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	baseFee := big.NewInt(20000000000)      // 20 Gwei
+	suggestedTip := big.NewInt(50000000000) // 50 Gwei - exceeds configured max (10 Gwei)
+
+	mockClient := setupMockClient(mockClientParams{
+		blockNumber:  1000,
+		baseFee:      baseFee,
+		suggestedTip: suggestedTip,
+		nonce:        5,
+		gasLimit:     21000,
+		chainID:      1,
+	})
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// Tip cap should be capped to configured maximum (10 Gwei = DefaultMainChainGasTipCap).
+	configuredTipMax := big.NewInt(DefaultMainChainGasTipCap)
+	assert.Equal(t, configuredTipMax, auth.GasTipCap, "GasTipCap should be capped to configured maximum")
+
+	// Fee cap should be (baseFee * 2) + configuredTipMax = (20 * 2) + 10 = 50 Gwei.
+	expectedFeeCap := new(big.Int).Mul(baseFee, big.NewInt(2))
+	expectedFeeCap.Add(expectedFeeCap, configuredTipMax)
+	assert.Equal(t, expectedFeeCap, auth.GasFeeCap, "GasFeeCap should use capped tip")
+}
+
+func TestGenerateAuthObj_TipCapExceedsFeeCap(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	// Edge case: very high base fee causes fee cap to be clamped, but tip cap is still below fee cap before clamping.
+	// but tip cap is still below fee cap before clamping.
+	// After fee cap clamping, tip might exceed fee cap.
+	baseFee := big.NewInt(250000000000)    // 250 Gwei
+	suggestedTip := big.NewInt(5000000000) // 5 Gwei (below config max of 10 Gwei)
+
+	mockClient := setupMockClient(mockClientParams{
+		blockNumber:  1000,
+		baseFee:      baseFee,
+		suggestedTip: suggestedTip,
+		nonce:        5,
+		gasLimit:     21000,
+		chainID:      1,
+	})
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// Calculated fee cap would be (250 * 2) + 5 = 505 Gwei, capped to 500 Gwei.
+	// Tip cap (5 Gwei) should not exceed fee cap (500 Gwei) - this case is fine
+
+	// Tip cap should never exceed fee cap.
+	assert.True(t, auth.GasTipCap.Cmp(auth.GasFeeCap) <= 0,
+		"GasTipCap (%s) should not exceed GasFeeCap (%s)", auth.GasTipCap, auth.GasFeeCap)
+}
+
+func TestGenerateAuthObj_BlockByNumberError(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	mockClient := &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			return nil, errors.New("RPC error: failed to fetch block")
+		},
+	}
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+
+	assert.Error(t, err, "Should return error when BlockByNumber fails")
+	assert.Nil(t, auth, "Auth should be nil when BlockByNumber fails")
+}
+
+func TestGenerateAuthObj_SuggestGasTipCapError(t *testing.T) {
+	t.Parallel()
+
+	InitTestHeimdallConfig("")
+
+	baseFee := big.NewInt(20000000000) // 20 Gwei
+
+	mockClient := &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			return types.NewBlockWithHeader(
+				&types.Header{
+					Number:  big.NewInt(1000),
+					BaseFee: baseFee,
+				},
+			), nil
+		},
+		suggestGasTipCapFn: func(ctx context.Context) (*big.Int, error) {
+			return nil, errors.New("RPC error: failed to suggest gas tip cap")
+		},
+	}
+
+	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	data := []byte("test data")
+
+	auth, err := generateAuthObjWithClient(mockClient, address, data)
+
+	assert.Error(t, err, "Should return error when SuggestGasTipCap fails")
+	assert.Nil(t, auth, "Auth should be nil when SuggestGasTipCap fails")
+}

--- a/packaging/templates/config/amoy/app.toml
+++ b/packaging/templates/config/amoy/app.toml
@@ -281,11 +281,9 @@ sh_stake_update_interval = "3h0m0s"
 sh_checkpoint_ack_interval = "30m0s"
 sh_max_depth_duration = "24h0m0s"
 
-#### gas limits ####
-main_chain_gas_limit = "5000000"
-
-#### gas price ####
-main_chain_max_gas_price = "400000000000"
+#### gas price configs (EIP-1559) ####
+main_chain_gas_fee_cap = "500000000000"
+main_chain_gas_tip_cap = "10000000000"
 
 ##### Timeout Config #####
 no_ack_wait_time = "30m0s"

--- a/packaging/templates/config/mainnet/app.toml
+++ b/packaging/templates/config/mainnet/app.toml
@@ -281,11 +281,9 @@ sh_stake_update_interval = "3h0m0s"
 sh_checkpoint_ack_interval = "30m0s"
 sh_max_depth_duration = "24h0m0s"
 
-#### gas limits ####
-main_chain_gas_limit = "5000000"
-
-#### gas price ####
-main_chain_max_gas_price = "400000000000"
+#### gas price configs (EIP-1559) ####
+main_chain_gas_fee_cap = "500000000000"
+main_chain_gas_tip_cap = "10000000000"
 
 ##### Timeout Config #####
 no_ack_wait_time = "30m0s"


### PR DESCRIPTION
# Description

Implemented changes to create transaction auth objects with EIP-1559 dynamic fee pricing. The function fetches current network conditions and calculates optimal gas parameters:

- Retrieve `baseFee` from the latest block and the suggested tip from the network
- Cap tip to configured maximum `MainChainGasTipCap`
- Calculate fee cap as `(baseFee * 2) + tipCap` for fluctuation buffer
- Cap fee cap to configured maximum `MainChainGasFeeCap`

Removed unused `MainChainGasLimit` config option.