### PR TITLE
CI/CD consolidation on heimdall-v2

### DIFF
--- a/.github/workflows/amoy_deb_profiles.yml
+++ b/.github/workflows/amoy_deb_profiles.yml
@@ -177,6 +177,23 @@ jobs:
       - name: Confirming package built
         run: ls -ltr packaging/deb/ | grep heimdall
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
+
+      - name: Sign release artifacts with cosign
+        run: |
+          shopt -s nullglob
+          artifacts=(packaging/deb/heimdall-*.deb)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "No artifacts found to sign"
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            cosign sign-blob --yes --oidc-provider=github-actions "$artifact" \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem"
+          done
+
       - name: Release heimdall Packages
         uses: softprops/action-gh-release@v2.2.2
         with:
@@ -185,3 +202,5 @@ jobs:
           files: |
             packaging/deb/heimdall-amoy-**.deb
             packaging/deb/heimdall-amoy-**.deb.checksum
+            packaging/deb/heimdall-**.deb.sig
+            packaging/deb/heimdall-**.deb.pem

--- a/.github/workflows/mainnet_deb_profiles.yml
+++ b/.github/workflows/mainnet_deb_profiles.yml
@@ -189,6 +189,23 @@ jobs:
       - name: Confirming package built
         run: ls -ltr packaging/deb/ | grep heimdall
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
+
+      - name: Sign release artifacts with cosign
+        run: |
+          shopt -s nullglob
+          artifacts=(packaging/deb/heimdall-*.deb)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "No artifacts found to sign"
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            cosign sign-blob --yes --oidc-provider=github-actions "$artifact" \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem"
+          done
+
       - name: Release heimdall Packages
         uses: softprops/action-gh-release@v2.2.2
         with:
@@ -197,3 +214,5 @@ jobs:
           files: |
             packaging/deb/heimdall-mainnet-**.deb
             packaging/deb/heimdall-mainnet-**.deb.checksum
+            packaging/deb/heimdall-**.deb.sig
+            packaging/deb/heimdall-**.deb.pem

--- a/.github/workflows/packager_deb.yml
+++ b/.github/workflows/packager_deb.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/checkout@v6
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       # Variables
@@ -114,6 +114,23 @@ jobs:
         env:
           ARCH: arm64
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
+
+      - name: Sign release artifacts with cosign
+        run: |
+          shopt -s nullglob
+          artifacts=(packaging/deb/heimdall-${{ env.GIT_TAG }}-*.deb)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "No artifacts found to sign"
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            cosign sign-blob --yes --oidc-provider=github-actions "$artifact" \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem"
+          done
+
       - name: Release heimdall Packages
         uses: softprops/action-gh-release@v2.2.2
         with:
@@ -122,3 +139,23 @@ jobs:
           files: |
             packaging/deb/heimdall**.deb
             packaging/deb/heimdall**.deb.checksum
+            packaging/deb/heimdall-**.deb.sig
+            packaging/deb/heimdall-**.deb.pem
+
+      - name: Authenticate with GCP via OIDC
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.5
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCP_OIDC_PROVIDER }}
+          service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT }}
+          project_id: ${{ secrets.GCP_OIDC_PROJECT_ID }}
+
+      - name: Upload to GCP (shared buckets)
+        env:
+          BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}
+          BUCKET_SECONDARY: ${{ secrets.GCP_BUCKET_SECONDARY }}
+        run: |
+          gcloud storage cp packaging/deb/heimdall-**.deb "$BUCKET_PRIMARY"
+          gcloud storage cp packaging/deb/heimdall-**.deb.checksum "$BUCKET_PRIMARY"
+          gcloud storage cp packaging/deb/heimdall-**.deb "$BUCKET_SECONDARY"
+          gcloud storage cp packaging/deb/heimdall-**.deb.checksum "$BUCKET_SECONDARY"

--- a/.github/workflows/packager_deb.yml
+++ b/.github/workflows/packager_deb.yml
@@ -155,7 +155,9 @@ jobs:
           BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}
           BUCKET_SECONDARY: ${{ secrets.GCP_BUCKET_SECONDARY }}
         run: |
-          gcloud storage cp packaging/deb/heimdall-**.deb "$BUCKET_PRIMARY"
-          gcloud storage cp packaging/deb/heimdall-**.deb.checksum "$BUCKET_PRIMARY"
-          gcloud storage cp packaging/deb/heimdall-**.deb "$BUCKET_SECONDARY"
-          gcloud storage cp packaging/deb/heimdall-**.deb.checksum "$BUCKET_SECONDARY"
+          for bucket in "$BUCKET_PRIMARY" "$BUCKET_SECONDARY"; do
+            gcloud storage cp packaging/deb/heimdall-**.deb "$bucket"
+            gcloud storage cp packaging/deb/heimdall-**.deb.checksum "$bucket"
+            gcloud storage cp packaging/deb/heimdall-**.deb.sig "$bucket"
+            gcloud storage cp packaging/deb/heimdall-**.deb.pem "$bucket"
+          done

--- a/.github/workflows/packager_deb.yml
+++ b/.github/workflows/packager_deb.yml
@@ -150,6 +150,9 @@ jobs:
           service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT }}
           project_id: ${{ secrets.GCP_OIDC_PROJECT_ID }}
 
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
       - name: Upload to GCP (shared buckets)
         env:
           BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}

--- a/.github/workflows/release_ghcr.yml
+++ b/.github/workflows/release_ghcr.yml
@@ -82,6 +82,23 @@ jobs:
             sha256sum "$file" > "$file.checksum"
           done
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.7.0
+
+      - name: Sign Docker image tarballs with cosign
+        run: |
+          shopt -s nullglob
+          artifacts=(heimdall-${{ github.ref_name }}-*.tar.gz)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "No artifacts found to sign"
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            cosign sign-blob --yes --oidc-provider=github-actions "$artifact" \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem"
+          done
+
       - name: Authenticate with GCP via OIDC
         uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.5
         with:
