### PR TITLE
ci: load kurtosis images from gcr instead of docker hub

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -19,85 +19,110 @@ env:
   ENCLAVE_NAME: kurtosis-e2e
 
 jobs:
+  build-bor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout bor
+        uses: actions/checkout@v5
+
+      - name: Build docker image
+        run: docker build -t bor:local --file Dockerfile .
+
+      - name: Save image
+        run: docker save bor:local | gzip > bor-image.tar.gz
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: bor-image
+          path: bor-image.tar.gz
+          retention-days: 1
+
+  build-heimdall-v2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout heimdall-v2
+        uses: actions/checkout@v5
+        with:
+          repository: 0xPolygon/heimdall-v2
+          ref: develop
+
+      - name: Build docker image
+        run: docker build -t heimdall-v2:local --file Dockerfile .
+
+      - name: Save image
+        run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: heimdall-v2-image
+          path: heimdall-v2-image.tar.gz
+          retention-days: 1
+
   e2e-tests:
+    needs:
+      - build-bor
+      - build-heimdall-v2
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
+    # These permissions are required to log in to GCR
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     steps:
-      # This is needed because the job fails with "System.IO.IOException: No space left on device".
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+      # Set up kurtosis
+      - name: Checkout kurtosis-pos
+        uses: actions/checkout@v5
         with:
-          android: false
-          docker-images: false
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          tool-cache: true
+          repository: 0xPolygon/kurtosis-pos
+          ref: hv2/tx-eip1559-gas-price-configs
 
-      - name: Install dependencies on Linux
-        if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
-
-      - name: Install Go
-        uses: actions/setup-go@v6
+      # This step will free disk space and thus remove any docker images previously built
+      - name: Pre kurtosis run
+        uses: ./.github/actions/kurtosis-pre-run
         with:
-          go-version: 'stable'
-
-      - name: Checkout heimdall-v2
-        uses: actions/checkout@v6
-        with:
-          path: heimdall-v2
-
-      - name: Checkout bor
-        uses: actions/checkout@v6
-        with:
-          repository: 0xPolygon/bor
-          ref: develop
-          path: bor
+          docker_username: ${{ secrets.DOCKERHUB }}
+          docker_token: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Checkout pos-workflows
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           repository: 0xPolygon/pos-workflows
           ref: main
           path: pos-workflows
 
-      - name: Checkout kurtosis-pos
-        uses: actions/checkout@v6
-        with:
-          repository: 0xPolygon/kurtosis-pos
-          ref: hv2/tx-eip1559-gas-price-configs
-          path: kurtosis-pos
-
-      - name: Pre kurtosis run
-        uses: ./pos-workflows/.github/actions/kurtosis-pre-run
-        with:
-          docker_username: ${{ secrets.DOCKERHUB }}
-          docker_token: ${{ secrets.DOCKERHUB_KEY }}
-
-      - name: Build heimdall-v2 docker image
-        run: |
-          cd heimdall-v2
-          docker build -t heimdall-v2:local --file Dockerfile .
-
-      - name: Build bor docker image
-        run: |
-          cd bor
-          docker build -t bor:local --file Dockerfile .
-
       - name: Copy kurtosis config
-        run: cp ./pos-workflows/.github/configs/kurtosis-e2e.yml ./kurtosis-pos/kurtosis-e2e.yml
+        run: cp ./pos-workflows/.github/configs/kurtosis-e2e.yml ./kurtosis-e2e.yml
 
+      # Load images
+      - name: Download bor image
+        uses: actions/download-artifact@v4
+        with:
+          name: bor-image
+
+      - name: Download heimdall-v2 image
+        uses: actions/download-artifact@v4
+        with:
+          name: heimdall-v2-image
+
+      - name: Load bor image
+        run: gunzip -c bor-image.tar.gz | docker load
+
+      - name: Load heimdall-v2 image
+        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+      
+      # Deploy kurtosis enclave
       - name: Kurtosis run
-        run: |
-          cd kurtosis-pos
-          kurtosis run --args-file=kurtosis-e2e.yml --enclave=${{ env.ENCLAVE_NAME }} .
+        run: kurtosis run --args-file=kurtosis-e2e.yml --enclave=${{ env.ENCLAVE_NAME }} .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
 
+      # Run e2e tests
       - name: Test state syncs
         run: kurtosis service exec ${{ env.ENCLAVE_NAME }} test-runner "bats --filter 'bridge MATIC/POL, ERC20, and ERC721 from L1 to L2 and confirm L2 balances increased' tests/pos/bridge.bats"
 
@@ -119,14 +144,18 @@ jobs:
       - name: Run smoke tests (Checkpoints and Milestones)
         run: bash ./pos-workflows/tests/kurtosis_smoke_test.sh
 
