### PR TITLE
helper, x/checkpoint: fix grpc client / add better logs / warn on bor client misconfig

### DIFF
--- a/helper/call.go
+++ b/helper/call.go
@@ -364,7 +364,11 @@ func (c *ContractCaller) GetRootHash(start, end, checkpointLength uint64) ([]byt
 	var err error
 
 	if c.BorChainGrpcFlag {
-		rootHash, err = c.BorChainGrpcClient.GetRootHash(ctx, start, end)
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			return nil, grpcErr
+		}
+		rootHash, err = grpcClient.GetRootHash(ctx, start, end)
 	} else {
 		rootHash, err = c.BorChainClient.GetRootHash(ctx, start, end)
 	}
@@ -390,7 +394,11 @@ func (c *ContractCaller) GetVoteOnHash(start, end uint64, hash, milestoneID stri
 	var err error
 
 	if c.BorChainGrpcFlag {
-		vote, err = c.BorChainGrpcClient.GetVoteOnHash(ctx, start, end, hash, milestoneID)
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			return false, grpcErr
+		}
+		vote, err = grpcClient.GetVoteOnHash(ctx, start, end, hash, milestoneID)
 	} else {
 		vote, err = c.BorChainClient.GetVoteOnHash(ctx, start, end, hash, milestoneID)
 	}
@@ -523,11 +531,16 @@ func (c *ContractCaller) GetBorChainBlock(ctx context.Context, blockNum *big.Int
 	var latestBlock *ethTypes.Header
 
 	if c.BorChainGrpcFlag {
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			Logger.Error(errUnableToConnect, "error", grpcErr)
+			return nil, grpcErr
+		}
 		if blockNum == nil {
 			// LatestBlockNumber is BlockNumber(-2) in go-ethereum rpc
-			latestBlock, err = c.BorChainGrpcClient.HeaderByNumber(ctx, -2)
+			latestBlock, err = grpcClient.HeaderByNumber(ctx, -2)
 		} else {
-			latestBlock, err = c.BorChainGrpcClient.HeaderByNumber(ctx, blockNum.Int64())
+			latestBlock, err = grpcClient.HeaderByNumber(ctx, blockNum.Int64())
 		}
 	} else {
 		latestBlock, err = c.BorChainClient.HeaderByNumber(ctx, blockNum)
@@ -1012,11 +1025,27 @@ func (c *ContractCaller) CheckIfBlocksExist(number uint64) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.BorChainTimeout)
 	defer cancel()
 
-	header, err := c.BorChainClient.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	var (
+		header *ethTypes.Header
+		err    error
+	)
+
+	if c.BorChainGrpcFlag {
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			return false, grpcErr
+		}
+		header, err = grpcClient.HeaderByNumber(ctx, int64(number))
+	} else {
+		header, err = c.BorChainClient.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	}
 	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			return false, nil
+		}
 		return false, err
 	}
