### PR TITLE
docs, .claude: add height-gated rollout review guidance

### DIFF
--- a/.claude/rules/hardfork-rollout.md
+++ b/.claude/rules/hardfork-rollout.md
@@ -1,0 +1,89 @@
+---
+paths:
+  - "helper/config.go"
+  - "app/**/*.go"
+  - "sidetxs/**/*.go"
+  - "x/**/keeper/*.go"
+  - "x/milestone/abci/**/*.go"
+  - "x/*/module.go"
+  - "x/*/types/**/*.go"
+  - "migration/**/*.go"
+  - "types/**/*.go"
+  - "proto/**/*.proto"
+  - "common/**/*.go"
+---
+# Hardfork Rollout Review
+
+Heimdall hardforks and height-gated behavior changes are consensus-critical.
+They affect validator agreement, app hash, Bor coordination, checkpointing,
+milestones, spans, side transactions, or store migrations. Review them as
+rollout wiring changes, not isolated code edits.
+
+## Trigger Conditions
+
+Apply this rule whenever a change:
+
+- Adds or changes a hardfork height, named network height, or config getter in
+  `helper/config.go`.
+- Gates ABCI behavior, side/post handlers, keeper writes, milestone logic,
+  checkpoint logic, span selection, validator-set updates, or vote extension
+  behavior by height.
+- Changes module `ConsensusVersion`, migrations, store keys, proto state,
+  genesis import/export, or replay behavior for existing chain state.
+- Introduces Bor/Heimdall coordination logic where a Heimdall height maps to a
+  Bor block, span, sprint, milestone, or checkpoint boundary.
+
+## Required Wiring
+
+For every new or changed fork, verify all of these surfaces before approving:
+
+- Mainnet, Amoy, and local/devnet values in `helper/config.go` are present,
+  named consistently, and intentionally different where needed.
+- Getters, setters, config structs, CLI/config loading, and tests all read the
+  same height. Avoid one path using a zero value while another path has the
+  intended network value.
+- ABCI handlers are symmetric: proposer-side filtering in `PrepareProposal`
+  must be validated by all validators in `ProcessProposal`; vote-extension
+  generation in `ExtendVote` must be matched by deterministic checks in
+  `VerifyVoteExtension`; deterministic writes belong in `PreBlocker` or
+  module keepers.
+- Height checks use the correct chain domain. Be explicit about Heimdall block
+  height, Bor block number, `height`, `height-1`, initial height, span start,
+  sprint start, milestone end, and checkpoint boundaries.
+- Module `ConsensusVersion`, migrations, store key registration, migration
+  order, proto generated code, and genesis export/import are updated together
+  when the fork changes stored state.
+- Existing chain state can replay through the fork. A fresh genesis-only test
+  is not enough for migrations or post-handler state changes.
+
+## Determinism Requirements
+
+- Deterministic paths must not use external RPC calls, wall clock time, random
+  data, goroutines, channel races, or unsorted map iteration.
+- `PrepareProposal` may be proposer-specific, but its output must be accepted
+  or rejected deterministically by `ProcessProposal` on every validator.
+- `VerifyVoteExtension`, `ProcessProposal`, `PreBlocker`, post-handlers, and
+  keeper writes must make identical decisions from identical inputs on every
+  validator.
+- Post-handler state changes that would alter the result of replaying old
+  blocks require explicit fork gating. Without the gate, upgraded validators
+  can produce a different app hash from the same historical block.
+
+## Rollout Checks
+
+- [ ] Does `git diff` show a new fork name, hardcoded height, or new
+      height-gated branch? If yes, list each network height and each runtime
+      path that loads it.
+- [ ] Are mainnet, Amoy, and devnet/local values wired through the same config
+      path, or is any network silently left at zero?
+- [ ] Are boundary tests present for `H-1`, `H`, and `H+1`, including any
+      Bor-block-to-Heimdall-height conversion?
+- [ ] If ABCI logic changed, do `PrepareProposal`, `ProcessProposal`,
+      `ExtendVote`, `VerifyVoteExtension`, and `PreBlocker` remain mutually
+      consistent?
+- [ ] If stored state changed, are `ConsensusVersion`, migrations, store keys,
+      proto definitions, generated code, and genesis import/export covered?
+- [ ] Is there a replay, migration, or app-hash-style test using pre-fork state
+      rather than only fresh genesis state?
+- [ ] During mixed-version rollout, is pre-fork behavior unchanged until the
+      activation height, and is rollback behavior understood before activation?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Security rules are in `.claude/rules/`. They load automatically based on which f
 - **`contract-interactions.md`** -- `helper/call.go`, `helper/tx.go`, `contracts/`, `x/bor/grpc/`, keepers, bridge processors: IContractCaller security, ABI encoding, tx construction, gRPC client
 - **`p2p-and-networking.md`** -- `helper/config.go`, `bridge/listener/`, `bridge/broadcaster/`, `cmd/`, `packaging/templates/`: CometBFT P2P config, RPC endpoint security, bridge networking, RabbitMQ
 - **`state-and-migration.md`** -- `migration/`, `types/`, `common/`, `proto/`, `x/*/types/`: state migration safety, proto compatibility, shared type integrity
+- **`hardfork-rollout.md`** -- `helper/config.go`, `app/`, `sidetxs/`, keepers, milestone ABCI, migrations, proto/state types: hardfork heights, height-gated consensus behavior, replay, migrations, ABCI symmetry
 
 #### Security-Critical Areas (ranked by impact)
 
