### PR TITLE
Allow comments for claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--model claude-opus-4-5-20251101'
+          claude_args: '--comment --model claude-opus-4-5-20251101'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,7 +51,7 @@ jobs:
           additional_permissions: |
             actions: read
 
-          claude_args: '--model claude-opus-4-5-20251101'
+          claude_args: '--comment --model claude-opus-4-5-20251101'
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
# Description

Allow claude to post comments on PRs.
Workflows' runs show `Since the --comment argument was NOT provided, I will not post any GitHub comments. The review is complete.`