### PR TITLE
chore: ci improvements

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -130,7 +130,11 @@ jobs:
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
 
-      # Run e2e tests
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
       - name: Install polycli
         run: |
           tmp_dir=$(mktemp -d)
@@ -142,20 +146,23 @@ jobs:
 
       - name: Run smoke tests
         working-directory: pos-workflows/tests
-        run: bash kurtosis_smoke_test.sh
-
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 'stable'
-
-      - name: Run producer planned downtime test
-        working-directory: pos-workflows/tests/producer_planned_downtime
-        run: go run .
+        run: ENABLE_PRODUCER_PLANNED_DOWNTIME_TEST=true bash kurtosis_smoke_test.sh
 
       - name: Run validator tests
         working-directory: pos-workflows/tests
         run: bash validator_tests.sh
+
+      - name: Verify milestones after validator tests
+        working-directory: pos-workflows/tests
+        run: bash milestone_monitor.sh
+
+      - name: Verify checkpoints after validator tests
+        working-directory: pos-workflows/tests
+        run: bash checkpoint_monitor.sh
+
+      - name: Verify producer planned downtime
+        working-directory: pos-workflows/tests
+        run: ENABLE_PRODUCER_PLANNED_DOWNTIME_TEST=true bash producer_planned_downtime/verify.sh
 
       # Clean up
       - name: Post kurtosis run


### PR DESCRIPTION
# Description

- Refactored producer planned downtime test — split into setup.sh/verify.sh, now triggered via the `ENABLE_PRODUCER_PLANNED_DOWNTIME_TEST` env var instead of a direct `go run .`     
- Added milestone & checkpoint monitor scripts (`milestone_monitor.sh`, `checkpoint_monitor.sh`) as post-validator-test verification steps