### PR TITLE
fix: HeimdallListener stuck on pruned snapshot nodes

### DIFF
--- a/bridge/listener/heimdall.go
+++ b/bridge/listener/heimdall.go
@@ -160,6 +160,14 @@ func (hl *HeimdallListener) fetchFromAndToBlock(ctx context.Context) (uint64, ui
 		}
 	}
 
+	// Clamp fromBlock to the node's earliest available block (this handles pruned snapshots)
+	earliestBlock := uint64(nodeStatus.SyncInfo.EarliestBlockHeight)
+	if earliestBlock > 0 && fromBlock < earliestBlock {
+		hl.Logger.Info("HeimdallListener: fromBlock is before the node's earliest available block, skipping ahead",
+			"fromBlock", fromBlock, "earliestBlock", earliestBlock)
+		fromBlock = earliestBlock
+	}
+
 	// toBlock - get the latest block height from heimdall node
 	toBlock := uint64(nodeStatus.SyncInfo.LatestBlockHeight)
 	if toBlock <= fromBlock {

--- a/bridge/listener/heimdall_test.go
+++ b/bridge/listener/heimdall_test.go
@@ -546,6 +546,66 @@ func TestHeimdallListener_EdgeCases(t *testing.T) {
 	})
 }
 
+func TestHeimdallListener_EarliestBlockClamping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clamps fromBlock to earliestBlock when node has pruned", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name             string
+			fromBlock        uint64
+			earliestBlock    uint64
+			expectedFromBlock uint64
+		}{
+			{
+				name:              "fromBlock before earliest, should clamp",
+				fromBlock:         100,
+				earliestBlock:     5000,
+				expectedFromBlock: 5000,
+			},
+			{
+				name:              "fromBlock equal to earliest, no clamp",
+				fromBlock:         5000,
+				earliestBlock:     5000,
+				expectedFromBlock: 5000,
+			},
+			{
+				name:              "fromBlock after earliest, no clamp",
+				fromBlock:         10000,
+				earliestBlock:     5000,
+				expectedFromBlock: 10000,
+			},
+			{
+				name:              "earliestBlock is zero (non-pruned node), no clamp",
+				fromBlock:         100,
+				earliestBlock:     0,
+				expectedFromBlock: 100,
+			},
+			{
+				name:              "earliestBlock is 1 (genesis), fromBlock before",
+				fromBlock:         0,
+				earliestBlock:     1,
+				expectedFromBlock: 1,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				fromBlock := tc.fromBlock
+				earliestBlock := tc.earliestBlock
+
+				// This mirrors the logic in fetchFromAndToBlock
+				if earliestBlock > 0 && fromBlock < earliestBlock {
+					fromBlock = earliestBlock
+				}
+
+				require.Equal(t, tc.expectedFromBlock, fromBlock)
+			})
+		}
+	})
+}
+
 func TestHeimdallListener_BlockRangeCalculations(t *testing.T) {
 	t.Parallel()
 

--- a/helper/query.go
+++ b/helper/query.go
@@ -50,58 +50,54 @@ func QueryTxWithProof(cliCtx cosmosContext.Context, hash []byte) (*ctypes.Result
 
 // GetBeginBlockEvents get block through per height
 func GetBeginBlockEvents(ctx context.Context, client *httpClient.HTTP, height int64) ([]abci.Event, error) {
-	var events []abci.Event
-	var err error
-
 	c, cancel := context.WithTimeout(ctx, CommitTimeout)
 	defer cancel()
 
-	// get block using the client
+	// Try to get block results directly
 	blockResults, err := client.BlockResults(c, &height)
 	if err == nil && blockResults != nil {
-		events = blockResults.FinalizeBlockEvents
-		return events, nil
+		return blockResults.FinalizeBlockEvents, nil
 	}
 
-	// subscriber
-	subscriber := fmt.Sprintf("new-block-%v", height)
+	// Only fallthrough to subscription if the block hasn't been committed yet.
+	// Otherwise, return the BlockResults error.
+	// Subscribing for an already-committed block (e.g., block pruned) would time out.
+	latestStatus, statusErr := client.Status(c)
+	if statusErr != nil || latestStatus == nil || height <= latestStatus.SyncInfo.LatestBlockHeight {
+		return nil, fmt.Errorf("BlockResults failed for block %d (possibly pruned or unavailable): %w", height, err)
+	}
 
-	// query for event
+	// Block is in the future, subscribe and wait for it
+	subscriber := fmt.Sprintf("new-block-%v", height)
 	query := cmtTypes.QueryForEvent(cmtTypes.EventNewBlock).String()
 
-	// register for the next event of this type
-	eventCh, err := client.Subscribe(c, subscriber, query)
-	if err != nil {
-		return events, errors.Wrap(err, "failed to subscribe")
+	eventCh, subscribeErr := client.Subscribe(c, subscriber, query)
+	if subscribeErr != nil {
+		return nil, errors.Wrap(subscribeErr, "failed to subscribe")
 	}
 
-	// unsubscribe query
 	defer func() {
-		if unsubscribeErr := client.Unsubscribe(c, subscriber, query); unsubscribeErr != nil && err == nil {
-			err = unsubscribeErr
-			events = nil // Set events to nil when returning an error
+		if unsubscribeErr := client.Unsubscribe(c, subscriber, query); unsubscribeErr != nil {
+			Logger.Error("GetBeginBlockEvents: error unsubscribing", "error", unsubscribeErr)
 		}
 	}()
 
 	for {
 		select {
 		case event := <-eventCh:
-			eventData := event.Data
-			switch t := eventData.(type) {
+			switch t := event.Data.(type) {
 			case cmtTypes.EventDataNewBlock:
 				if t.Block.Height == height {
-					events = t.ResultFinalizeBlock.GetEvents()
-					return events, err
+					return t.ResultFinalizeBlock.GetEvents(), nil
 				}
 			default:
 				Logger.Error("GetBeginBlockEvents", "unexpected event type", fmt.Sprintf("%+v", t))
-				return events, fmt.Errorf("unexpected event type: %T", t)
+				return nil, fmt.Errorf("unexpected event type: %T", t)
 			}
 		case <-ctx.Done():
-			// Parent context canceled - return immediately
-			return events, ctx.Err()
+			return nil, ctx.Err()
 		case <-c.Done():
-			return events, errors.New("timed out waiting for event")
+			return nil, errors.New("timed out waiting for event")
 		}
 	}
 }

--- a/helper/query_test.go
+++ b/helper/query_test.go
@@ -1,0 +1,169 @@
+package helper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httpClient "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/stretchr/testify/require"
+)
+
+// jsonRPCRequest mirrors the CometBFT JSON-RPC request format for parsing in tests.
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// jsonRPCResponse is the JSON-RPC response format expected by the CometBFT client.
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    string `json:"data,omitempty"`
+}
+
+func writeJSONRPC(w http.ResponseWriter, resp jsonRPCResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func errorResp(id json.RawMessage, code int, msg string) jsonRPCResponse {
+	return jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &jsonRPCError{Code: code, Message: msg},
+	}
+}
+
+func resultResp(id json.RawMessage, rawJSON string) jsonRPCResponse {
+	return jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  json.RawMessage(rawJSON),
+	}
+}
+
+func TestGetBeginBlockEvents_BlockResultsSuccess(t *testing.T) {
+	t.Parallel()
+
+	blockResultJSON := `{
+		"height": "100",
+		"finalize_block_events": [
+			{
+				"type": "test-event",
+				"attributes": [
+					{"key": "key1", "value": "value1", "index": false}
+				]
+			}
+		]
+	}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "block_results":
+			writeJSONRPC(w, resultResp(req.ID, blockResultJSON))
+		default:
+			writeJSONRPC(w, errorResp(req.ID, -32601, fmt.Sprintf("method %s not found", req.Method)))
+		}
+	}))
+	defer ts.Close()
+
+	client, err := httpClient.New(ts.URL, "/websocket")
+	require.NoError(t, err)
+
+	events, err := GetBeginBlockEvents(context.Background(), client, 100)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, "test-event", events[0].Type)
+	require.Equal(t, "key1", events[0].Attributes[0].Key)
+	require.Equal(t, "value1", events[0].Attributes[0].Value)
+}
+
+func TestGetBeginBlockEvents_BlockResultsFailsAndBlockCommitted(t *testing.T) {
+	t.Parallel()
+
+	// latest block height = 200 (block 100 already committed).
+	statusJSON := `{
+		"node_info": {"protocol_version": {"p2p": "0", "block": "0", "app": "0"}, "id": "", "listen_addr": "", "network": "", "version": "", "channels": "", "moniker": "", "other": {"tx_index": "", "rpc_address": ""}},
+		"sync_info": {"latest_block_hash": "", "latest_app_hash": "", "latest_block_height": "200", "latest_block_time": "2024-01-01T00:00:00Z", "earliest_block_hash": "", "earliest_app_hash": "", "earliest_block_height": "1", "earliest_block_time": "2024-01-01T00:00:00Z", "catching_up": false},
+		"validator_info": {"address": "", "pub_key": {"type": "tendermint/PubKeyEd25519", "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}, "voting_power": "0"}
+	}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "block_results":
+			writeJSONRPC(w, errorResp(req.ID, -32603, "block results not available (pruned)"))
+		case "status":
+			writeJSONRPC(w, resultResp(req.ID, statusJSON))
+		default:
+			writeJSONRPC(w, errorResp(req.ID, -32601, fmt.Sprintf("method %s not found", req.Method)))
+		}
+	}))
+	defer ts.Close()
+
+	client, err := httpClient.New(ts.URL, "/websocket")
+	require.NoError(t, err)
+
+	// Block 100 was already committed (latest is 200), so this should return an error
+	// instead of falling through to subscription
+	events, err := GetBeginBlockEvents(context.Background(), client, 100)
+	require.Error(t, err)
+	require.Nil(t, events)
+	require.Contains(t, err.Error(), "BlockResults failed for block 100")
+	require.Contains(t, err.Error(), "possibly pruned or unavailable")
+}
+
+func TestGetBeginBlockEvents_BlockResultsFailsAndStatusFails(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		switch req.Method {
+		case "block_results":
+			writeJSONRPC(w, errorResp(req.ID, -32603, "block not found"))
+		case "status":
+			writeJSONRPC(w, errorResp(req.ID, -32603, "status unavailable"))
+		default:
+			writeJSONRPC(w, errorResp(req.ID, -32601, fmt.Sprintf("method %s not found", req.Method)))
+		}
+	}))
+	defer ts.Close()
+
+	client, err := httpClient.New(ts.URL, "/websocket")
+	require.NoError(t, err)
+
+	// When both BlockResults and Status fail, should return an error (not fall through to subscription)
+	events, err := GetBeginBlockEvents(context.Background(), client, 100)
+	require.Error(t, err)
+	require.Nil(t, events)
+	require.Contains(t, err.Error(), "BlockResults failed for block 100")
+}


### PR DESCRIPTION
# Description

On a node restored from a pruned snapshot, the bridge has no stored `heimdall-last-block`, so it falls back to the hardcoded value for the specific network (mainnet, testnet, devnet). If the snapshot's earliest block is ahead, `BlockResults` for a pruned block silently falls through to subscribing for a block that was committed blocks ago, times out after 2 minutes, and retries the same pruned block forever. To fix this, we clamp `fromBlock` to the node's earliest available block height in `fetchFromAndToBlock()`, so the Heimdall listener skips ahead instead of trying to query pruned blocks. This includes the fix to `GetBeginBlockEvents()` to return immediately when `BlockResults` fails for an already-committed block, instead of falling through to a 2-minute websocket subscription that can never succeed.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on the local environment
- [x] I have tested this code manually on a remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli