### PR TITLE
go: bump go version to fix govuln

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.25.7
+  go: 1.25.8
   tests: true
 linters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/0xPolygon/heimdall-v2
 
 // Note: Change the go image version in Dockerfile if you change this.
-go 1.25.7
+go 1.25.8
 
 require (
 	cosmossdk.io/api v0.7.5


### PR DESCRIPTION
# Description

Bump go version to fix some govuln issues.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least two reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments — if any — by pushing each fix in a separate commit and linking the commit hash in the comment reply