### PR TITLE
bridge: context-aware sleeps and deterministic test

### DIFF
--- a/bridge/listener/rootchain_selfheal.go
+++ b/bridge/listener/rootchain_selfheal.go
@@ -264,6 +264,13 @@ func (rl *RootChainListener) processStateSynced(ctx context.Context) {
 
 	const maxRetriesPerState = 3
 
+	sleepTimer := time.NewTimer(0)
+	if !sleepTimer.Stop() {
+		<-sleepTimer.C
+	}
+
+	defer sleepTimer.Stop()
+
 	for i := latestPolygonStateId.Int64() + 1; i <= latestEthereumStateId.Int64(); i++ {
 		if _, err = util.GetClerkEventRecord(i, rl.cliCtx.Codec); err == nil {
 			rl.Logger.Info("Self-healing: state ID already synced on Heimdall; skipping", "stateId", i)
@@ -298,8 +305,10 @@ func (rl *RootChainListener) processStateSynced(ctx context.Context) {
 				break
 			}
 
+			sleepTimer.Reset(1 * time.Second)
+
 			select {
-			case <-time.After(1 * time.Second):
+			case <-sleepTimer.C:
 			case <-ctx.Done():
 				return
 			}
@@ -313,8 +322,10 @@ func (rl *RootChainListener) processStateSynced(ctx context.Context) {
 					break
 				}
 				rl.Logger.Info("Self-healing: stateId not yet found on Heimdall; retrying", "stateId", i)
+				sleepTimer.Reset(1 * time.Second)
+
 				select {
-				case <-time.After(1 * time.Second):
+				case <-sleepTimer.C:
 				case <-ctx.Done():
 					return
 				}

--- a/bridge/listener/rootchain_selfheal.go
+++ b/bridge/listener/rootchain_selfheal.go
@@ -298,7 +298,11 @@ func (rl *RootChainListener) processStateSynced(ctx context.Context) {
 				break
 			}
 
-			time.Sleep(1 * time.Second)
+			select {
+			case <-time.After(1 * time.Second):
+			case <-ctx.Done():
+				return
+			}
 
 			var confirmed bool
 
@@ -309,7 +313,11 @@ func (rl *RootChainListener) processStateSynced(ctx context.Context) {
 					break
 				}
 				rl.Logger.Info("Self-healing: stateId not yet found on Heimdall; retrying", "stateId", i)
-				time.Sleep(1 * time.Second)
+				select {
+				case <-time.After(1 * time.Second):
+				case <-ctx.Done():
+					return
+				}
 			}
 
 			if confirmed {

--- a/bridge/processor/checkpoint.go
+++ b/bridge/processor/checkpoint.go
@@ -116,6 +116,9 @@ type CheckpointProcessor struct {
 	// noAckInProgress prevents overlapping handleCheckpointNoAck goroutines
 	noAckInProgress atomic.Bool
 
+	// noAckSkipCount tracks how many times a tick was skipped because noAckInProgress was true (used in tests)
+	noAckSkipCount atomic.Uint64
+
 	// RootChain abi
 	rootChainAbi *abi.ABI
 }
@@ -172,6 +175,7 @@ func (cp *CheckpointProcessor) startPollingForNoAck(ctx context.Context, interva
 		case <-ticker.C:
 			if !cp.noAckInProgress.CompareAndSwap(false, true) {
 				cp.Logger.Debug("CheckpointProcessor: skipping no-ack check, previous run still in progress")
+				cp.noAckSkipCount.Add(1)
 				continue
 			}
 

--- a/bridge/processor/checkpoint_test.go
+++ b/bridge/processor/checkpoint_test.go
@@ -114,7 +114,9 @@ func TestCheckpointProcessor_NoAckGuard(t *testing.T) {
 		}()
 
 		// Wait for at least one tick to be processed (the skip path)
-		time.Sleep(50 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			return cp.noAckInProgress.Load()
+		}, 2*time.Second, 10*time.Millisecond, "expected at least one tick to fire")
 		cancel()
 
 		select {

--- a/bridge/processor/checkpoint_test.go
+++ b/bridge/processor/checkpoint_test.go
@@ -113,10 +113,10 @@ func TestCheckpointProcessor_NoAckGuard(t *testing.T) {
 			cp.startPollingForNoAck(ctx, 20*time.Millisecond)
 		}()
 
-		// Wait for at least one tick to be processed (the skip path)
+		// Wait for at least one tick to hit the skip path
 		require.Eventually(t, func() bool {
-			return cp.noAckInProgress.Load()
-		}, 2*time.Second, 10*time.Millisecond, "expected at least one tick to fire")
+			return cp.noAckSkipCount.Load() > 0
+		}, 2*time.Second, 10*time.Millisecond, "expected at least one tick to fire and be skipped")
 		cancel()
 
 		select {


### PR DESCRIPTION
# Description

Follow-up to PR #560, containing the following improvements: 

- `bridge/listener/rootchain_selfheal.go`: Replace `time.Sleep` calls with `select` on `time.After` and `ctx.Done()`, so the self-heal loop exits promptly on shutdown instead of blocking.
- `bridge/processor/checkpoint_test.go`: Replace flaky `time.Sleep(50ms)` with `require.Eventually`, making the test deterministic.