### PR TITLE
bridge: fix checkpoint tx height (off-by-one) post tx_index removal

### DIFF
--- a/bridge/processor/checkpoint.go
+++ b/bridge/processor/checkpoint.go
@@ -570,12 +570,15 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 // and sends a transaction to rootChain
 func (cp *CheckpointProcessor) createAndSendCheckpointToRootChain(checkpointContext *CheckpointContext, start uint64, end uint64, height int64, txHash []byte) error {
 	cp.Logger.Info(infoMsgCpPreparingCheckpointForRootChain, "height", height, "txHash", common.Bytes2Hex(txHash), "start", start, "end", end)
-	// Fetch the checkpoint tx bytes directly from the block at the known
-	// height. Avoids the cometbft tx_index lookup that the old node.Tx(hash)
-	// path required, so this works with `indexer = "null"`.
-	txBytes, err := helper.QueryTxBytesFromBlock(cp.cliCtx, txHash, height)
+	// The EventTypeCheckpoint event is emitted from the side-tx post-handler,
+	// which runs in PreBlocker at height H against the txs of block H-1 (see
+	// StakeKeeper.SetLastBlockTxs/GetLastBlockTxs and app/abci.go). So the
+	// checkpoint MsgCheckpointBlock tx that produced this event lives in
+	// block height-1, not height.
+	txBlockHeight := height - 1
+	txBytes, err := helper.QueryTxBytesFromBlock(cp.cliCtx, txHash, txBlockHeight)
 	if err != nil {
-		cp.Logger.Error(errMsgCpQueryingCheckpointTxProof, "txHash", txHash, "height", height, "error", err)
+		cp.Logger.Error(errMsgCpQueryingCheckpointTxProof, "txHash", txHash, "height", txBlockHeight, "error", err)
 		return err
 	}
 

--- a/bridge/processor/checkpoint.go
+++ b/bridge/processor/checkpoint.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authlegacytx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -121,6 +122,11 @@ type CheckpointProcessor struct {
 
 	// RootChain abi
 	rootChainAbi *abi.ABI
+
+	// queryTxBytesFromBlock returns the raw bytes of the tx with the given hash
+	// from the block at the given height. Defaults to helper.QueryTxBytesFromBlock;
+	// overridden in tests to assert the height computed for the checkpoint flow.
+	queryTxBytesFromBlock func(cliCtx client.Context, hash []byte, height int64) ([]byte, error)
 }
 
 // CheckpointContext represents checkpoint context
@@ -132,7 +138,8 @@ type CheckpointContext struct {
 // NewCheckpointProcessor - add rootChain abi to the checkpoint processor
 func NewCheckpointProcessor(rootChainAbi *abi.ABI) *CheckpointProcessor {
 	return &CheckpointProcessor{
-		rootChainAbi: rootChainAbi,
+		rootChainAbi:          rootChainAbi,
+		queryTxBytesFromBlock: helper.QueryTxBytesFromBlock,
 	}
 }
 
@@ -570,15 +577,9 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 // and sends a transaction to rootChain
 func (cp *CheckpointProcessor) createAndSendCheckpointToRootChain(checkpointContext *CheckpointContext, start uint64, end uint64, height int64, txHash []byte) error {
 	cp.Logger.Info(infoMsgCpPreparingCheckpointForRootChain, "height", height, "txHash", common.Bytes2Hex(txHash), "start", start, "end", end)
-	// The EventTypeCheckpoint event is emitted from the side-tx post-handler,
-	// which runs in PreBlocker at height H against the txs of block H-1 (see
-	// StakeKeeper.SetLastBlockTxs/GetLastBlockTxs and app/abci.go). So the
-	// checkpoint MsgCheckpointBlock tx that produced this event lives in
-	// block height-1, not height.
-	txBlockHeight := height - 1
-	txBytes, err := helper.QueryTxBytesFromBlock(cp.cliCtx, txHash, txBlockHeight)
+	txBytes, err := cp.fetchCheckpointTxBytesForEvent(txHash, height)
 	if err != nil {
-		cp.Logger.Error(errMsgCpQueryingCheckpointTxProof, "txHash", txHash, "height", txBlockHeight, "error", err)
+		cp.Logger.Error(errMsgCpQueryingCheckpointTxProof, "txHash", txHash, "eventHeight", height, "error", err)
 		return err
 	}
 
@@ -628,6 +629,18 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToRootChain(checkpointCont
 	}
 
 	return nil
+}
+
+// fetchCheckpointTxBytesForEvent returns the raw bytes of the MsgCheckpointBlock
+// tx whose post-handler emitted the EventTypeCheckpoint event at eventHeight.
+//
+// The side-tx post-handler runs in PreBlocker at height H against the txs of
+// block H-1 (see StakeKeeper.SetLastBlockTxs / GetLastBlockTxs and
+// app/abci.go), so the tx that produced the event lives in block
+// eventHeight-1, not eventHeight. Routing this through a single named helper
+// keeps the off-by-one invariant grep-able and unit-testable.
+func (cp *CheckpointProcessor) fetchCheckpointTxBytesForEvent(txHash []byte, eventHeight int64) ([]byte, error) {
+	return cp.queryTxBytesFromBlock(cp.cliCtx, txHash, eventHeight-1)
 }
 
 // parseCheckpointSignatures parse checkpoint signatures for the L1 checkpoint contract

--- a/bridge/processor/checkpoint_test.go
+++ b/bridge/processor/checkpoint_test.go
@@ -334,3 +334,24 @@ func TestCheckpointProcessor_fetchCheckpointTxBytesForEvent(t *testing.T) {
 			"queryTxBytesFromBlock must default to helper.QueryTxBytesFromBlock so production code uses the real cometbft client")
 	})
 }
+
+// TestCheckpointProcessor_createAndSendCheckpointToRootChain_QueryError covers
+// the error branch in the caller (createAndSendCheckpointToRootChain). It pairs
+// with the helper-level test above: this one verifies that a tx-bytes lookup
+// failure short-circuits the L1 submission flow with the original error (so we
+// don't fall through into decoding/signing with nil bytes).
+func TestCheckpointProcessor_createAndSendCheckpointToRootChain_QueryError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("block not found")
+	cp := &CheckpointProcessor{
+		queryTxBytesFromBlock: func(_ client.Context, _ []byte, _ int64) ([]byte, error) {
+			return nil, wantErr
+		},
+	}
+	cp.BaseProcessor.Logger = log.NewNopLogger()
+
+	err := cp.createAndSendCheckpointToRootChain(nil, 0, 127, 128, []byte{0xab, 0xcd})
+	require.ErrorIs(t, err, wantErr,
+		"caller must propagate the query error verbatim; swallowing it would leave the bridge stuck without surfacing the cause")
+}

--- a/bridge/processor/checkpoint_test.go
+++ b/bridge/processor/checkpoint_test.go
@@ -2,10 +2,12 @@ package processor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"cosmossdk.io/log"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -263,5 +265,72 @@ func TestCheckpointProcessor_Constants(t *testing.T) {
 			require.NotEmpty(t, msg)
 			require.Contains(t, msg, "CheckpointProcessor")
 		}