@@ -123,6 +124,39 @@ Security rules are in `.claude/rules/`. They load automatically based on which f
 - Dependency updates (especially forked `cosmos-sdk`, `cometbft`, `bor`)
 - Changes to validation logic, threshold calculations, or signature verification
 - Any change touching `helper/call.go` (the L1 interface)
+- Any new or changed hardfork height, network-specific activation height, or
+  height-gated consensus behavior
+
+#### Standalone Hardfork and Height-Gated Rollout Review
+
+Even outside the PoS team workspace, treat hardforks and height-gated behavior
+changes as consensus-critical. A diff is hardfork-shaped if it adds or changes
+network heights in `helper/config.go`, ABCI behavior, vote-extension semantics,
+side/post handlers, keeper writes, milestone/checkpoint/span logic,
+validator-set behavior, module `ConsensusVersion`, store migrations, proto
+state, or genesis import/export.
+
+For every hardfork-shaped diff, explicitly verify:
+
+- Mainnet, Amoy, and local/devnet heights are all set intentionally in the same
+  runtime initialization path in `helper/config.go`.
+- Getters, setters, tests, and config loading all read the same height values.
+- A network is not silently left at `0` or TODO when the behavior should
+  activate at a specific height. Check each helper's zero semantics: for
+  example, `phuketHardforkHeight == 0` disables Phuket through the
+  `IsPhuketHardfork` guard, while a `*HeightMinus1` style gate such as
+  `height >= GetTallyFixHeight()-1` can make `0` active at block 1.
+- Off-by-one semantics are documented in tests: Heimdall height vs Bor block,
+  `height`, `height-1`, initial height, span boundary, milestone boundary, and
+  checkpoint boundary.
+- `PrepareProposal`, `ProcessProposal`, `VerifyVoteExtension`, `ExtendVote`,
+  and `PreBlocker` remain compatible. Proposer-only filtering is not enough;
+  validators must accept or reject proposals deterministically.
+- Deterministic paths contain no external RPC calls, wall-clock time, random
+  data, goroutine races, or unsorted map iteration.
+- State-shape changes update module `ConsensusVersion`, migrations, store keys,
+  proto generated code, genesis import/export, and replay tests from existing
+  state.
 
 ### Before Making Changes
 


### PR DESCRIPTION
## Summary

Adds standalone hardfork and height-gated rollout review guidance for Heimdall-v2.

Height-gated changes in Heimdall-v2 can affect ABCI behavior, vote extensions, side and post handlers, keeper writes, validator-set handling, milestones, checkpoints, migrations, proto/state schema, and replay from existing state. This PR
adds a path-scoped Claude rule plus repo-level AGENTS guidance so AI-assisted reviews can catch incomplete rollout wiring even when run directly inside this repository.

The guidance emphasizes network-specific activation heights, zero-height semantics (e.g. `phuketHardforkHeight == 0` disables Phuket via its `IsPhuketHardfork` guard, while a `*HeightMinus1` style gate such as `height >=
GetTallyFixHeight()-1` can make `0` active at block 1), ABCI handler symmetry, deterministic execution paths, migration / replay safety, and activation-boundary tests.

## What changed

- Added `.claude/rules/hardfork-rollout.md` with a path-scoped frontmatter that auto-loads on edits to `helper/config.go`, `app/`, `sidetxs/`, `x/**/keeper/`, `x/milestone/abci/`, `x/*/module.go`, `x/*/types/`, `migration/`, `types/`,
`proto/`, and `common/`.
- Added the new rule to the `AGENTS.md` security rules list.
- Added an explicit trigger to the `AGENTS.md` "When to Trigger Security Review" section for any new or changed hardfork height, network-specific activation height, or height-gated consensus behavior.
- Added a Standalone Hardfork and Height-Gated Rollout Review subsection to `AGENTS.md` so the guidance applies even when an AI agent is launched directly inside this repository, outside the PoS team workspace.
- Documented required checks for:
  - mainnet, Amoy, and local/devnet height wiring in `helper/config.go`
  - zero / TODO activation-height mistakes and gate-specific zero semantics
  - `height` vs `height-1` semantics
  - Heimdall height vs Bor block boundaries
  - `PrepareProposal`, `ProcessProposal`, `VerifyVoteExtension`, `ExtendVote`, and `PreBlocker` consistency (proposer-only filtering is not sufficient)
  - deterministic-path constraints (no external RPC, wall clock, randomness, goroutine races, or unsorted map iteration)
  - module `ConsensusVersion`, migrations, store keys, proto generated code, genesis import/export, and replay tests from pre-fork state
  - `H-1` / `H` / `H+1` activation-boundary test coverage

## Executed tests

Docs / rules-only change; no runtime code touched.

```bash
git diff --check
```

Also checked the updated markdown files for trailing whitespace.

The rule body was empirically validated by running fresh-context AI reviews against three historical hardfork-shaped PRs across bor and heimdall-v2. Each case was flagged at CRITICAL severity with concrete file:line evidence; per-case
verdicts and full findings live in the corresponding workspace PR.

## Rollout notes

No runtime behavior changes. This only affects repo-local AI guidance and review checklists.

Future hardfork or height-gated PRs should use this rule to verify activation heights, off-by-one behavior, deterministic ABCI execution, ABCI handler symmetry, replay from existing state, and migration / state-schema safety.

## Related PRs

- https://github.com/0xPolygon/pos-team-workspace/pull/2 - adds the corresponding workspace-level steering, the /pos-code-review skill triage step, and the empirical backtest detail.
- https://github.com/0xPolygon/bor/pull/2229 - adds the corresponding Bor hardfork rollout review rule.