### PR TITLE
Switch to GCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ─── BUILDER STAGE ───────────────────────────────────────────────────────────────
-FROM golang:1.25-alpine AS builder
+FROM mirror.gcr.io/library/golang:1.25-alpine AS builder
 
 ARG HEIMDALL_DIR=/var/lib/heimdall/
 ENV HEIMDALL_DIR=${HEIMDALL_DIR}
@@ -22,7 +22,7 @@ RUN --mount=type=ssh \
     make build
 
 # ─── RUNTIME STAGE ────────────────────────────────────────────────────────────────
-FROM alpine:latest
+FROM mirror.gcr.io/library/alpine:3.21
 
 ARG HEIMDALL_DIR=/var/lib/heimdall/
 ENV HEIMDALL_DIR=${HEIMDALL_DIR}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM mirror.gcr.io/library/alpine:3.21
 
 ARG HEIMDALL_DIR=/var/lib/heimdall/
 ENV HEIMDALL_DIR=$HEIMDALL_DIR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ version: "3"
 services:
   rabbitmq:
     container_name: rabbitmq
-    image: rabbitmq:3-alpine
+    image: mirror.gcr.io/library/rabbitmq:3-alpine
     ports:
       - "5672:5672" # RabbitMQ
     restart: unless-stopped


### PR DESCRIPTION
# Description

Switch to GCR for our CI / CD instead of Docker Hub.

This is intended to address the request rate limiting we receive on Docker Hub