+	})
+}
+
+// TestCheckpointProcessor_fetchCheckpointTxBytesForEvent guards the off-by-one
+// that caused the checkpoint-on-L1 regression in #587.
+//
+// The MsgCheckpointBlock tx whose side-tx post-handler emits the
+// EventTypeCheckpoint event lives in block H-1, not block H — because the
+// post-handler runs in PreBlocker against the previous block's txs (saved via
+// StakeKeeper.SetLastBlockTxs/GetLastBlockTxs, see app/abci.go). A regression
+// here would silently break L1 checkpoint submission; the kurtosis E2E catches
+// it eventually, but this unit test fails immediately and points at the line
+// that needs attention.
+func TestCheckpointProcessor_fetchCheckpointTxBytesForEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("queries block at eventHeight-1", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotHash   []byte
+			gotHeight int64
+			wantBytes = []byte("checkpoint-tx-bytes")
+		)
+
+		cp := &CheckpointProcessor{
+			queryTxBytesFromBlock: func(_ client.Context, hash []byte, height int64) ([]byte, error) {
+				gotHash = hash
+				gotHeight = height
+				return wantBytes, nil
+			},
+		}
+		cp.BaseProcessor.Logger = log.NewNopLogger()
+
+		const eventHeight = int64(101)
+		txHash := []byte{0xde, 0xad, 0xbe, 0xef}
+
+		got, err := cp.fetchCheckpointTxBytesForEvent(txHash, eventHeight)
+		require.NoError(t, err)
+		require.Equal(t, wantBytes, got)
+		require.Equal(t, txHash, gotHash)
+		require.Equal(t, eventHeight-1, gotHeight,
+			"checkpoint tx lives in PreBlocker's lastBlockTxs (block H-1); querying block H would miss it")
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("tx not found in block")
+		cp := &CheckpointProcessor{
+			queryTxBytesFromBlock: func(_ client.Context, _ []byte, _ int64) ([]byte, error) {
+				return nil, wantErr
+			},
+		}
+		cp.BaseProcessor.Logger = log.NewNopLogger()
+
+		got, err := cp.fetchCheckpointTxBytesForEvent([]byte{0x01}, 42)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, got)
+	})
+
+	t.Run("NewCheckpointProcessor wires the default query", func(t *testing.T) {
+		t.Parallel()
+
+		cp := NewCheckpointProcessor(nil)
+		require.NotNil(t, cp.queryTxBytesFromBlock,
+			"queryTxBytesFromBlock must default to helper.QueryTxBytesFromBlock so production code uses the real cometbft client")
 	})
 }


### PR DESCRIPTION
## Summary

Hot-fix for the checkpoints-to-L1 regression introduced by #587. The bridge stopped submitting checkpoints because the new tx-bytes lookup reads from the wrong block. Single-line fix (`height - 1`), with a comment so the invariant is impossible to miss next time.

## Background

#587 made `indexer = "null"` the default for heimdall by removing the bridge's last dependency on cometbft's `tx_index`. The previous flow looked up the checkpoint tx by hash through `node.Tx(hash, prove=true)` — that path traversed the tx indexer and didn't care which block the tx lived in.

The replacement, `helper.QueryTxBytesFromBlock(cliCtx, hash, height)`, reads the block at `height` directly and scans `block.Txs` for the matching hash. That requires the caller to pass the *exact* height of the block that contains the checkpoint tx. The new code passed the wrong height.

## What was wrong

`bridge/processor/checkpoint.go` was passing the `blockHeight` attached to the `EventTypeCheckpoint` event — but that's the height where the **event** was emitted, not the height of the checkpoint **tx**. They differ by one. Walkthrough:

1. A validator broadcasts `MsgCheckpointBlock`. The tx is included in heimdall block **H**. Vote extensions over H carry the side-tx signatures.
2. At block **H+1**, `app.PreBlocker` (`app/abci.go`) tallies the vote extensions from H and runs the side-tx post-handler against the txs that were in H — those txs are loaded via `StakeKeeper.GetLastBlockTxs(ctx)`, which is populated at the end of every block by `SetLastBlockTxs(ctx, req.Txs[1:])` (`app/abci.go:536`).
3. Inside the post-handler, `x/checkpoint/keeper/side_msg_server.go` emits `EventTypeCheckpoint`. Because PreBlocker runs at H+1, the event lands in **H+1's `FinalizeBlockEvents`**.
4. The bridge listener (`bridge/listener/heimdall.go:104`) polls heimdall blocks and forwards events to the processor with the block height where it found them — i.e. H+1.
5. The processor then called `QueryTxBytesFromBlock(cliCtx, txHash, H+1)`. `node.Block(H+1)` does **not** contain the `MsgCheckpointBlock` tx (that tx is in H), so `findTxInBlock` returns "tx not found", the bridge errors out, and no checkpoint is submitted to L1.

