### PR TITLE
No more nuking default node home when /tmp is not writeable

### DIFF
--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -74,7 +74,7 @@ const (
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", "heimdall")
 	if err != nil {
-		fmt.Printf("Failed to create temporary directory, falling back to the default node home: %v", err)
+		fmt.Printf("Failed to create temporary directory, falling back to the default node home: %v\n", err)
 		// Fallback to the default node home if the tmp directory cannot be created,
 		// we do NOT schedule this for deletion
 		return app.DefaultNodeHome

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -74,7 +74,10 @@ const (
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", "heimdall")
 	if err != nil {
-		dir = app.DefaultNodeHome
+		fmt.Printf("Failed to create temporary directory, falling back to the default node home: %v", err)
+		// Fallback to the default node home if the tmp directory cannot be created,
+		// we do NOT schedule this for deletion
+		return app.DefaultNodeHome
 	}
 	defer func() {
 		err := os.RemoveAll(dir)


### PR DESCRIPTION
## Summary
When heimdalld does not have access to create a temp directory, it currently defaults to using node home as the dir for tempdir, but it would still default to deleting the node home directory, resulting in potential data loss. 


## Executed tests
No longer deletes the node datadir when I run it as a user which cannot access /tmp

## Rollout notes
I am assuming it defaulting to node home on error is the correct behavior; if that is not the case, then this PR needs to be updated. 
