### PR TITLE
app, helper, x/topup: implement fee withdraw validator gate

### DIFF
--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -705,6 +705,7 @@ func TestSideTxsHappyPath(t *testing.T) {
 		runtime.NewKVStoreService(app.GetKey(borTypes.StoreKey)),
 		app.BankKeeper,
 		app.ChainManagerKeeper,
+		&app.StakeKeeper,
 		mockCaller,
 	)
 	app.MilestoneKeeper = milestoneKeeper.NewKeeper(
@@ -875,6 +876,7 @@ func TestAllUnhappyPathBorSideTxs(t *testing.T) {
 		runtime.NewKVStoreService(app.GetKey(borTypes.StoreKey)),
 		app.BankKeeper,
 		app.ChainManagerKeeper,
+		&app.StakeKeeper,
 		mockCaller,
 	)
 	app.MilestoneKeeper = milestoneKeeper.NewKeeper(
@@ -1150,6 +1152,7 @@ func TestAllUnhappyPathClerkSideTxs(t *testing.T) {
 		runtime.NewKVStoreService(app.GetKey(borTypes.StoreKey)),
 		app.BankKeeper,
 		app.ChainManagerKeeper,
+		&app.StakeKeeper,
 		mockCaller,
 	)
 	app.MilestoneKeeper = milestoneKeeper.NewKeeper(
@@ -1566,6 +1569,7 @@ func TestAllUnhappyPathTopupSideTxs(t *testing.T) {
 		runtime.NewKVStoreService(app.GetKey(borTypes.StoreKey)),
 		app.BankKeeper,
 		mockChainKeeper,
+		&app.StakeKeeper,
 		mockCaller,
 	)
 	mockTopupKeeper := app.TopupKeeper

--- a/app/app.go
+++ b/app/app.go
@@ -284,20 +284,21 @@ func NewHeimdallApp(
 		logger,
 	)
 
-	app.TopupKeeper = topupKeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[topupTypes.StoreKey]),
-		app.BankKeeper,
-		app.ChainManagerKeeper,
-		app.caller,
-	)
-
 	app.StakeKeeper = stakeKeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[staketypes.StoreKey]),
 		app.BankKeeper,
 		app.ChainManagerKeeper,
 		address.HexCodec{},
+		app.caller,
+	)
+
+	app.TopupKeeper = topupKeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[topupTypes.StoreKey]),
+		app.BankKeeper,
+		app.ChainManagerKeeper,
+		&app.StakeKeeper,
 		app.caller,
 	)
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -240,6 +240,8 @@ var producerDowntimeHeight int64 = 0
 
 var phuketHardforkHeight int64 = 0
 
+var feeWithdrawValidatorGateHeight int64 = 0
+
 type ChainManagerAddressMigration struct {
 	PolTokenAddress       string
 	RootChainAddress      string
@@ -476,6 +478,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		initialHeight = 24404501
 		producerDowntimeHeight = 34966593
 		phuketHardforkHeight = 44070000
+		feeWithdrawValidatorGateHeight = 46361000
 	case MumbaiChain:
 		milestoneDeletionHeight = 0
 		faultyMilestoneNumber = -1
@@ -486,6 +489,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		initialHeight = 0
 		producerDowntimeHeight = 0
 		phuketHardforkHeight = 0
+		feeWithdrawValidatorGateHeight = 0
 	case AmoyChain:
 		milestoneDeletionHeight = 0
 		faultyMilestoneNumber = -1
@@ -496,6 +500,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		initialHeight = 8788501
 		producerDowntimeHeight = 20457139
 		phuketHardforkHeight = 32276400
+		feeWithdrawValidatorGateHeight = 35914000
 	default:
 		milestoneDeletionHeight = 0
 		faultyMilestoneNumber = -1
@@ -506,6 +511,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		initialHeight = 0
 		producerDowntimeHeight = 0
 		phuketHardforkHeight = 0
+		feeWithdrawValidatorGateHeight = 0
 	}
 }
 