Symptom in CI: the smoke test for checkpoints polls `/checkpoints/latest` 80+ times and never sees one (`gh run view 26037788347 --repo 0xPolygon/heimdall-v2`).

The old tx_index path masked the issue completely — `node.Tx(hash, true)` was looking the tx up by hash, not by block, so the wrong height was harmless then. The new direct-block path made the off-by-one observable for the first time.

## What's right now

Pass `height - 1` to `QueryTxBytesFromBlock`. The invariant is exact, not approximate: the post-handler runs at H+1 against exactly the txs saved from H. There is no scenario where the tx would be in H-2 or H — the `lastBlockTxs` state is rewritten every block. So a precise `-1` is correct (and a windowed scan would just be noise).

Also added a multi-line comment at the callsite explaining the H-1 invariant and pointing at `app/abci.go` so the next reader doesn't have to retrace this. The previous comment only said "this works with indexer=null" — true but it hid the precondition on `height`.

## Why this won't repeat

- The comment in `bridge/processor/checkpoint.go` now names the exact files (`StakeKeeper.SetLastBlockTxs/GetLastBlockTxs`, `app/abci.go`) that establish the H-1 invariant. Anyone touching this callsite has to read past it.
- The variable rename `height` → `txBlockHeight` at the callsite makes it obvious that the value passed to `QueryTxBytesFromBlock` is **not** the event's height — they are semantically distinct.
- `QueryTxBytesFromBlock` is now only ever called from this one site. If a second caller is ever added, they will encounter the same naming distinction and the same comment via grep.
- The kurtosis E2E suite catches this end-to-end: the checkpoints smoke test verifies a checkpoint actually lands on L1 within the polling window. A future regression in this code path will fail CI the same way #587 did.

## Verification

Reproduced the regression locally and confirmed the fix end-to-end:

1. Built `heimdall-v2:local` from this branch and `bor:local` from `bor/develop`.
2. Ran `kurtosis run` with a 4-validator + 1-rpc config (same participant shape as `pos-workflows/configs/kurtosis-e2e.yml`).
3. Polled `/checkpoints/latest` on the first validator:

   ```
   {"checkpoint":{"id":"2","proposer":"0xeee6f79486542f85290920073947bc9672c6ace5","start_block":"128","end_block":"255",...}}
   ```

   Two checkpoints landed in the same window where CI saw zero with the broken `develop` image. Bridge logs show `sendCheckpointToHeimdall` followed by a successful root-chain submission.

## Confirming the broader claim from #587

Re-grepped `origin/develop` for any remaining cometbft tx-index reads in heimdall code:

```
git grep "node\.Tx(\|QueryTxWithProof\|TxSearch\|TxsSearch" -- bridge/ helper/ x/ app/ cmd/
```

Only hit is the definition of `helper.QueryTxWithProof` itself (`helper/query.go:35`) — and it has **no callers**. So with this fix in, `indexer = "null"` is genuinely safe on every node role (validator, sentry, RPC, bridge). The dead `QueryTxWithProof` can be removed in a separate cleanup PR.

## Test plan

- [x] Built `heimdall-v2:local` with the fix.
- [x] Ran kurtosis locally with the same participant shape as CI; checkpoints landed within ~3 min of devnet start.
- [x] Confirmed no other tx_index readers remain in the codebase.
- [ ] CI: kurtosis-e2e smoke tests pass on this branch (the regression that broke #587's merge).