-      - name: Run set producer downtime test
-        run: |
-          cd pos-workflows/tests/producer_planned_downtime
-          go mod tidy
-          go run .
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
 
+      - name: Run set producer downtime test
+        working-directory: pos-workflows/tests/producer_planned_downtime
+        run: go run .
+
+      # Clean up
       - name: Post kurtosis run
         if: always()
-        uses: ./pos-workflows/.github/actions/kurtosis-post-run
+        uses: ./.github/actions/kurtosis-post-run
         with:
           enclave_name: ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout bor
         uses: actions/checkout@v5
+        with:
+          repository: 0xPolygon/bor
+          ref: develop
 
       - name: Build docker image
         run: docker build -t bor:local --file Dockerfile .
@@ -45,9 +48,6 @@ jobs:
     steps:
       - name: Checkout heimdall-v2
         uses: actions/checkout@v5
-        with:
-          repository: 0xPolygon/heimdall-v2
-          ref: develop
 
       - name: Build docker image
         run: docker build -t heimdall-v2:local --file Dockerfile .

--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -110,10 +110,16 @@ jobs:
           name: heimdall-v2-image
 
       - name: Load bor image
-        run: gunzip -c bor-image.tar.gz | docker load
+        run: |
+          gunzip -c bor-image.tar.gz | docker load
+          echo "Loaded bor image:"
+          docker images bor:local --format "{{.ID}} {{.CreatedAt}}"
 
       - name: Load heimdall-v2 image
-        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+        run: |
+          gunzip -c heimdall-v2-image.tar.gz | docker load
+          echo "Loaded heimdall-v2 image:"
+          docker images heimdall-v2:local --format "{{.ID}} {{.CreatedAt}}"
       
       # Deploy kurtosis enclave
       - name: Kurtosis run

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -129,6 +129,15 @@ jobs:
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
 
       # Run e2e tests