@@ -665,6 +671,18 @@ func SetPhuketHardforkHeight(height int64) {
 
 func GetPhuketHardforkHeight() int64 {
 	return phuketHardforkHeight
+}
+
+func IsFeeWithdrawValidatorGate(height int64) bool {
+	return feeWithdrawValidatorGateHeight > 0 && height >= feeWithdrawValidatorGateHeight
+}
+
+func SetFeeWithdrawValidatorGateHeight(height int64) {
+	feeWithdrawValidatorGateHeight = height
+}
+
+func GetFeeWithdrawValidatorGateHeight() int64 {
+	return feeWithdrawValidatorGateHeight
 }
 
 func GetChainManagerAddressMigration(blockNum int64) (ChainManagerAddressMigration, bool) {

--- a/helper/config_test.go
+++ b/helper/config_test.go
@@ -7,7 +7,36 @@ import (
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 )
+
+func TestIsFeeWithdrawValidatorGate(t *testing.T) {
+	prev := GetFeeWithdrawValidatorGateHeight()
+	defer SetFeeWithdrawValidatorGateHeight(prev)
+
+	t.Run("disabled when height is zero", func(t *testing.T) {
+		SetFeeWithdrawValidatorGateHeight(0)
+		require.False(t, IsFeeWithdrawValidatorGate(0))
+		require.False(t, IsFeeWithdrawValidatorGate(1))
+		require.False(t, IsFeeWithdrawValidatorGate(1_000_000))
+	})
+
+	t.Run("inactive strictly before activation height", func(t *testing.T) {
+		SetFeeWithdrawValidatorGateHeight(100)
+		require.False(t, IsFeeWithdrawValidatorGate(99))
+	})
+
+	t.Run("active at activation height", func(t *testing.T) {
+		SetFeeWithdrawValidatorGateHeight(100)
+		require.True(t, IsFeeWithdrawValidatorGate(100))
+	})
+
+	t.Run("active strictly after activation height", func(t *testing.T) {
+		SetFeeWithdrawValidatorGateHeight(100)
+		require.True(t, IsFeeWithdrawValidatorGate(101))
+		require.True(t, IsFeeWithdrawValidatorGate(1_000_000))
+	})
+}
 
 // TestHeimdallConfig checks heimdall configs
 func TestHeimdallConfig(t *testing.T) {

--- a/x/topup/keeper/keeper.go
+++ b/x/topup/keeper/keeper.go
@@ -25,6 +25,7 @@ type Keeper struct {
 
 	BankKeeper     types.BankKeeper
 	ChainKeeper    types.ChainKeeper
+	StakeKeeper    types.StakeKeeper
 	contractCaller helper.IContractCaller
 
 	sequences        collections.KeySet[string]
@@ -37,6 +38,7 @@ func NewKeeper(
 	storeService store.KVStoreService,
 	bankKeeper types.BankKeeper,
 	chainKeeper types.ChainKeeper,
+	stakeKeeper types.StakeKeeper,
 	contractCaller helper.IContractCaller,
 ) Keeper {
 	sb := collections.NewSchemaBuilder(storeService)
@@ -46,6 +48,7 @@ func NewKeeper(
 		storeService:   storeService,
 		BankKeeper:     bankKeeper,
 		ChainKeeper:    chainKeeper,
+		StakeKeeper:    stakeKeeper,
 		contractCaller: contractCaller,
 
 		sequences:        collections.NewKeySet(sb, types.TopupSequencePrefixKey, "topup_sequence", collections.StringKey),

--- a/x/topup/keeper/keeper_test.go
+++ b/x/topup/keeper/keeper_test.go
@@ -65,6 +65,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	defer ctrl.Finish()
 	bankKeeper := testutil.NewMockBankKeeper(ctrl)
 	chainKeeper := testutil.NewMockChainKeeper(ctrl)
+	stakeKeeper := testutil.NewMockStakeKeeper(ctrl)
 
 	s.contractCaller = mocks.IContractCaller{}
 
@@ -73,6 +74,7 @@ func (s *KeeperTestSuite) SetupTest() {
 		storeService,
 		bankKeeper,
 		chainKeeper,
+		stakeKeeper,
 		&s.contractCaller,
 	)
 

--- a/x/topup/keeper/msg_server.go
+++ b/x/topup/keeper/msg_server.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -123,6 +125,10 @@ func (srv msgServer) WithdrawFeeTx(ctx context.Context, msg *types.MsgWithdrawFe
 			"proposer address %s is invalid: %v", msg.Proposer, err)
 	}
 
+	if err = srv.requireValidatorAfterGate(ctx, msg.Proposer); err != nil {
+		return nil, err
+	}
+
 	// partial withdrawal
 	amount := msg.Amount
 
@@ -163,8 +169,6 @@ func (srv msgServer) WithdrawFeeTx(ctx context.Context, msg *types.MsgWithdrawFe
 		return nil, errors.Wrapf(sdkerrors.ErrLogic, "%v", err)
 	}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
 	// add Fee to dividendAccount
 	feeAmount := amount.BigInt()
 	if err := srv.k.AddFeeToDividendAccount(ctx, msg.Proposer, feeAmount); err != nil {
@@ -175,6 +179,7 @@ func (srv msgServer) WithdrawFeeTx(ctx context.Context, msg *types.MsgWithdrawFe
 		return nil, errors.Wrapf(sdkerrors.ErrLogic, "%v", err)
 	}
 
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	sdkCtx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeFeeWithdraw,
@@ -192,4 +197,25 @@ func (srv msgServer) WithdrawFeeTx(ctx context.Context, msg *types.MsgWithdrawFe
 func recordTopupTransactionMetric(method string, start time.Time, err *error) {
 	success := *err == nil
 	api.RecordAPICallWithStart(api.TopupSubsystem, method, api.TxType, success, start)
+}
+
+// requireValidatorAfterGate restricts fee withdrawal to current validators once
+// the height gate activates. The stake keeper surfaces "address not in validators
+// store" as a wrapped collections.ErrNotFound; treat that as the dominant
+// non-validator case and only surface ErrLogic for genuine store failures.
+func (srv msgServer) requireValidatorAfterGate(ctx context.Context, proposer string) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	if !helper.IsFeeWithdrawValidatorGate(sdkCtx.BlockHeight()) {
+		return nil
+	}
+	isValidator, err := srv.k.StakeKeeper.IsCurrentValidatorByAddress(ctx, proposer)
+	if err != nil && !stderrors.Is(err, collections.ErrNotFound) {
+		srv.k.Logger(ctx).Error("Validator lookup failed", "proposer", proposer, "err", err)
+		return errors.Wrapf(sdkerrors.ErrLogic, "validator lookup failed: %v", err)
+	}
+	if err != nil || !isValidator {
+		srv.k.Logger(ctx).Error("Fee withdrawal rejected for non-validator proposer", "proposer", proposer)
+		return errors.Wrapf(sdkerrors.ErrUnauthorized, "fee withdrawal restricted to current validators")
+	}
+	return nil
 }

--- a/x/topup/keeper/msg_server_test.go
+++ b/x/topup/keeper/msg_server_test.go
@@ -1,11 +1,14 @@
 package keeper_test
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
 	"time"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,6 +16,7 @@ import (
 	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/golang/mock/gomock"
 
+	"github.com/0xPolygon/heimdall-v2/helper"
 	"github.com/0xPolygon/heimdall-v2/x/topup/testutil"
 	"github.com/0xPolygon/heimdall-v2/x/topup/types"
 )
@@ -114,5 +118,100 @@ func (s *KeeperTestSuite) TestWithdrawFeeTx() {
 		_, err := msgServer.WithdrawFeeTx(ctx, &msg)
 		require.Error(err)
 		require.Contains(err.Error(), "insufficient funds")
+	})
+}
+
+func (s *KeeperTestSuite) TestWithdrawFeeTxValidatorGate() {
+	msgServer, require, keeper, t := s.msgServer, s.Require(), s.keeper, s.T()
+
+	const gateHeight int64 = 100
+
+	_, _, addr := testdata.KeyTestPubAddr()
+	mockStake := keeper.StakeKeeper.(*testutil.MockStakeKeeper)
+	mockBank := keeper.BankKeeper.(*testutil.MockBankKeeper)
+
+	// Restore the disabled-gate default after this test so other tests aren't affected.
+	prev := helper.GetFeeWithdrawValidatorGateHeight()
+	helper.SetFeeWithdrawValidatorGateHeight(gateHeight)
+	defer helper.SetFeeWithdrawValidatorGateHeight(prev)
+
+	expectBankSuccess := func() {
+		coins, err := simulation.RandomFees(rand.New(rand.NewSource(time.Now().UnixNano())), s.ctx, sdk.Coins{sdk.NewCoin(authTypes.FeeToken, math.NewInt(1000000000000000000))})
+		require.NoError(err)
+		mockBank.EXPECT().SpendableCoin(gomock.Any(), gomock.Any(), gomock.Any()).Return(coins[0]).Times(1)
+		mockBank.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockBank.EXPECT().BurnCoins(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	}
+
+	t.Run("pre-gate non-validator passes (H-1)", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight - 1)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		expectBankSuccess()
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.NoError(err)
+		require.NotNil(res)
+	})
+
+	// The real stake keeper surfaces "address not in validators store" as a
+	// wrapped collections.ErrNotFound, not (false, nil). Mock matches production.
+	notFound := fmt.Errorf("error while fetching the validator from the store %w", collections.ErrNotFound)
+
+	t.Run("at-gate non-validator rejected (H)", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		mockStake.EXPECT().IsCurrentValidatorByAddress(gomock.Any(), gomock.Any()).Return(false, notFound).Times(1)
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.Error(err)
+		require.Nil(res)
+		require.Contains(err.Error(), "unauthorized")
+		require.Contains(err.Error(), "restricted to current validators")
+	})
+
+	t.Run("post-gate non-validator rejected (H+1)", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight + 1)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		mockStake.EXPECT().IsCurrentValidatorByAddress(gomock.Any(), gomock.Any()).Return(false, notFound).Times(1)
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.Error(err)
+		require.Nil(res)
+		require.Contains(err.Error(), "unauthorized")
+		require.Contains(err.Error(), "restricted to current validators")
+	})
+
+	t.Run("post-gate (false, nil) still rejected as unauthorized", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight + 1)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		mockStake.EXPECT().IsCurrentValidatorByAddress(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.Error(err)
+		require.Nil(res)
+		require.Contains(err.Error(), "unauthorized")
+	})
+
+	t.Run("post-gate validator passes through", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight + 1)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		mockStake.EXPECT().IsCurrentValidatorByAddress(gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+		expectBankSuccess()
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.NoError(err)
+		require.NotNil(res)
+	})
+
+	t.Run("post-gate stake lookup error propagates", func(t *testing.T) {
+		ctx := s.ctx.WithBlockHeight(gateHeight + 1)
+		msg := *types.NewMsgWithdrawFeeTx(addr.String(), math.ZeroInt())
+		mockStake.EXPECT().IsCurrentValidatorByAddress(gomock.Any(), gomock.Any()).Return(false, errors.New("lookup failure")).Times(1)
+
+		res, err := msgServer.WithdrawFeeTx(ctx, &msg)
+		require.Error(err)
+		require.Nil(res)
+		require.Contains(err.Error(), "validator lookup failed")
+		require.NotContains(err.Error(), "restricted to current validators")
 	})
 }

