### PR TITLE
chore: add Claude Code security review rules for AI-assisted code review

### DIFF
--- a/.claude/rules/consensus-critical.md
+++ b/.claude/rules/consensus-critical.md
@@ -1,0 +1,94 @@
+---
+paths:
+  - "app/**/*.go"
+  - "sidetxs/**/*.go"
+  - "x/checkpoint/**/*.go"
+  - "x/milestone/**/*.go"
+  - "x/bor/**/*.go"
+---
+
+# Consensus-Critical Code Review
+
+This code directly affects consensus. Bugs here can halt the chain, cause forks, or enable fund theft. Review with extreme caution.
+
+## Determinism Requirements
+
+- All validators MUST produce identical results from identical inputs
+- Never use maps for iteration order (use sorted slices) -- Go randomizes map iteration intentionally
+- Never use `time.Now()` -- use `ctx.BlockTime()` for all timestamps
+- Never use goroutines or channels in deterministic consensus paths (`ProcessProposal`, `PreBlocker`, post-handlers)
+- Never use floating point arithmetic -- use `math.LegacyDec` (Cosmos SDK's decimal type)
+- Random number generation must use deterministic seeds (span seed from L1, not local randomness)
+- `fmt.Sprintf("%v", map)` produces non-deterministic output -- never use map-derived strings in state or hashing
+
+## ABCI++ Handler Semantics (CometBFT v0.38 / Cosmos SDK v0.50)
+
+Understand which handlers are deterministic vs non-deterministic:
+
+- **`ExtendVote`**: per-validator, MAY make external RPC calls (L1, Bor), MAY be non-deterministic. This is where side-handlers run and produce validator-specific opinions.
+- **`VerifyVoteExtension`**: per-validator, MUST be deterministic for vote validity. All validators must agree on whether a vote extension is valid. No external network calls.
+- **`ProcessProposal`**: deterministic validation. All validators must accept or reject the same proposal identically. No external network calls.
+- **`PreBlocker`**: deterministic execution. Tallies votes, runs post-handlers, applies approved side-txs. No external network calls. State writes happen here.
+- **`PrepareProposal`**: proposer-only, may filter/reorder txs. Not required to be deterministic with other validators, but output must pass `ProcessProposal`.
+
+Confusing these guarantees is the #1 source of consensus bugs.
+
+## Vote Extension Security
+
+- Validate ALL fields of incoming vote extensions: block height, block hash, proto encoding
+- Reject vote extensions with unknown proto fields -- CometBFT's proto unmarshaling ignores unknown fields by default, which can be used to smuggle data
+- Check for duplicate validator votes in the same round
+- Use canonical voting power from the validator set at height H-1 (penultimate block), NEVER trust power values from `ExtendedCommitInfo`
+- Verify vote extension signatures against the canonical public key set at H-1
+- Enforce 2/3+ voting power threshold for side-tx approval (use `> 2/3` not `>= 2/3` -- match CometBFT's convention)
+- Enforce the single-side-msg-per-tx invariant to prevent vote hash collisions
+- `VoteExtensionsEnableHeight` in CometBFT config determines when VEs activate -- code must handle blocks before this height where VEs are absent
+
+## PrepareProposal / ProcessProposal
+
+- Both handlers must enforce identical validation rules -- any divergence causes consensus failure
+- PrepareProposal filters invalid vote extensions; ProcessProposal rejects the entire proposal if any invalid VE is included
+- VEBLOP conditions (MsgVoteProducers, MsgSetProducerDowntime) must be checked consistently in both handlers
+- PrepareProposal chooses transaction order; ProcessProposal must validate any valid ordering (don't assume order)
+
+## PreBlocker Security
+
+- Tallying logic must use canonical validator set from H-1, never trust caller-provided voting power
+- 2/3 majority threshold for milestone acceptance, 1/3 for pending status -- verify exact threshold math (off-by-one in voting power comparison is a consensus vulnerability)
+- Checkpoint signature aggregation must validate each signature individually
+- Post-handlers for approved side-txs execute state changes -- they MUST be deterministic and MUST NOT make external calls
+- Post-handlers should be safe to crash-recover (node restarts mid-block replay the entire block)
+
+## Panic Safety
+
+- Panics in any ABCI handler crash the node and can halt the chain if triggered for all validators
+- Guard against nil pointer dereference: proto message fields, RPC responses, interface values
+- Guard against index out of range: vote extension arrays, validator lists, event logs
+- Guard against division by zero: voting power calculations, span duration math
+- Use `defer func() { recover() }()` only as a last resort -- prefer explicit nil/bounds checks
+
+## Computation Bounds
+
+- ABCI handlers (PrepareProposal, ProcessProposal, PreBlocker) have no Cosmos SDK gas metering
+- Unbounded computation causes CometBFT timeouts and consensus stalls
+- Bound iteration over vote extensions, side-tx responses, and validator sets
+- Maximum 50 side-tx responses per vote extension -- validate this bound before iterating
+
+## Side Transaction Invariants
+
+- No duplicate tx hashes in side-tx responses
+- Valid vote types only (YES, NO, UNSPECIFIED)
+- `SideTxDecorator` must enforce at most one side-tx message per transaction
+- Side handlers (in `ExtendVote`) produce per-validator opinions -- disagreement is normal
+- Post-handlers (in `PreBlocker`) execute only for txs with 2/3+ approval -- must be deterministic
+
+## Red Flags -- Reject Immediately
+
+- Any change that skips vote extension validation
+- Removing or weakening the 2/3 voting power threshold
+- Adding non-deterministic operations in `ProcessProposal`, `PreBlocker`, or post-handlers
+- Adding external network calls in `ProcessProposal`, `VerifyVoteExtension`, or `PreBlocker`
+- Trusting unverified data from `ExtendedCommitInfo` or `RequestPrepareProposal`
+- Modifying state directly in ABCI handlers instead of through keepers
+- Changes to tallying logic without corresponding test updates
+- Unguarded array/slice indexing on external data in ABCI handlers

--- a/.claude/rules/consensus-critical.md
+++ b/.claude/rules/consensus-critical.md
@@ -11,6 +11,17 @@ paths:
 
 This code directly affects consensus. Bugs here can halt the chain, cause forks, or enable fund theft. Review with extreme caution.
 
+## External Attack Vectors
+
+These are the actors who can trigger consensus bugs **remotely** -- making any exploitable issue CRITICAL:
+
+- **Malicious proposer** (1 of ~100 validators): crafts proposals with malformed VEs, invalid tx ordering, or oversized payloads. If this triggers a panic in `ProcessProposal` on ALL honest validators, the chain halts. The proposer sacrifices their own block but stops the network.
+- **Malicious validator**: sends crafted vote extensions (malformed proto, oversized NonRpVE, duplicate votes, smuggled unknown fields). If `VerifyVoteExtension` panics or produces different results on different honest nodes, consensus breaks.
+- **External tx submitter** (anyone): submits transactions designed to exploit side-tx handlers, ante decorators, or keeper logic. If a crafted message causes non-deterministic state writes across validators, app hash diverges.
+- **Colluding minority** (<1/3 validators): submits conflicting vote extensions or milestones to exploit threshold edge cases (e.g., non-deterministic map iteration when multiple values meet 1/3 threshold).
+
+**Key question for every finding: "Can a malicious proposer/validator/user trigger this on honest nodes?"** If yes, it is CRITICAL regardless of how unlikely. Self-inflicted bugs (misconfiguration, code bug affecting only the buggy node) are lower severity.
+
 **Every module keeper change is consensus-critical.** Divergences in keeper state propagate to the app layer. If two nodes run different states, they produce the infamous **app hash mismatch error**, halting heimdall block production and impacting bor (finality, checkpoints, network liveness). Even if all nodes run the same version, a change in state management applied to previous blocks triggers app hash mismatch -- this is why **hard forks are required** for state-divergence changes (e.g., post-handler modifications).
 
 ## Determinism Requirements

--- a/.claude/rules/consensus-critical.md
+++ b/.claude/rules/consensus-critical.md
@@ -2,14 +2,16 @@
 paths:
   - "app/**/*.go"
   - "sidetxs/**/*.go"
-  - "x/checkpoint/**/*.go"
-  - "x/milestone/**/*.go"
-  - "x/bor/**/*.go"
+  - "x/**/keeper/*.go"
+  - "x/milestone/abci/**/*.go"
+  - "x/*/module.go"
 ---
 
 # Consensus-Critical Code Review
 
 This code directly affects consensus. Bugs here can halt the chain, cause forks, or enable fund theft. Review with extreme caution.
+
+**Every module keeper change is consensus-critical.** Divergences in keeper state propagate to the app layer. If two nodes run different states, they produce the infamous **app hash mismatch error**, halting heimdall block production and impacting bor (finality, checkpoints, network liveness). Even if all nodes run the same version, a change in state management applied to previous blocks triggers app hash mismatch -- this is why **hard forks are required** for state-divergence changes (e.g., post-handler modifications).
 
 ## Determinism Requirements
 
@@ -26,12 +28,14 @@ This code directly affects consensus. Bugs here can halt the chain, cause forks,
 Understand which handlers are deterministic vs non-deterministic:
 
 - **`ExtendVote`**: per-validator, MAY make external RPC calls (L1, Bor), MAY be non-deterministic. This is where side-handlers run and produce validator-specific opinions.
-- **`VerifyVoteExtension`**: per-validator, MUST be deterministic for vote validity. All validators must agree on whether a vote extension is valid. No external network calls.
-- **`ProcessProposal`**: deterministic validation. All validators must accept or reject the same proposal identically. No external network calls.
-- **`PreBlocker`**: deterministic execution. Tallies votes, runs post-handlers, applies approved side-txs. No external network calls. State writes happen here.
-- **`PrepareProposal`**: proposer-only, may filter/reorder txs. Not required to be deterministic with other validators, but output must pass `ProcessProposal`.
+- **`VerifyVoteExtension`**: per-validator, MUST be deterministic for vote validity. All validators must agree on whether a vote extension is valid. No external network calls. Should mirror the validation logic of `ExtendVote` -- every check in `ExtendVote` should have a corresponding verification in `VerifyVoteExtension`.
+- **`ProcessProposal`**: deterministic validation. All validators must accept or reject the same proposal identically. No external network calls. **All validation checks from `PrepareProposal` must also be executed in `ProcessProposal`** -- if the proposer validates something, all validators must validate it too.
+- **`PreBlocker`**: deterministic execution. State writes happen here at two levels:
+  - **App-level PreBlocker** (`app/abci.go`): tallies votes, runs post-handlers for approved side-txs, processes milestone propositions, handles checkpoint signatures
+  - **Module-level PreBlockers**: invoked by the app-level PreBlocker at the end. The **stake module** performs validator set updates here. Changes to module PreBlockers are as critical as app-level ones.
+- **`PrepareProposal`**: proposer-only, may filter/reorder txs. Not required to be deterministic with other validators, but output must pass `ProcessProposal`. **Malformed VEs must be filtered out here** (not halt consensus), but explicitly rejected during ProcessProposal.
 
-Confusing these guarantees is the #1 source of consensus bugs.
+**Every error returned by an ABCI method triggers a panic in CometBFT, which can halt the chain.** Errors must be justified by strong backing reasons (e.g., proposal is provably invalid). When in doubt, log and continue rather than return an error.
 
 ## Vote Extension Security
 
@@ -42,26 +46,42 @@ Confusing these guarantees is the #1 source of consensus bugs.
 - Verify vote extension signatures against the canonical public key set at H-1
 - Enforce 2/3+ voting power threshold for side-tx approval (use `> 2/3` not `>= 2/3` -- match CometBFT's convention)
 - Enforce the single-side-msg-per-tx invariant to prevent vote hash collisions
-- `VoteExtensionsEnableHeight` in CometBFT config determines when VEs activate -- code must handle blocks before this height where VEs are absent
+- **`VoteExtensionsEnableHeight`**: heimdall-v2 launched with VEs always enabled (final v1 block + 1). This value MUST NEVER be changed -- modifying it would be catastrophic for consensus.
+- Enforce explicit size bounds on VEs and NonRpVEs -- filter/reject oversized and undersized extensions. Size params are defined in module params and enforced in PrepareProposal/ProcessProposal.
 
 ## PrepareProposal / ProcessProposal
 
-- Both handlers must enforce identical validation rules -- any divergence causes consensus failure
-- PrepareProposal filters invalid vote extensions; ProcessProposal rejects the entire proposal if any invalid VE is included
+- **All checks in PrepareProposal must be mirrored in ProcessProposal.** If the proposer validates something, all validators must validate it identically.
+- PrepareProposal **filters** invalid/malformed vote extensions (silently drops them to avoid halting consensus). ProcessProposal **rejects** the entire proposal if invalid VEs are included (the proposer should have filtered them).
 - VEBLOP conditions (MsgVoteProducers, MsgSetProducerDowntime) must be checked consistently in both handlers
 - PrepareProposal chooses transaction order; ProcessProposal must validate any valid ordering (don't assume order)
 
+## Milestone Module ABCI (`x/milestone/abci/`)
+
+The milestone module has its own ABCI implementation requiring particular attention:
+
+- Milestone propositions affect **bor finality** -- incorrect milestones compromise the entire finality guarantee of the Polygon PoS stack
+- `GenMilestoneProposition` makes external RPC calls to Bor (allowed in ExtendVote)
+- `GetMajorityMilestoneProposition` runs in PreBlocker (deterministic path) -- map iterations MUST be sorted
+- Milestone acceptance (2/3 majority) vs pending status (1/3) have different thresholds with different safety properties
+- Stalled milestones trigger span rotation -- incorrect milestone logic cascades into producer selection failures
+
 ## PreBlocker Security
 
+- State writes happen at **both** app level and module level:
+  - App-level: vote tallying, side-tx post-handlers, milestone processing, checkpoint signatures
+  - Module-level: stake module performs **validator set updates** via `ApplyAndReturnValidatorSetUpdates()`, chainmanager migrates contract addresses at specific heights
 - Tallying logic must use canonical validator set from H-1, never trust caller-provided voting power
 - 2/3 majority threshold for milestone acceptance, 1/3 for pending status -- verify exact threshold math (off-by-one in voting power comparison is a consensus vulnerability)
 - Checkpoint signature aggregation must validate each signature individually
 - Post-handlers for approved side-txs execute state changes -- they MUST be deterministic and MUST NOT make external calls
 - Post-handlers should be safe to crash-recover (node restarts mid-block replay the entire block)
+- **Any change to post-handler state logic applied to previous blocks requires a hard fork** -- you cannot change how past blocks are processed without causing app hash mismatch
 
 ## Panic Safety
 
 - Panics in any ABCI handler crash the node and can halt the chain if triggered for all validators
+- **Any error returned from an ABCI method triggers a CometBFT panic** -- only return errors when you have strong justification (provably invalid proposal, corrupted state). Prefer logging + graceful degradation over error returns.
 - Guard against nil pointer dereference: proto message fields, RPC responses, interface values
 - Guard against index out of range: vote extension arrays, validator lists, event logs
 - Guard against division by zero: voting power calculations, span duration math
@@ -73,14 +93,16 @@ Confusing these guarantees is the #1 source of consensus bugs.
 - Unbounded computation causes CometBFT timeouts and consensus stalls
 - Bound iteration over vote extensions, side-tx responses, and validator sets
 - Maximum 50 side-tx responses per vote extension -- validate this bound before iterating
+- Enforce explicit size bounds on VEs and NonRpVEs: filter/reject oversized and undersized extensions at PrepareProposal, reject at ProcessProposal
 
 ## Side Transaction Invariants
 
 - No duplicate tx hashes in side-tx responses
-- Valid vote types only (YES, NO, UNSPECIFIED)
+- Valid vote types: YES and NO are actively used. UNSPECIFIED exists in the proto definition but is not actively used in code -- treat it as an abstain/no-op, do not assume it carries semantic meaning.
 - `SideTxDecorator` must enforce at most one side-tx message per transaction
 - Side handlers (in `ExtendVote`) produce per-validator opinions -- disagreement is normal
 - Post-handlers (in `PreBlocker`) execute only for txs with 2/3+ approval -- must be deterministic
+- **`side_msg_server.go` in every module is especially critical** -- these define the side and post handlers that directly write state. Any change here can cause app hash divergence.
 
 ## Red Flags -- Reject Immediately
 
@@ -92,3 +114,6 @@ Confusing these guarantees is the #1 source of consensus bugs.
 - Modifying state directly in ABCI handlers instead of through keepers
 - Changes to tallying logic without corresponding test updates
 - Unguarded array/slice indexing on external data in ABCI handlers
+- Changes to post-handler state logic without planning a hard fork
+- Modifying `VoteExtensionsEnableHeight`
+- Any ABCI error return without strong justification (it triggers a CometBFT panic)

--- a/.claude/rules/contract-interactions.md
+++ b/.claude/rules/contract-interactions.md
@@ -1,0 +1,95 @@
+---
+paths:
+  - "helper/call.go"
+  - "helper/tx.go"
+  - "helper/receipt.go"
+  - "helper/unpack.go"
+  - "helper/mocks/**/*.go"
+  - "contracts/**/*.go"
+  - "x/bor/grpc/**/*.go"
+  - "x/*/keeper/keeper.go"
+  - "x/*/keeper/grpc_query.go"
+  - "bridge/processor/**/*.go"
+  - "cmd/heimdalld/cmd/stake.go"
+---
+
+# Smart Contract Interaction Security Review
+
+All Ethereum/Bor contract interactions flow through `helper.IContractCaller`. This is the trust boundary between Heimdall consensus and external chains. Bugs here can forge validator joins, steal funds, or corrupt checkpoints.
+
+## IContractCaller Interface (`helper/call.go`)
+
+- This is the single most security-critical non-consensus file in the codebase
+- Every method must validate its return values -- nil checks on all pointer returns, length checks on byte slices
+- `GetConfirmedTxReceipt()` must enforce finality (finalized block, not latest) -- this is the root of all L1 trust
+- `GetHeaderInfo()`, `GetLastChildBlock()` read from RootChain -- verify the contract instance was created with the address from ChainManager params, not a hardcoded address
+- `GetValidatorInfo()` reads from StakingInfo -- cross-check returned data against expected ranges (non-zero amount, valid epoch)
+- `GetRootHash()` and `GetVoteOnHash()` call Bor RPC -- validate response length (root hash = 32 bytes) and non-nil
+- `CurrentAccountStateRoot()` reads merkle root -- used for checkpoint validation, single-bit difference means invalid checkpoint
+- ABI instances are loaded at init time from compiled bindings in `contracts/` -- integrity depends on the bindings matching deployed contracts
+
+## Determinism in Contract Calls: Side Handlers vs Post Handlers
+
+This is a critical architectural distinction:
+
+- **Side handlers** (run in `ExtendVote`): CAN make RPC calls to L1/Bor. Each validator calls independently. RPC failures, timeouts, or different results across validators are expected -- they produce different vote extension opinions (YES/NO/UNSPECIFIED). This is by design.
+- **Post handlers** (run in `PreBlocker`): MUST NOT make RPC calls. They execute only for side-txs that received 2/3+ approval. They must be fully deterministic using only the data already in the Cosmos SDK state store. Any external call here breaks consensus.
+
+If a change adds an `IContractCaller` call, verify it's in a side handler path, never a post handler path.
+
+## Transaction Construction (`helper/tx.go`)
+
+- `GenerateAuthObj()` creates EIP-1559 `TransactOpts` -- verify gas tip cap and fee cap have upper bounds to prevent overpaying. Don't blindly trust `ethclient.SuggestGasPrice()` from remote RPCs -- a malicious RPC can suggest extreme gas prices.
+- `SendCheckpoint()` submits to RootChain -- irreversible L1 write, validate ALL inputs before the call. A bad checkpoint on L1 requires governance intervention to fix.
+- `StakeFor()` and `ApproveTokens()` move real funds -- double-validate amounts and addresses, verify the spender is the expected StakeManager contract
+- Nonce management: query pending nonce before sending, use mutex if concurrent tx submission is possible. Same-nonce txs with higher gas replace previous ones (front-running vector).
+- Set explicit gas limits -- `EstimateGas()` from a malicious RPC can return 0 or max uint64
+
+## Contract Upgrade Risk
+
+- L1 contracts (RootChain, StakeManager, StakingInfo) may be upgradeable proxies. If the implementation changes, ABI bindings become stale.
+- ChainManager stores contract addresses and can update them via governance -- this is the correct upgrade path
+- If ChainManager params change, verify the new addresses point to contracts with compatible ABIs
+- After any L1 contract upgrade, regenerate Go bindings with `abigen` and verify they compile
+
+## ABI Encoding/Decoding (`helper/unpack.go`, `contracts/`)
+
+- ABI mismatch silently produces wrong values with no error -- this is the most insidious class of bug
+- `UnpackLog()` decodes event logs -- always verify `log.Topics[0]` (event signature) matches the expected ABI event before decoding
+- `UnpackSigAndVotes()` decodes checkpoint signatures -- validate array lengths match expected signer count, validate each signature format (65 bytes: r[32] + s[32] + v[1])
+- Generated bindings in `contracts/` must match deployed contract ABIs exactly -- track deployed contract versions
+- When decoding events from receipts, always verify `log.Address` matches the expected contract
+
+## Bor gRPC Client (`x/bor/grpc/`)
+
+- Direct gRPC client to Bor bypasses the `IContractCaller` abstraction -- apply identical security standards
+- `HeaderByNumber`, `BlockByNumber`: validate response is non-nil, block number matches request, chain ID matches expected Bor chain
+- `GetRootHash`: response must be exactly 32 bytes, non-zero
+- `TransactionReceipt`: verify receipt status and that the block is finalized on Bor
+- All gRPC calls need `context.WithTimeout` -- default CometBFT ABCI timeout is 10s, so gRPC timeout must be shorter
+- gRPC connection failures must return explicit errors, never nil responses that pass downstream validation
+
+## Module Keepers Using `IContractCaller`
+
+- Every keeper that holds `IContractCaller` is a potential attack surface
+- Side handlers call `contractCaller` during `ExtendVote` -- RPC errors here produce a NO vote, which is safe
+- gRPC query handlers (`grpc_query.go`) expose contract data to external clients -- sanitize responses, don't leak internal state
+- Mock implementations (`helper/mocks/`) must cover error cases (RPC timeout, nil response, wrong chain ID) -- tests that only mock happy paths miss critical vulnerabilities
+
+## Bridge Processors (`bridge/processor/`)
+
+- Processors create their own `ContractCaller` instances -- same security rules apply as `helper/call.go`
+- `checkpoint.go` calls `SendCheckpoint()` -- the most critical write operation in the system. Must verify checkpoint isn't already submitted on L1 before sending.
+- All processors must validate event data before constructing Heimdall transactions
+- Check tx status against Heimdall before re-submitting to prevent duplicate transactions
+
+## Red Flags
+
+- Any change to `helper/call.go` or `helper/tx.go` without corresponding test updates
+- Removing or weakening receipt finality checks
+- Hardcoding contract addresses instead of reading from ChainManager params
+- ABI changes without regenerating Go bindings
+- New contract calls without `context.WithTimeout`
+- Transaction construction with unbounded gas or unchecked amounts
+- Bor gRPC calls without nil/error checking on responses
+- Adding `IContractCaller` usage in a post-handler or `PreBlocker` path

--- a/.claude/rules/contract-interactions.md
+++ b/.claude/rules/contract-interactions.md
@@ -17,6 +17,13 @@ paths:
 
 All Ethereum/Bor contract interactions flow through `helper.IContractCaller`. This is the trust boundary between Heimdall consensus and external chains. Bugs here can forge validator joins, steal funds, or corrupt checkpoints.
 
+## External Attack Vectors
+
+- **Malicious/compromised RPC provider**: returns fabricated block headers, fake receipts, wrong chain IDs, manipulated gas estimates, or zero-value responses. If `IContractCaller` doesn't validate responses, all validators using that provider vote based on false data. A coordinated RPC attack on a popular provider (Infura, Alchemy) can affect a majority of validators simultaneously.
+- **L1 contract upgrader** (Polygon governance): if L1 contracts (RootChain, StakeManager) are upgraded via proxy, ABI bindings become stale. Mismatched ABIs decode silently with wrong values -- no error, just garbage data flowing into consensus.
+- **Front-running attacker** (L1 MEV): observes Heimdall's `SendCheckpoint` or `StakeFor` transaction in the L1 mempool and front-runs with a same-nonce higher-gas replacement, or sandwich-attacks to manipulate gas pricing.
+- **Bor chain attacker**: if Bor's gRPC endpoint is compromised or a malicious Bor node is connected, it can feed false root hashes, block headers, or milestone data to Heimdall's side handlers.
+
 ## IContractCaller Interface (`helper/call.go`)
 
 - This is the single most security-critical non-consensus file in the codebase

--- a/.claude/rules/cross-chain.md
+++ b/.claude/rules/cross-chain.md
@@ -1,0 +1,87 @@
+---
+paths:
+  - "bridge/**/*.go"
+  - "helper/**/*.go"
+  - "contracts/**/*.go"
+  - "x/stake/**/*.go"
+  - "x/topup/**/*.go"
+  - "x/clerk/**/*.go"
+  - "x/chainmanager/**/*.go"
+---
+
+# Cross-Chain & Bridge Security Review
+
+This code handles L1<->L2 communication. Bugs here can lead to unauthorized validator joins, stolen funds, forged checkpoints, or state sync corruption.
+
+## L1 Receipt Validation
+
+- ALWAYS verify transaction receipts against finalized L1 blocks (`rpc.FinalizedBlockNumber`), never pending/latest
+- Validate the receipt's contract address matches the expected contract from ChainManager params
+- Check `receipt.Status == 1` (success) before trusting event logs -- reverted txs still emit events in some edge cases
+- Verify log indices -- a single transaction can emit multiple events; extracting the wrong log index is a critical vulnerability
+- Ensure tx confirmation count meets the required threshold before processing
+- Validate `receipt.BlockNumber` is not zero (zero indicates the receipt was not mined)
+
+## Event Log Verification
+
+- Decode event logs using the correct ABI -- mismatched ABIs silently produce wrong values with no error
+- Verify `log.Topics[0]` matches the expected event signature hash before decoding
+- Verify ALL fields from the event, not just a subset (e.g., for ValidatorJoin: signer, pubkey, activation epoch, amount, nonce, validator ID)
+- Cross-check decoded values against expected ranges:
+  - Amounts: must be > 0 and within sane bounds (not exceeding total supply)
+  - Epochs: activation epoch >= current epoch for joins; deactivation epoch > current epoch for exits
+  - Addresses: must not be zero address (`0x0000...0000`)
+  - Nonces: must be exactly `validator.Nonce + 1`
+- Never trust event data alone for state transitions -- cross-validate with contract view calls where possible
+
+## Staking Security
+
+- Nonce must equal `validator.Nonce + 1` for all staking operations (join, update, signer change, exit) -- prevents replay and reordering attacks
+- Verify secp256k1 public key format: 33-byte compressed, first byte must be 0x02 or 0x03
+- Signer address must match `crypto.PubkeyToAddress(pubkey)` derived from the event log -- never trust a signer address provided separately from its public key
+- ValidatorJoin: verify the validator ID doesn't already exist in the active set
+- ValidatorExit: deactivation epoch must be strictly > current epoch
+- SignerUpdate: verify both old and new signer, ensure the old signer matches current on-chain state, fee token transfer must occur
+- StakeUpdate: verify updated amount doesn't drop below minimum stake
+- Slashing: validate slash amount against the minimum stake requirement, verify the slashing event comes from the SlashManager contract specifically
+
+## Checkpoint Security
+
+- Checkpoint continuity: new checkpoint start block must equal previous checkpoint end block + 1 -- any gap or overlap corrupts the checkpoint chain
+- Root hash must match the value computed from Bor chain's `GetRootHash` for the exact same block range
+- Account root hash must match the value from Bor's state at the checkpoint end block
+- Proposer must be the expected proposer from the validator set rotation (round-robin based on voting power)
+- Checkpoint ack: cross-validate header block number, proposer, start/end, root hash against L1 RootChain contract
+- Checkpoint no-ack: verify the timeout period has actually elapsed since the last checkpoint
+
+## State Sync (Clerk Module)
+
+- State sync events must be processed in order by event nonce/ID -- out-of-order processing corrupts L2 state
+- Verify the StateSender contract address matches ChainManager params
+- Validate state sync data size bounds -- unbounded data causes OOM in consensus
+- Event record ID must be monotonically increasing -- reject duplicates and gaps
+
+## TopUp Fee Validation
+
+- Verify the fee amount is > 0 and the fee token address matches the expected POL/MATIC token from ChainManager
+- Validate the recipient validator exists and is active
+- TopUp events from L1 must reference a valid, confirmed receipt
+
+## Bridge Event Processing
+
+- Listeners must filter events by exact contract address -- accepting events from wrong contracts is critical
+- Processors must validate event data before creating Heimdall transactions
+- RabbitMQ message processing must be idempotent (safe to replay on failure)
+- Handle chain reorgs: using `finalized` block subscription prevents reorg issues, but verify this is enforced throughout -- any path using `latest` is vulnerable
+- Rate limit bridge transaction creation to prevent spam during high L1 activity
+
+## Red Flags -- Reject Immediately
+
+- Removing or weakening finality requirements for L1 receipt validation
+- Trusting event data without receipt status check
+- Skipping nonce validation on any staking operation
+- Processing events from unverified contract addresses
+- Using `latest` instead of `finalized` block for L1 queries in consensus-critical paths
+- Any change that makes bridge processing non-idempotent
+- State sync events processed out of order
+- Zero-address accepted as valid signer or validator

--- a/.claude/rules/cross-chain.md
+++ b/.claude/rules/cross-chain.md
@@ -13,6 +13,13 @@ paths:
 
 This code handles L1<->L2 communication. Bugs here can lead to unauthorized validator joins, stolen funds, forged checkpoints, or state sync corruption.
 
+## External Attack Vectors
+
+- **L1 transaction crafter** (anyone with ETH): deploys a contract that emits events with matching topic hashes but from a wrong address, or crafts transactions with multiple events where log index extraction grabs the wrong one. If Heimdall doesn't verify `log.Address` and log index correctly, fake validator joins, stake updates, or state syncs are accepted.
+- **L1 reorg exploiter**: submits a staking event, waits for Heimdall to process it on a non-finalized block, then reorgs L1. If the bridge uses `latest` instead of `finalized`, the event is processed but never happened.
+- **Replay attacker**: replays a previously valid staking event (join, exit, signer change) if nonce checks are missing or flawed. Cost: one L1 transaction.
+- **Malicious validator (as tx submitter)**: crafts Heimdall messages with manipulated fields (wrong nonce, fake pubkey, altered amount) that pass `ValidateBasic()` but exploit weak side-handler validation.
+
 ## L1 Receipt Validation
 
 - ALWAYS verify transaction receipts against finalized L1 blocks (`rpc.FinalizedBlockNumber`), never pending/latest

--- a/.claude/rules/p2p-and-networking.md
+++ b/.claude/rules/p2p-and-networking.md
@@ -1,0 +1,77 @@
+---
+paths:
+  - "helper/config.go"
+  - "helper/query.go"
+  - "bridge/broadcaster/**/*.go"
+  - "bridge/listener/**/*.go"
+  - "bridge/service/**/*.go"
+  - "bridge/queue/**/*.go"
+  - "cmd/**/*.go"
+  - "packaging/templates/**"
+---
+
+# P2P, Networking & RPC Security Review
+
+Heimdall delegates P2P consensus to CometBFT, but configures seeds, peers, RPC endpoints, and runs bridge listeners/broadcasters that connect to L1, Bor, and RabbitMQ. Compromised networking allows eclipse attacks, transaction censorship, or forged chain data.
+
+## CometBFT P2P Configuration
+
+- Seed nodes and persistent peers must come from verified config for known networks (mainnet, amoy) -- never accept seeds from unvalidated runtime input
+- `PeerGossipSleepDuration` and `PeerQueryMaj23SleepDuration` affect consensus timing -- lowering these increases bandwidth; raising them degrades liveness. Changes require network-wide coordination.
+- `AddrBookStrict = false` disables address verification -- acceptable for testnets only, never mainnet
+- Verify `MinPeerThreshold` / `WarnPeerThreshold` are set to sane values -- low peer counts make the node vulnerable to eclipse attacks (attacker controls all peers)
+- P2P config changes in `packaging/templates/` propagate to all new deployments -- review with same rigor as code changes
+- Peer Exchange (PEX) reactor: if enabled, peers can inject malicious peer addresses. For validator nodes, prefer `pex = false` with explicit persistent peers. Sentry nodes can use PEX.
+- Validator nodes should not expose their P2P port publicly -- use sentry node architecture where sentry nodes shield validators from direct network access
+
+## RPC Endpoint Security
+
+- All RPC URLs (CometBFT, Ethereum, Bor) must come from config, never hardcoded in source
+- Use TLS (`https://` / `wss://`) for remote RPC endpoints. Local endpoints (`localhost`, `127.0.0.1`) may use plaintext but must bind to loopback only, not `0.0.0.0`.
+- Every RPC call must use `context.WithTimeout` -- hanging connections block consensus or bridge processing. Timeout should be shorter than CometBFT's ABCI timeout (~10s).
+- Handle RPC errors explicitly: never silently use zero values from failed calls -- this is the most common source of consensus divergence between validators
+- Validate L1/Bor chain IDs on initial connection and periodically -- prevents connecting to wrong network (testnet vs mainnet)
+- Consider RPC provider reliability: if using third-party providers (Infura, Alchemy), a provider outage affects all validators using it, which can stall consensus. Recommend multiple fallback providers.
+
+## Bridge Listeners
+
+- Listeners must subscribe to **finalized** blocks on L1 (`rpc.FinalizedBlockNumber`), never pending/latest -- this is the primary reorg protection
+- Filter events by exact contract address from ChainManager params -- accepting events from wrong contracts enables arbitrary state injection
+- Self-heal mechanisms (`rootchain_selfheal.go`) must validate recovered events with the same strictness as live events -- weaker validation in self-heal is a backdoor
+- SubGraph queries for self-healing: validate the subgraph endpoint is the official Polygon subgraph, verify response schema, cross-validate results against L1 when possible
+- Listener polling intervals affect event detection latency -- too slow misses events, too fast wastes resources and may trigger RPC rate limits
+
+## Bridge Broadcaster
+
+- `BroadcastToHeimdall()` signs Cosmos SDK txs using the keyring -- verify keyring backend is `file` or `os` in production, never `test`
+- `BroadcastToBorChain()` sends raw Ethereum txs -- nonce management must be serialized (mutex or channel) to prevent nonce collisions in concurrent sends
+- Set explicit gas limits on all broadcast transactions -- `EstimateGas()` from untrusted RPCs can return manipulated values
+- Log tx hashes for audit trail, but never log private keys, keyring passwords, or raw signing bytes
+- Implement retry with backoff for failed broadcasts, but cap retries to prevent infinite loops on permanently rejected txs
+
+## RabbitMQ / Message Queue
+
+- Queue connections must use authentication and TLS in production -- unauthenticated AMQP allows message injection (attacker can forge bridge events)
+- Message processing must be idempotent -- RabbitMQ guarantees at-least-once delivery, so duplicate messages are expected
+- Validate message content before processing -- treat queue messages as untrusted input, verify expected schema
+- Monitor queue depth -- unbounded growth indicates stuck processing or DoS
+- Set message TTL to prevent indefinite accumulation of stale events
+
+## CLI Commands (`cmd/`)
+
+- CLI commands that interact with contracts (`stake.go`: StakeFor, ApproveTokens) must validate all user inputs before calling the contract layer
+- Never log or echo private keys, even in error messages or debug output
+- `--home` flag controls key storage location -- validate path permissions (not world-readable, mode 0700 for keyring directory)
+- `testnet` command generates node keys and persistent peer lists -- verify generated keys have proper entropy and peer IDs are derived correctly
+
+## Red Flags
+
+- Removing TLS requirements for remote RPC endpoints
+- Accepting seeds/peers from unvalidated runtime input
+- RPC calls without `context.WithTimeout`
+- Bridge listeners using `latest` instead of `finalized` block subscription
+- Queue connections without authentication in production configs
+- Self-heal code with weaker validation than live event processing
+- Validator P2P port exposed to public internet without sentry nodes
+- `pex = true` on validator nodes in mainnet config
+- Keyring backend set to `test` in production

--- a/.claude/rules/p2p-and-networking.md
+++ b/.claude/rules/p2p-and-networking.md
@@ -14,6 +14,14 @@ paths:
 
 Heimdall delegates P2P consensus to CometBFT, but configures seeds, peers, RPC endpoints, and runs bridge listeners/broadcasters that connect to L1, Bor, and RabbitMQ. Compromised networking allows eclipse attacks, transaction censorship, or forged chain data.
 
+## External Attack Vectors
+
+- **Eclipse attacker** (any P2P participant): monopolizes a validator's peer connections by flooding with sybil peers. The isolated validator sees only attacker-controlled blocks/txs, can be tricked into signing conflicting proposals or missing votes. Low peer thresholds and enabled PEX make this easier.
+- **MITM on RPC** (network-level): if RPC connections to L1/Bor use plaintext HTTP, a network-level attacker can intercept and modify responses -- feeding fake finalized blocks, wrong root hashes, or fabricated receipts. Affects all bridge operations.
+- **RabbitMQ message injector** (adjacent service/host): if AMQP uses default `guest:guest` credentials or no TLS, any process on the same network can inject fabricated bridge events (fake state syncs, forged staking events) or consume/drop legitimate ones.
+- **Gossip flooder** (any peer): exploits aggressive gossip settings (e.g., 25ms `PeerGossipSleepDuration`) to amplify bandwidth consumption, degrading consensus performance for the target validator.
+- **SubGraph endpoint attacker** (MITM or compromised endpoint): feeds fabricated or empty event data to self-heal logic, causing the bridge to skip events or process fake ones during recovery.
+
 ## CometBFT P2P Configuration
 
 - Seed nodes and persistent peers must come from verified config for known networks (mainnet, amoy) -- never accept seeds from unvalidated runtime input

--- a/.claude/rules/p2p-and-networking.md
+++ b/.claude/rules/p2p-and-networking.md
@@ -23,6 +23,7 @@ Heimdall delegates P2P consensus to CometBFT, but configures seeds, peers, RPC e
 - P2P config changes in `packaging/templates/` propagate to all new deployments -- review with same rigor as code changes
 - Peer Exchange (PEX) reactor: if enabled, peers can inject malicious peer addresses. For validator nodes, prefer `pex = false` with explicit persistent peers. Sentry nodes can use PEX.
 - Validator nodes should not expose their P2P port publicly -- use sentry node architecture where sentry nodes shield validators from direct network access
+- **Reference the repo's own config templates** for current defaults and param tuning: `packaging/templates/config/mainnet/config.toml` and `packaging/templates/config/amoy/config.toml`. CometBFT params set programmatically in `cmd/heimdalld/cmd/commands.go` (`initCometBFTConfig`) may differ from template defaults.
 
 ## RPC Endpoint Security
 
@@ -59,6 +60,7 @@ Heimdall delegates P2P consensus to CometBFT, but configures seeds, peers, RPC e
 
 ## CLI Commands (`cmd/`)
 
+- Most modules have **autocli enabled** -- auto-generated CLI commands must correctly reflect the manually implemented CLI commands. If a module adds custom CLI commands, ensure they don't conflict with or shadow autocli-generated ones.
 - CLI commands that interact with contracts (`stake.go`: StakeFor, ApproveTokens) must validate all user inputs before calling the contract layer
 - Never log or echo private keys, even in error messages or debug output
 - `--home` flag controls key storage location -- validate path permissions (not world-readable, mode 0700 for keyring directory)

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,49 @@
+# Security Review Rules
+
+## Pre-Commit Security Checklist
+
+Before approving or completing any code change, verify:
+
+- No hardcoded secrets, private keys, mnemonics, or RPC endpoints
+- No logging of sensitive data (private keys, validator key material, keyring contents)
+- All external inputs validated before use (L1 receipts, event logs, RPC responses)
+- Nonce/sequence checks present for replay protection
+- Error messages do not leak internal state or validator identity
+- New dependencies audited for known CVEs (`govulncheck ./...`)
+- Tests pass with `-race` flag to detect data races
+
+## Secret Management
+
+- Secrets come from environment variables or keyring, never from source code
+- Config files with secrets must be in `.gitignore`
+- Never log private keys, mnemonics, keyring passphrases, or signing material at any log level
+- Checkpoint signatures and vote extension payloads may be logged at Debug level only
+
+## Go Security Patterns
+
+- Use `crypto/rand` for all randomness, never `math/rand` in any security-relevant code
+- Never use the `unsafe` package in consensus or crypto paths
+- Bound all loops and slices that process external data (vote extensions, event logs, validator lists) -- unbounded input causes OOM/DoS
+- Use `context.WithTimeout` for all RPC calls to L1 and Bor
+- Check `err != nil` immediately after every call -- do not defer error handling
+- Use `math.Int` (from `cosmossdk.io/math`) for all arithmetic involving token amounts or voting power -- `sdk.Int` is deprecated in Cosmos SDK v0.50, and native `int64`/`uint64` overflow silently
+- Guard against log injection: external data in log messages can contain newlines that forge log entries -- use structured logging (zerolog fields), not string interpolation
+- Protect against nil pointer dereference in all paths that handle RPC responses, proto messages, or interface values -- panics in ABCI handlers crash the node
+
+## Dependency Security
+
+- Forked dependencies (`cosmos-sdk`, `cometbft`, `bor`) must pin to exact commit hashes via `replace` directives in `go.mod`
+- Run `go mod verify` to ensure module checksums match
+- Run `govulncheck ./...` to check for known vulnerabilities
+- Review `go.sum` changes in every PR -- unexpected checksum changes indicate supply chain risk
+- Verify that `replace` directives point to the expected 0xPolygon fork repositories, not third-party forks
+
+## Security Response Protocol
+
+When a security issue is found during review:
+
+1. **STOP** -- do not continue with the change
+2. Classify severity: CRITICAL (consensus break, fund loss), HIGH (validator manipulation, DoS), MEDIUM (info leak, degraded security), LOW (hardening opportunity)
+3. For CRITICAL/HIGH: flag immediately, do not merge, recommend fix before any other work
+4. Check the entire codebase for similar patterns
+5. If secrets were exposed: rotate immediately, check git history with `git log -p --all -S 'SECRET_VALUE'`

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,5 +1,23 @@
 # Security Review Rules
 
+## Threat Model -- External vs Self-Inflicted
+
+When classifying severity, always consider **who can trigger the bug**:
+
+| Attacker | Example | Severity Multiplier |
+|---|---|---|
+| **External user/tx submitter** | Crafted transaction crashes all validators | **Highest** -- anyone can attack, no permissions needed |
+| **Malicious validator/proposer** | Proposal with crafted VEs triggers panic in ProcessProposal on all honest nodes | **Critical** -- 1 of ~100 validators can halt the chain |
+| **Malicious RPC provider** | Fabricated L1 responses cause wrong side-tx votes | **High** -- trusted dependency, but external |
+| **Adjacent service** | RabbitMQ message injection forges bridge events | **High** -- requires network access |
+| **Malicious peer** | Eclipse attack, gossip flooding | **High** -- any P2P participant |
+| **Node misconfiguration** | Wrong chain ID, bad RPC URL | **Lower** -- operator error, self-inflicted |
+| **Code bug (no external trigger)** | Race condition, memory leak | **Lower** -- affects only the buggy node |
+
+**Key principle**: A bug that a single external actor (proposer, validator, user, peer) can trigger to crash/corrupt ALL honest nodes is always CRITICAL, regardless of how unlikely the scenario seems. A bug that only affects the node running the bad code is lower severity.
+
+When reviewing, ask: **"Can someone else make my node do this?"** If yes, severity goes up.
+
 ## Pre-Commit Security Checklist
 
 Before approving or completing any code change, verify:
@@ -43,7 +61,11 @@ Before approving or completing any code change, verify:
 When a security issue is found during review:
 
 1. **STOP** -- do not continue with the change
-2. Classify severity: CRITICAL (consensus break, fund loss), HIGH (validator manipulation, DoS), MEDIUM (info leak, degraded security), LOW (hardening opportunity)
+2. Classify severity using both impact AND attacker model:
+   - **CRITICAL**: externally triggerable consensus break or fund loss (malicious proposer/validator/user can halt chain or steal funds)
+   - **HIGH**: externally triggerable DoS or validator manipulation (malicious peer/RPC/queue can degrade network)
+   - **MEDIUM**: self-inflicted consensus risk or externally triggerable info leak
+   - **LOW**: self-inflicted degradation, hardening opportunity
 3. For CRITICAL/HIGH: flag immediately, do not merge, recommend fix before any other work
 4. Check the entire codebase for similar patterns
 5. If secrets were exposed: rotate immediately, check git history with `git log -p --all -S 'SECRET_VALUE'`

--- a/.claude/rules/state-and-migration.md
+++ b/.claude/rules/state-and-migration.md
@@ -13,6 +13,12 @@ paths:
 
 Changes to shared types, state migration, and proto definitions can silently corrupt chain state or break consensus across validators running different versions.
 
+## External Attack Vectors
+
+- **Malicious tx submitter** (anyone): crafts messages with fields that exploit `ValidateBasic()` gaps -- zero-value addresses, maximum-length strings, negative amounts that wrap unsigned, or proto messages with unexpected `oneof` variants. If these reach keepers and corrupt state, all nodes are affected.
+- **Governance attacker** (validator coalition): proposes param changes that set critical values to zero (span duration, checkpoint interval, min stake) or extremes, triggering division-by-zero panics or infinite loops in ABCI handlers. Params without bounds validation are exploitable.
+- **Upgrade-time attacker**: if a migration has a non-deterministic bug, the attacker waits for the upgrade height and submits transactions that exercise the buggy path, causing some validators to produce different post-migration state than others -- splitting the network.
+
 ## State Migration
 
 - Migrations must be deterministic -- all validators must produce identical post-migration state from identical pre-migration state

--- a/.claude/rules/state-and-migration.md
+++ b/.claude/rules/state-and-migration.md
@@ -1,0 +1,76 @@
+---
+paths:
+  - "migration/**/*.go"
+  - "types/**/*.go"
+  - "common/**/*.go"
+  - "proto/**/*.proto"
+  - "x/*/types/**/*.go"
+  - "x/*/module.go"
+  - "app/app.go"
+---
+
+# State, Types & Migration Security Review
+
+Changes to shared types, state migration, and proto definitions can silently corrupt chain state or break consensus across validators running different versions.
+
+## State Migration
+
+- Migrations must be deterministic -- all validators must produce identical post-migration state from identical pre-migration state
+- Never delete or rename store keys without a migration path from the old key -- orphaned data silently persists and new keys start empty
+- Test migrations against real chain state exports (not just genesis) -- production state has edge cases genesis doesn't
+- Verify migration order: module migrations run in the order set by `SetOrderMigrations()` in `app.go`. If not explicitly set, defaults to module registration order -- implicit ordering is fragile.
+- Off-by-one errors in block height migration triggers can skip or double-apply migrations -- verify the exact upgrade height
+- Migrations that fail midway leave the store in a partially migrated state -- consider writing a migration version marker before and after to detect incomplete migrations
+- State migrations run during `InitChainer` on upgrade -- they block the chain until complete. Estimate runtime for large state sets.
+
+## Store Keys and Module Accounts
+
+- Adding new store keys requires registration in `app.go` (`KVStoreKeys`) -- missing keys cause panics at runtime, not compile time
+- Each module must use a unique store key prefix -- KV prefix collisions between modules silently overwrite each other's data
+- Module accounts (e.g., for fee collection, staking pool) hold real tokens. Verify:
+  - Only the owning module can mint/burn from its module account
+  - Module account permissions (`Minter`, `Burner`, `Staking`) match intended behavior
+  - No code path allows unauthorized transfers from module accounts
+
+## Proto Definitions
+
+- Never change field numbers in existing proto messages -- this silently breaks decoding of stored state and network messages
+- Never remove fields -- mark as `reserved` with both the field number and name
+- Adding new fields is safe only if all consumers handle the zero value correctly (empty string, 0, nil)
+- `oneof` fields: adding a new variant is safe, but changing or removing existing variants breaks decoding
+- Proto changes require `make proto-all` and verification that generated Go code compiles and tests pass
+- Enum values must never be reordered or renumbered -- add new values at the end only
+- `google.protobuf.Any` fields: verify the type URL is validated on unmarshal to prevent type confusion attacks
+
+## Shared Types (`types/`, `x/*/types/`)
+
+- Changes to message types affect wire encoding -- all validators must agree on serialization. A mismatch causes the chain to fork.
+- Validate all new message fields in `ValidateBasic()` -- this is the first line of defense before messages reach keepers
+- `ValidateBasic()` must be pure (no state access, no external calls) and deterministic
+- Events and error types must not leak sensitive validator information (private key material, internal IP addresses)
+- Genesis import/export must be round-trip safe: `export -> import` produces identical state. Test this explicitly.
+- Custom Amino registrations (if any remain) must match Protobuf definitions -- Cosmos SDK v0.50 uses Protobuf for state storage, but Amino may still be used for legacy signing in some paths. Encoding mismatches between Amino and Protobuf are consensus-breaking.
+
+## Common Utilities (`common/`)
+
+- Cache invalidation bugs can serve stale data to consensus-critical code paths -- if a cache is used in a keeper, verify invalidation happens at the correct block boundaries (epoch, span, checkpoint interval)
+- Hex encoding/decoding must handle edge cases: odd-length strings, `0x` prefix vs no prefix, empty input, mixed case
+- Tracing context propagation must not affect determinism -- trace IDs must not be included in state hashes or consensus messages
+- String utility functions used on external data must handle malformed UTF-8 and control characters
+
+## Governance Parameter Changes
+
+- Some module params can be changed via governance proposals at runtime -- verify that all param values are bounds-checked
+- Critical params (checkpoint interval, span duration, minimum stake, voting power thresholds) must have min/max bounds to prevent governance attacks
+- Param changes that affect consensus must be applied at epoch/span boundaries, not mid-block
+
+## Red Flags
+
+- Changing proto field numbers or removing fields without `reserved`
+- Migrations without state verification (compare pre/post state roots)
+- Shared type changes without updating `ValidateBasic()`
+- Cache changes without considering consensus determinism
+- New store keys not registered in `app.go`
+- Module account permission changes without thorough review
+- Missing round-trip test for genesis import/export after type changes
+- Governance-changeable params without bounds validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,41 @@ x/<module>/
    go test -v ./path/to/package
    ```
 
+## Security Review
+
+Security rules are in `.claude/rules/`. They load automatically based on which files are being edited:
+
+- **`security.md`** -- always active: pre-commit checklist, Go security patterns, dependency checks
+- **`consensus-critical.md`** -- `app/`, `sidetxs/`, `x/checkpoint/`, `x/milestone/`, `x/bor/`: determinism, vote extension integrity, tallying thresholds
+- **`cross-chain.md`** -- `bridge/`, `helper/`, `contracts/`, `x/stake/`, `x/topup/`, `x/clerk/`, `x/chainmanager/`: L1 receipt validation, nonce replay, event log verification
+- **`contract-interactions.md`** -- `helper/call.go`, `helper/tx.go`, `contracts/`, `x/bor/grpc/`, keepers, bridge processors: IContractCaller security, ABI encoding, tx construction, gRPC client
+- **`p2p-and-networking.md`** -- `helper/config.go`, `bridge/listener/`, `bridge/broadcaster/`, `cmd/`, `packaging/templates/`: CometBFT P2P config, RPC endpoint security, bridge networking, RabbitMQ
+- **`state-and-migration.md`** -- `migration/`, `types/`, `common/`, `proto/`, `x/*/types/`: state migration safety, proto compatibility, shared type integrity
+
+### Security-Critical Areas (ranked by impact)
+
+1. **ABCI++ handlers** (`app/abci.go`, `app/vote_ext_utils.go`) -- consensus break, chain halt
+2. **Vote extension tallying** -- forged approvals, unauthorized state changes
+3. **L1 receipt validation** (`helper/call.go`) -- fake validator joins, stolen funds
+4. **Staking nonce checks** (`x/stake/keeper/side_msg_server.go`) -- replay attacks
+5. **Checkpoint verification** (`x/checkpoint/keeper/side_msg_server.go`) -- forged checkpoints
+6. **Bridge event processing** (`bridge/`) -- state sync corruption
+
+### When to Trigger Security Review
+
+- Any change to files matched by `consensus-critical.md` or `cross-chain.md`
+- New RPC endpoints or API handlers
+- Dependency updates (especially forked `cosmos-sdk`, `cometbft`, `bor`)
+- Changes to validation logic, threshold calculations, or signature verification
+- Any change touching `helper/call.go` (the L1 interface)
+
 ## Before Making Changes
 
 1. **Identify impact**: What other modules or components depend on this code?
 2. **Plan implementation**: Outline the approach before writing code
 3. **Plan testing**: How will you verify correctness? What edge cases exist?
 4. **Check for breaking changes**: Will this affect APIs, proto definitions, or stored state?
+5. **Check security implications**: Does this touch consensus, cross-chain, or validator logic? See `.claude/rules/`
 
 ## Common Pitfalls
 


### PR DESCRIPTION
# Description

Add `.claude/rules/` directory with 6 path-specific security rule files and update `CLAUDE.md` to guide AI agents (Claude Code) during security-sensitive code reviews. The rules encode heimdall-v2-specific domain knowledge: ABCI++ handler semantics, vote extension integrity, cross-chain receipt validation, smart contract interaction patterns, P2P/bridge networking, and state migration safety.

Each rule file activates automatically when Claude works with matching files, providing contextual security guidance without manual invocation. Rules include external attack vector threat models classifying severity by attacker type (malicious proposer/validator/user/peer/RPC) vs self-inflicted bugs.

**Files added:**
- `.claude/rules/security.md` — always active: threat model, pre-commit checklist, Go security patterns
- `.claude/rules/consensus-critical.md` — `app/`, `sidetxs/`, `x/**/keeper/*.go`: determinism, ABCI++ semantics, vote extensions, app hash mismatch prevention
- `.claude/rules/cross-chain.md` — `bridge/`, `helper/`, `x/stake/`, `x/clerk/`, `x/topup/`: L1 receipt validation, nonce replay, event log verification
- `.claude/rules/contract-interactions.md` — `helper/call.go`, `helper/tx.go`, `contracts/`, `x/bor/grpc/`: IContractCaller security, ABI encoding, tx construction
- `.claude/rules/p2p-and-networking.md` — `bridge/listener/`, `bridge/broadcaster/`, `cmd/`: CometBFT P2P, RPC security, RabbitMQ, bridge networking
- `.claude/rules/state-and-migration.md` — `migration/`, `types/`, `proto/`, `x/*/types/`: state migration, proto compatibility, module accounts, governance params

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Rules validated by running a full AI-assisted security review of the heimdall-v2 codebase using the created rules. The review identified 8 CRITICAL, 12 HIGH, and 14 MEDIUM findings across ABCI handlers, contract interactions, staking, and bridge components.

# Additional comments

These rules are for AI agent guidance only (`.claude/rules/`). They do not affect build, runtime, or tests. No code logic changes.