-	if header == nil {
+	if header == nil || header.Number == nil {
 		return false, nil
 	}
 
@@ -1029,7 +1058,11 @@ func (c *ContractCaller) GetBlockByNumber(ctx context.Context, blockNumber uint6
 	var err error
 
 	if c.BorChainGrpcFlag {
-		block, err = c.BorChainGrpcClient.BlockByNumber(ctx, int64(blockNumber))
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			return nil, grpcErr
+		}
+		block, err = grpcClient.BlockByNumber(ctx, int64(blockNumber))
 	} else {
 		block, err = c.BorChainClient.BlockByNumber(ctx, big.NewInt(int64(blockNumber)))
 	}
@@ -1060,7 +1093,11 @@ func (c *ContractCaller) GetBorTxReceipt(txHash common.Hash) (*ethTypes.Receipt,
 	defer cancel()
 
 	if c.BorChainGrpcFlag {
-		return c.getTxReceipt(ctx, nil, c.BorChainGrpcClient, txHash)
+		grpcClient, grpcErr := c.getRequiredBorGRPCClient()
+		if grpcErr != nil {
+			return nil, grpcErr
+		}
+		return c.getTxReceipt(ctx, nil, grpcClient, txHash)
 	}
 	return c.getTxReceipt(ctx, c.BorChainClient, nil, txHash)
 }
@@ -1091,6 +1128,14 @@ func (c *ContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte, 
 	chainABI := c.RootChainABI
 
 	return UnpackSigAndVotes(payload, chainABI)
+}
+
+// getRequiredBorGRPCClient returns the bor grpc client or an error
+func (c *ContractCaller) getRequiredBorGRPCClient() (*grpc.BorGRPCClient, error) {
+	if c.BorChainGrpcClient == nil {
+		return nil, errors.New("bor grpc client is nil while bor grpc flag is enabled")
+	}
+	return c.BorChainGrpcClient, nil
 }
 
 // utility and helper methods

--- a/helper/config.go
+++ b/helper/config.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -82,7 +83,7 @@ const (
 
 	DefaultCometBFTNodeURL = "http://0.0.0.0:26657"
 
-	NoACKWaitTime = 1800 * time.Second // Time ack service waits to clear buffer and elect new proposer (1800 seconds ~ 30 min)
+	NoACKWaitTime = 1800 * time.Second // Time ack service waits to clear the buffer and elect the new proposer (1800 seconds ~ 30 min)
 
 	DefaultCheckpointPollInterval = 5 * time.Minute
 	DefaultSyncerPollInterval     = 1 * time.Minute
@@ -167,7 +168,7 @@ type CustomConfig struct {
 	SHMaxDepthDuration      time.Duration `mapstructure:"sh_max_depth_duration"`      // Max duration that allows to suggest self-healing is not needed
 
 	// wait-time-related options
-	NoACKWaitTime time.Duration `mapstructure:"no_ack_wait_time"` // Time ack service waits to clear buffer and elect new proposer
+	NoACKWaitTime time.Duration `mapstructure:"no_ack_wait_time"` // Time ack service waits to clear the buffer and elect the new proposer
 
 	// Log related options
 	LogsType       string `mapstructure:"logs_type"`        // if true, enable logging in json format
@@ -428,6 +429,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	}
 
 	borClient = ethclient.NewClient(borRPCClient)
+	warnIfBorRPCInaccessible(borClient, conf.Custom.BorRPCTimeout, conf.Custom.BorRPCUrl)
 
 	if conf.Custom.BorGRPCFlag && conf.Custom.BorGRPCUrl != "" {
 		client, err := borgrpc.NewBorGRPCClient(conf.Custom.BorGRPCUrl, Logger)
@@ -435,6 +437,9 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 			log.Fatal("unable to create bor gRPC client", "URL", conf.Custom.BorGRPCUrl, "error", err)
 		}
 		borGRPCClient = client
+		warnIfBorGRPCInaccessible(borGRPCClient, conf.Custom.BorRPCTimeout, conf.Custom.BorGRPCUrl)
+	} else if conf.Custom.BorGRPCFlag && conf.Custom.BorGRPCUrl == "" {
+		log.Fatal("bor gRPC is enabled but bor_grpc_url is empty")
 	}
 
 	// Set default producers based on the chain if not already set by config or flags
@@ -507,6 +512,38 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		disableValSetCheckHeight = 0
 		initialHeight = 0
 		producerDowntimeHeight = 0
+	}
+}
+
+// warnIfBorRPCInaccessible checks if the Bor RPC endpoint is accessible by making a simple call to get the latest block number.
+// If the call fails, it logs a warning message. This is useful to detect issues with the Bor RPC endpoint at startup.
+func warnIfBorRPCInaccessible(client *ethclient.Client, timeout time.Duration, url string) {
+	if client == nil {
+		Logger.Warn("Bor RPC client is nil", "URL", url)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if _, err := client.BlockNumber(ctx); err != nil {
+		Logger.Warn("Bor RPC endpoint appears inaccessible at startup", "URL", url, "error", err)
+	}
+}
+
+// warnIfBorGRPCInaccessible checks if the Bor gRPC endpoint is accessible by making a simple call to get the latest block header.
+// If the call fails, it logs a warning message. This is useful to detect issues with the Bor gRPC endpoint at startup.
+func warnIfBorGRPCInaccessible(client *borgrpc.BorGRPCClient, timeout time.Duration, url string) {
+	if client == nil {
+		Logger.Warn("Bor gRPC client is nil", "URL", url)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if _, err := client.HeaderByNumber(ctx, -2); err != nil {
+		Logger.Warn("Bor gRPC endpoint appears inaccessible at startup", "URL", url, "error", err)
 	}
 }
 

--- a/x/checkpoint/types/merkle.go
+++ b/x/checkpoint/types/merkle.go
@@ -42,7 +42,7 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 		exists, err := contractCaller.CheckIfBlocksExist(end + confirmations)
 		if err != nil {
 			return false, fmt.Errorf(
-				"%w: block existence check failed (end=%d confirmations=%d target=%d): %v",
+				"%w: block existence check failed (end=%d confirmations=%d target=%d): %w",
 				borTypes.ErrFailedToQueryBor,
 				end,
 				confirmations,
@@ -72,7 +72,7 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 		root, err = contractCaller.GetRootHash(start, end, checkpointLength)
 		if err != nil {
 			return false, fmt.Errorf(
-				"%w: root hash query failed (start=%d end=%d checkpointLength=%d): %v",
+				"%w: root hash query failed (start=%d end=%d checkpointLength=%d): %w",
 				borTypes.ErrFailedToQueryBor,
 				start,
 				end,

--- a/x/checkpoint/types/merkle.go
+++ b/x/checkpoint/types/merkle.go
@@ -41,7 +41,14 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 		// Check if blocks exist locally
 		exists, err := contractCaller.CheckIfBlocksExist(end + confirmations)
 		if err != nil {
-			return false, borTypes.ErrFailedToQueryBor
+			return false, fmt.Errorf(
+				"%w: block existence check failed (end=%d confirmations=%d target=%d): %v",
+				borTypes.ErrFailedToQueryBor,
+				end,
+				confirmations,
+				end+confirmations,
+				err,
+			)
 		}
 		if !exists {
 			return false, errors.New("blocks not found locally")
@@ -64,7 +71,14 @@ func IsValidCheckpoint(start uint64, end uint64, rootHash []byte, checkpointLeng
 		// Compare RootHash
 		root, err = contractCaller.GetRootHash(start, end, checkpointLength)
 		if err != nil {
-			return false, borTypes.ErrFailedToQueryBor
+			return false, fmt.Errorf(
+				"%w: root hash query failed (start=%d end=%d checkpointLength=%d): %v",
+				borTypes.ErrFailedToQueryBor,
+				start,
+				end,
+				checkpointLength,
+				err,
+			)
 		}
 
 		if len(root) > 0 {


### PR DESCRIPTION
# Description

Following improvements are implemented in this PR:
- warn at startup if the bor client (jsonRPC or gRPC) is misconfigured
- fix behaviour for `CheckIfBlocksExist`: this call was unconditionally using JSON RPC, ignoring the gRPC flag.
- Improve logs for merkle root queries: two of them were masking the real errors and using the same log error messages
  
# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Node audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it
(e.g., by adding a flag with a default value...)

# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross-repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on the local environment
- [ ] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli