### PR TITLE
fix(logs): enable millisecond-precision timestamps in heimdall logs

### DIFF
--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -2,7 +2,6 @@ package heimdalld
 
 import (
 	"os"
-	"time"
 
 	"cosmossdk.io/log"
 	"github.com/cometbft/cometbft/cmd/cometbft/commands"
@@ -137,11 +136,12 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			logNoColor := serverCtx.Viper.GetBool(flags.FlagLogNoColor)
-			// Store timestamps with sub-second precision so that log lines carry
-			// millisecond granularity. Without this, zerolog stores the Unix
-			// timestamp as RFC3339 (second precision) before the ConsoleWriter
-			// ever gets a chance to format it, resulting in second-only output.
-			zerolog.TimeFieldFormat = time.RFC3339Nano
+			// Store timestamps with millisecond precision so that log lines carry
+			// sub-second granularity. Without this, zerolog stores the timestamp
+			// as RFC3339 (second precision) before the ConsoleWriter ever gets a
+			// chance to format it, resulting in second-only output.
+			// Using 3 decimal places ("000") matches bor's log timestamp format.
+			zerolog.TimeFieldFormat = "2006-01-02T15:04:05.000Z07:00"
 			var logOpts []log.Option
 			if serverCtx.Viper.GetString(flags.FlagLogFormat) == flags.OutputFormatJSON {
 				logOpts = append(logOpts, log.OutputJSONOption())
@@ -150,7 +150,7 @@ func NewRootCmd() *cobra.Command {
 			}
 			logOpts = append(logOpts,
 				log.LevelOption(logLevel),
-				log.TimeFormatOption(time.RFC3339Nano),
+				log.TimeFormatOption("2006-01-02T15:04:05.000Z07:00"),
 			)
 
 			serverCtx.Logger = log.NewLogger(cmd.OutOrStdout(), logOpts...).With(log.ModuleKey, "server")

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -137,6 +137,11 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			logNoColor := serverCtx.Viper.GetBool(flags.FlagLogNoColor)
+			// Store timestamps with sub-second precision so that log lines carry
+			// millisecond granularity. Without this, zerolog stores the Unix
+			// timestamp as RFC3339 (second precision) before the ConsoleWriter
+			// ever gets a chance to format it, resulting in second-only output.
+			zerolog.TimeFieldFormat = time.RFC3339Nano
 			var logOpts []log.Option
 			if serverCtx.Viper.GetString(flags.FlagLogFormat) == flags.OutputFormatJSON {
 				logOpts = append(logOpts, log.OutputJSONOption())

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -141,7 +141,7 @@ func NewRootCmd() *cobra.Command {
 			// as RFC3339 (second precision) before the ConsoleWriter ever gets a
 			// chance to format it, resulting in second-only output.
 			// Using 3 decimal places ("000") matches bor's log timestamp format.
-			zerolog.TimeFieldFormat = "2006-01-02T15:04:05.000Z07:00"
+			zerolog.TimeFieldFormat = helper.LogTimestampFormat
 			var logOpts []log.Option
 			if serverCtx.Viper.GetString(flags.FlagLogFormat) == flags.OutputFormatJSON {
 				logOpts = append(logOpts, log.OutputJSONOption())
@@ -150,7 +150,7 @@ func NewRootCmd() *cobra.Command {
 			}
 			logOpts = append(logOpts,
 				log.LevelOption(logLevel),
-				log.TimeFormatOption("2006-01-02T15:04:05.000Z07:00"),
+				log.TimeFormatOption(helper.LogTimestampFormat),
 			)
 
 			serverCtx.Logger = log.NewLogger(cmd.OutOrStdout(), logOpts...).With(log.ModuleKey, "server")

--- a/helper/config.go
+++ b/helper/config.go
@@ -368,7 +368,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	}
 	logOpts = append(logOpts,
 		logger.LevelOption(logLevel),
-		logger.TimeFormatOption(time.RFC3339Nano),
+		logger.TimeFormatOption("2006-01-02T15:04:05.000Z07:00"),
 	)
 
 	Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logOpts...)

--- a/helper/config.go
+++ b/helper/config.go
@@ -93,6 +93,11 @@ const (
 
 	DefaultMilestonePollInterval = 30 * time.Second
 
+	// LogTimestampFormat is the millisecond-precision timestamp layout used for
+	// all heimdall log output. Matches bor's log format for consistent
+	// cross-service log analysis.
+	LogTimestampFormat = "2006-01-02T15:04:05.000Z07:00"
+
 	// Self-healing defaults
 
 	DefaultEnableSH                = false
@@ -368,7 +373,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 	}
 	logOpts = append(logOpts,
 		logger.LevelOption(logLevel),
-		logger.TimeFormatOption("2006-01-02T15:04:05.000Z07:00"),
+		logger.TimeFormatOption(LogTimestampFormat),
 	)
 
 	Logger = logger.NewLogger(GetLogsWriter(conf.Custom.LogsWriterFile), logOpts...)


### PR DESCRIPTION
## Problem

Heimdall log lines carry only second-precision timestamps, e.g.:

```
2026-03-25T21:07:40Z INF Milestone stored successfully endBlock=84676411 ...
```

This makes it impossible to accurately measure sub-second timing between milestone events without relying on the Datadog ingestion timestamp — which carries a variable delay and is not a reliable high-resolution event marker.

## Root cause

`zerolog.TimeFieldFormat` (a zerolog global) defaults to `time.RFC3339`, which has second-level precision. This global controls how the timestamp is **stored** in the zerolog event before the `ConsoleWriter` ever formats it. `TimeFormatOption(time.RFC3339Nano)` was already set for the ConsoleWriter display layer, but the stored value only carried second granularity — so the displayed timestamp was always truncated to the second regardless of display format.

## Fix

Set `zerolog.TimeFieldFormat` to a fixed 3-decimal-place millisecond format (`"2006-01-02T15:04:05.000Z07:00"`) before logger construction, and apply the same format to `TimeFormatOption`. This makes all log lines emit millisecond-precision timestamps that are consistent with bor's log format:

```
2026-03-26T13:54:28.593Z INF Generated a new milestone proposition ...
2026-03-26T13:54:28.793Z INF 2/3rd majority reached on milestone proposition ...
2026-03-26T13:54:28.793Z INF Milestone stored successfully ...
```

## Motivation

The change is driven by block-finality latency analysis. The key heimdall events being timed are:

- `Generated a new milestone proposition` — proposal phase (T2)
- `2/3rd majority reached on milestone proposition` — consensus achieved (T3)
- `Milestone stored successfully` — finality committed (T4)

With second precision, derived latencies have ±500ms noise per step. With millisecond precision, inter-event timing becomes accurate enough to identify the dominant bottleneck in the finality pipeline (CometBFT consensus round duration, validator nil-vote behavior) without relying on Datadog ingestion timestamps.

Milliseconds (3 decimal places) were chosen over nanoseconds to match bor's existing log timestamp format, keeping both services consistent for cross-service log analysis.

## Validation

Tested on a local kurtosis devnet — confirmed all three milestone log events carry millisecond-precision timestamps after the fix.