--- a/x/topup/testutil/expected_keepers_mocks.go
+++ b/x/topup/testutil/expected_keepers_mocks.go
@@ -185,3 +185,41 @@ func (mr *MockChainKeeperMockRecorder) GetParams(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockChainKeeper)(nil).GetParams), ctx)
 }
+
+// MockStakeKeeper is a mock of StakeKeeper interface.
+type MockStakeKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockStakeKeeperMockRecorder
+}
+
+// MockStakeKeeperMockRecorder is the mock recorder for MockStakeKeeper.
+type MockStakeKeeperMockRecorder struct {
+	mock *MockStakeKeeper
+}
+
+// NewMockStakeKeeper creates a new mock instance.
+func NewMockStakeKeeper(ctrl *gomock.Controller) *MockStakeKeeper {
+	mock := &MockStakeKeeper{ctrl: ctrl}
+	mock.recorder = &MockStakeKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStakeKeeper) EXPECT() *MockStakeKeeperMockRecorder {
+	return m.recorder
+}
+
+// IsCurrentValidatorByAddress mocks base method.
+func (m *MockStakeKeeper) IsCurrentValidatorByAddress(ctx context.Context, address string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCurrentValidatorByAddress", ctx, address)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsCurrentValidatorByAddress indicates an expected call of IsCurrentValidatorByAddress.
+func (mr *MockStakeKeeperMockRecorder) IsCurrentValidatorByAddress(ctx, address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCurrentValidatorByAddress", reflect.TypeOf((*MockStakeKeeper)(nil).IsCurrentValidatorByAddress), ctx, address)
+}

--- a/x/topup/types/expected_keepers.go
+++ b/x/topup/types/expected_keepers.go
@@ -24,3 +24,8 @@ type BankKeeper interface {
 type ChainKeeper interface {
 	GetParams(ctx context.Context) (chainmanagertypes.Params, error)
 }
+
+// StakeKeeper defines the stake keeper contract used by x/topup module
+type StakeKeeper interface {
+	IsCurrentValidatorByAddress(ctx context.Context, address string) (bool, error)
+}


### PR DESCRIPTION
## Summary

Restricts fee withdrawals (`MsgWithdrawFeeTx`) to addresses that are current validators, activated at a per-network hardfork height so the new validity rule rolls out deterministically across the validator set.

- `helper/config.go`: new `feeWithdrawValidatorGateHeight` with `IsFeeWithdrawValidatorGate(height)` / getter / setter, scheduled per network.
- `x/topup`: the keeper gains a `StakeKeeper` dependency; `WithdrawFeeTx` rejects a non-current-validator proposer once the gate height is reached (`StakeKeeper.IsCurrentValidatorByAddress`). A "not in validators store" lookup is treated as the non-validator case; genuine store errors surface as `ErrLogic`.
- `app`: `StakeKeeper` is now constructed before and injected into `TopupKeeper`.

Activation heights:

| Network | Height     | Target (UTC)        |
| ------- | ---------- | ------------------- |
| Mainnet | `46361000` | 2026-06-02 14:00    |
| Amoy    | `35914000` | 2026-05-28 14:00    |

## Executed tests

Beyond the standard CI gates:

Version already rolled out via private release.

## Rollout notes

- **Consensus-affecting.** The rule changes `MsgWithdrawFeeTx` validity at the activation height; all validators must run this version before the scheduled mainnet/Amoy heights or they will diverge.
- **Backwards-compatible until activation.** The gate is dormant pre-height (and on networks left at `0`), so pre-fork behavior is identical.
- **Operator-facing.** After activation, fee withdrawals from non-validator addresses are rejected.