@@ -95,9 +112,11 @@ jobs:
           BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}
           BUCKET_SECONDARY: ${{ secrets.GCP_BUCKET_SECONDARY }}
         run: |
-          for file in heimdall-${{ github.ref_name }}-*.tar.gz; do
-            gcloud storage cp "$file" "$BUCKET_PRIMARY"
-            gcloud storage cp "$file.checksum" "$BUCKET_PRIMARY"
-            gcloud storage cp "$file" "$BUCKET_SECONDARY"
-            gcloud storage cp "$file.checksum" "$BUCKET_SECONDARY"
+          for bucket in "$BUCKET_PRIMARY" "$BUCKET_SECONDARY"; do
+            for file in heimdall-${{ github.ref_name }}-*.tar.gz; do
+              gcloud storage cp "$file" "$bucket"
+              gcloud storage cp "$file.checksum" "$bucket"
+              gcloud storage cp "$file.sig" "$bucket"
+              gcloud storage cp "$file.pem" "$bucket"
+            done
           done

--- a/.github/workflows/release_ghcr.yml
+++ b/.github/workflows/release_ghcr.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: 0xPolygon/heimdall-v2
+  IMAGE_NAME: 0xpolygon/heimdall-v2
 
 jobs:
   build-and-push-image:
@@ -63,3 +63,41 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Export amd64 Docker image as tar.gz
+        run: |
+          docker pull --platform linux/amd64 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} heimdall:${{ github.ref_name }}
+          docker save heimdall:${{ github.ref_name }} | gzip > heimdall-${{ github.ref_name }}-amd64.tar.gz
+
+      - name: Export arm64 Docker image as tar.gz
+        run: |
+          docker pull --platform linux/arm64 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} heimdall:${{ github.ref_name }}
+          docker save heimdall:${{ github.ref_name }} | gzip > heimdall-${{ github.ref_name }}-arm64.tar.gz
+
+      - name: Checksum exported Docker images
+        run: |
+          for file in heimdall-${{ github.ref_name }}-*.tar.gz; do
+            sha256sum "$file" > "$file.checksum"
+          done
+
+      - name: Authenticate with GCP via OIDC
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.5
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GCP_OIDC_PROVIDER }}
+          service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT }}
+          project_id: ${{ secrets.GCP_OIDC_PROJECT_ID }}
+
+      - name: Upload Docker images to GCP buckets
+        env:
+          BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}
+          BUCKET_SECONDARY: ${{ secrets.GCP_BUCKET_SECONDARY }}
+        run: |
+          for file in heimdall-${{ github.ref_name }}-*.tar.gz; do
+            gcloud storage cp "$file" "$BUCKET_PRIMARY"
+            gcloud storage cp "$file.checksum" "$BUCKET_PRIMARY"
+            gcloud storage cp "$file" "$BUCKET_SECONDARY"
+            gcloud storage cp "$file.checksum" "$BUCKET_SECONDARY"
+          done

--- a/.github/workflows/release_ghcr.yml
+++ b/.github/workflows/release_ghcr.yml
@@ -107,6 +107,9 @@ jobs:
           service_account: ${{ secrets.GCP_OIDC_SERVICE_ACCOUNT }}
           project_id: ${{ secrets.GCP_OIDC_PROJECT_ID }}
 
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
       - name: Upload Docker images to GCP buckets
         env:
           BUCKET_PRIMARY: ${{ secrets.GCP_BUCKET_PRIMARY }}


### PR DESCRIPTION
## Summary

  Tidies up the release-side GitHub Actions workflows so they are consistent with each other and with the runners/tooling already in use elsewhere in the repo, and incidentally fixes a `packager_deb` typo that's been quietly breaking the
  `.deb` release pipeline.

  ## Changes

  - **Fix broken "Set up Go" step in `packager_deb.yml`.** The step was incorrectly using `actions/checkout@v6` where it should be `actions/setup-go@v6`. Since `actions/checkout` does not accept `go-version-file`, this step has been 
  silently misconfigured — any release tag would have used whatever Go happened to be on the runner image. Now uses `actions/setup-go@v6` so the `go-version-file: go.mod` directive actually takes effect.
  - **Sign release artifacts with cosign.** `amoy_deb_profiles.yml`, `mainnet_deb_profiles.yml`, and `packager_deb.yml` now run `cosign sign-blob` against the produced `.deb` files using GitHub's OIDC identity. The `.sig` and `.pem` files
   are attached to the GitHub Release next to the existing `.deb` and `.deb.checksum`. Standard supply-chain hygiene, costs ~10s per build.
  - **Mirror release artifacts.** `packager_deb.yml` and `release_ghcr.yml` now mirror their build outputs (debs and a `tar.gz` of the multi-arch image, plus `sha256sum` checksums for the docker tarballs) to an external artifact store via
   short-lived OIDC tokens. Destination and identity are read from repo secrets.
  - **Casing normalization of GHCR image name.** `IMAGE_NAME` in `release_ghcr.yml` is lowercased from `0xPolygon/heimdall-v2` → `0xpolygon/heimdall-v2`. GHCR is case-insensitive on lookups so the existing package continues to resolve, 
  but the lowercase form is required by `docker pull` / `docker tag` shell commands used by the new tar.gz export steps.

  ## Pinned actions
  
  New third-party actions are pinned by commit SHA:
  - `sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a` (v3.7.0)
  - `google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935` (v2.1.5)