+      - name: Install polycli
+        run: |
+          tmp_dir=$(mktemp -d)
+          curl -L https://github.com/0xPolygon/polygon-cli/releases/download/${{ env.POLYCLI_VERSION }}/polycli_${{ env.POLYCLI_VERSION }}_linux_amd64.tar.gz | tar -xz -C "$tmp_dir"
+          mv "$tmp_dir"/* /usr/local/bin/polycli
+          rm -rf "$tmp_dir"
+          sudo chmod +x /usr/local/bin/polycli
+          polycli version
+
       - name: Run stateless sync tests
         working-directory: pos-workflows/tests/stateless_tests
         run: bash kurtosis_stateless_test.sh

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -1,5 +1,4 @@
-name: Stateless Sync Tests
-
+name: Stateless Sync E2E Tests
 on:
   push:
     branches:
@@ -17,92 +16,123 @@ concurrency:
 
 env:
   ENCLAVE_NAME: kurtosis-stateless-e2e
+  POLYCLI_VERSION: v0.1.102
 
 jobs:
+  build-bor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout bor
+        uses: actions/checkout@v5
+
+      - name: Build docker image
+        run: docker build -t bor:local --file Dockerfile .
+
+      - name: Save image
+        run: docker save bor:local | gzip > bor-image.tar.gz
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: bor-image
+          path: bor-image.tar.gz
+          retention-days: 1
+
+  build-heimdall-v2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout heimdall-v2
+        uses: actions/checkout@v5
+        with:
+          repository: 0xPolygon/heimdall-v2
+          ref: develop
+
+      - name: Build docker image
+        run: docker build -t heimdall-v2:local --file Dockerfile .
+
+      - name: Save image
+        run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: heimdall-v2-image
+          path: heimdall-v2-image.tar.gz
+          retention-days: 1
+
   e2e-tests:
+    needs:
+      - build-bor
+      - build-heimdall-v2
     runs-on: ubuntu-latest
     timeout-minutes: 45
-
+    # These permissions are required to log in to GCR
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     steps:
-      # This is needed because the job fails with "System.IO.IOException: No space left on device".
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+      # Set up kurtosis
+      - name: Checkout kurtosis-pos
+        uses: actions/checkout@v5
         with:
-          android: false
-          docker-images: false
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          tool-cache: true
+          repository: 0xPolygon/kurtosis-pos
+          ref: hv2/tx-eip1559-gas-price-configs
 
-      - name: Install dependencies on Linux
-        if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
-
-      - name: Checkout heimdall-v2
-        uses: actions/checkout@v6
+      # This step will free disk space and thus remove any docker images previously built
+      - name: Pre kurtosis run
+        uses: ./.github/actions/kurtosis-pre-run
         with:
-          path: heimdall-v2
-
-      - name: Checkout bor
-        uses: actions/checkout@v6
-        with:
-          repository: 0xPolygon/bor
-          ref: develop
-          path: bor
+          docker_username: ${{ secrets.DOCKERHUB }}
+          docker_token: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Checkout pos-workflows
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           repository: 0xPolygon/pos-workflows
           ref: main
           path: pos-workflows
 
-      - name: Checkout kurtosis-pos
-        uses: actions/checkout@v6
-        with:
-          repository: 0xPolygon/kurtosis-pos
-          ref: hv2/tx-eip1559-gas-price-configs
-          path: kurtosis-pos
-
-      - name: Pre kurtosis run
-        uses: ./pos-workflows/.github/actions/kurtosis-pre-run
-        with:
-          docker_username: ${{ secrets.DOCKERHUB }}
-          docker_token: ${{ secrets.DOCKERHUB_KEY }}
-
-      - name: Build bor docker image
-        run: |
-          cd bor
-          docker build -t bor:local --file Dockerfile .
-
-      - name: Build heimdall-v2 docker image
-        run: |
-          cd heimdall-v2
-          docker build -t heimdall-v2:local --file Dockerfile .
-
       - name: Copy kurtosis config
-        run: cp ./pos-workflows/.github/configs/kurtosis-stateless-e2e.yml ./kurtosis-pos/kurtosis-stateless-e2e.yml
+        run: cp ./pos-workflows/.github/configs/kurtosis-stateless-e2e.yml ./kurtosis-stateless-e2e.yml
 
+      # Load images
+      - name: Download bor image
+        uses: actions/download-artifact@v4
+        with:
+          name: bor-image
+
+      - name: Download heimdall-v2 image
+        uses: actions/download-artifact@v4
+        with:
+          name: heimdall-v2-image
+
+      - name: Load bor image
+        run: gunzip -c bor-image.tar.gz | docker load
+
+      - name: Load heimdall-v2 image
+        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+      
+      # Deploy kurtosis enclave
       - name: Kurtosis run
-        run: |
-          cd kurtosis-pos
-          kurtosis run --args-file=kurtosis-stateless-e2e.yml --enclave ${{ env.ENCLAVE_NAME }} .
+        run: kurtosis run --args-file=kurtosis-stateless-e2e.yml --enclave ${{ env.ENCLAVE_NAME }} .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
 
+      # Run e2e tests
       - name: Run stateless sync tests
-        run: |
-          cd pos-workflows
-          bash tests/stateless_tests/kurtosis_stateless_test.sh
+        working-directory: pos-workflows/tests/stateless_tests
+        run: bash kurtosis_stateless_test.sh
 
       - name: Test state syncs (post VeBlop HF)
         run: kurtosis service exec ${{ env.ENCLAVE_NAME }} test-runner "bats --filter 'bridge MATIC/POL, ERC20, and ERC721 from L1 to L2 and confirm L2 balances increased' tests/pos/bridge.bats"
 
+      # Clean up
       - name: Post kurtosis run
         if: always()
-        uses: ./pos-workflows/.github/actions/kurtosis-post-run
+        uses: ./.github/actions/kurtosis-post-run
         with:
           enclave_name: ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout bor
         uses: actions/checkout@v5
+        with:
+          repository: 0xPolygon/bor
+          ref: develop
 
       - name: Build docker image
         run: docker build -t bor:local --file Dockerfile .
@@ -45,9 +48,6 @@ jobs:
     steps:
       - name: Checkout heimdall-v2
         uses: actions/checkout@v5
-        with:
-          repository: 0xPolygon/heimdall-v2
-          ref: develop
 
       - name: Build docker image
         run: docker build -t heimdall-v2:local --file Dockerfile .

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -110,10 +110,16 @@ jobs:
           name: heimdall-v2-image
 
       - name: Load bor image
-        run: gunzip -c bor-image.tar.gz | docker load
+        run: |
+          gunzip -c bor-image.tar.gz | docker load
+          echo "Loaded bor image:"
+          docker images bor:local --format "{{.ID}} {{.CreatedAt}}"
 
       - name: Load heimdall-v2 image
-        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+        run: |
+          gunzip -c heimdall-v2-image.tar.gz | docker load
+          echo "Loaded heimdall-v2 image:"
+          docker images heimdall-v2:local --format "{{.ID}} {{.CreatedAt}}"
       
       # Deploy kurtosis enclave
       - name: Kurtosis run


### PR DESCRIPTION
- Reuse kurtosis-pos pre and post kurtosis actions instead of pos-workflows actions
  - It allows to rely on the most up to date versions of the actions
  - It also allows to pull most of the images directly from our GCR instead of Docker Hub, preventing rate limits
- Speed up the workflow by building bor and heimdall-v2 images in parallel

Related to https://github.com/0xPolygon/bor/pull/2014