### PR TITLE
bor, helper, bridge, metrics: add Bor endpoint failover

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -571,6 +571,18 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 
 // InitChainer application update at chain initialization
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
+	// newApp started the Bor failover prober and per-endpoint probe clients via
+	// InitHeimdallConfig, but the start command only registers their shutdown
+	// cleanup in PostSetup, which runs after InitChain. Any abort here (error
+	// return or panic) exits before that, so close them on every non-success
+	// exit. CloseBorChainClients is idempotent and mutex-guarded.
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			helper.CloseBorChainClients()
+		}
+	}()
+
 	var genesisState GenesisState
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
@@ -609,10 +621,6 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 	// record yet; re-check now that InitGenesis has written validator and span
 	// state. Node-local: only the misconfigured producer aborts InitChain.
 	if err := app.enforceBorFailoverBPGuard(ctx); err != nil {
-		// This abort path returns the InitChain error before the start command's
-		// PostSetup registers the shutdown cleanup, so the prober and probe clients
-		// started by newApp would leak. Close them here, mirroring newStartApp.
-		helper.CloseBorChainClients()
 		return &abci.ResponseInitChain{}, err
 	}
 
@@ -645,6 +653,7 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 	}
 
 	// update validators
+	succeeded = true
 	return &abci.ResponseInitChain{
 		Validators: valUpdates,
 	}, nil

--- a/app/app.go
+++ b/app/app.go
@@ -603,6 +603,15 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 		return &abci.ResponseInitChain{}, err
 	}
 
+	// Fail closed if this node is a protected block producer with Bor endpoint
+	// failover configured. The startup check in newStartApp runs before genesis
+	// state exists, so on a fresh DB a genesis producer's signer has no validator
+	// record yet; re-check now that InitGenesis has written validator and span
+	// state. Node-local: only the misconfigured producer aborts InitChain.
+	if err := app.enforceBorFailoverBPGuard(ctx); err != nil {
+		return &abci.ResponseInitChain{}, err
+	}
+
 	moduleAccTopUp := app.AccountKeeper.GetModuleAccount(ctx, topupTypes.ModuleName)
 	if moduleAccTopUp == nil {
 		panic(fmt.Sprintf("%s module account has not been set", topupTypes.ModuleName))

--- a/app/app.go
+++ b/app/app.go
@@ -609,6 +609,10 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain)
 	// record yet; re-check now that InitGenesis has written validator and span
 	// state. Node-local: only the misconfigured producer aborts InitChain.
 	if err := app.enforceBorFailoverBPGuard(ctx); err != nil {
+		// This abort path returns the InitChain error before the start command's
+		// PostSetup registers the shutdown cleanup, so the prober and probe clients
+		// started by newApp would leak. Close them here, mirroring newStartApp.
+		helper.CloseBorChainClients()
 		return &abci.ResponseInitChain{}, err
 	}
 

--- a/app/bor_failover_guard.go
+++ b/app/bor_failover_guard.go
@@ -16,6 +16,16 @@ import (
 // EnforceBorFailoverBPGuard rejects Bor endpoint failover for protected block
 // producer validators.
 func (app *HeimdallApp) EnforceBorFailoverBPGuard() error {
+	ctx := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
+	return app.enforceBorFailoverBPGuard(ctx)
+}
+
+// enforceBorFailoverBPGuard runs the guard against the given context's state. It
+// is shared by the startup check (loaded state) and InitChainer (after genesis
+// state is written): on a fresh DB the startup check runs before InitGenesis
+// populates the validator set, so a genesis block producer is only caught by
+// the InitChainer call.
+func (app *HeimdallApp) enforceBorFailoverBPGuard(ctx sdk.Context) error {
 	if !helper.BorFailoverConfigured(helper.GetConfig()) {
 		return nil
 	}
@@ -25,7 +35,6 @@ func (app *HeimdallApp) EnforceBorFailoverBPGuard() error {
 		return fmt.Errorf("failed to resolve local signer for Bor failover BP guard: %w", err)
 	}
 
-	ctx := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
 	return app.validateBorFailoverBPGuard(ctx, signer)
 }
 

--- a/app/bor_failover_guard.go
+++ b/app/bor_failover_guard.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"cosmossdk.io/collections"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
+)
+
+// EnforceBorFailoverBPGuard rejects Bor endpoint failover for protected block
+// producer validators.
+func (app *HeimdallApp) EnforceBorFailoverBPGuard() error {
+	if !helper.BorFailoverConfigured(helper.GetConfig()) {
+		return nil
+	}
+
+	signer, err := helper.GetAddressString()
+	if err != nil {
+		return fmt.Errorf("failed to resolve local signer for Bor failover BP guard: %w", err)
+	}
+
+	ctx := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
+	return app.validateBorFailoverBPGuard(ctx, signer)
+}
+
+func (app *HeimdallApp) validateBorFailoverBPGuard(ctx sdk.Context, signer string) error {
+	localValidatorID, hasValidatorRecord, err := app.validatorIDForSigner(ctx, signer)
+	if err != nil {
+		return err
+	}
+	if !hasValidatorRecord {
+		app.Logger().Info("Bor endpoint failover allowed; local signer is not a validator", "signer", signer)
+		return nil
+	}
+
+	protectedProducerIDs, err := app.borFailoverProtectedProducerIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := protectedProducerIDs[localValidatorID]; ok {
+		return fmt.Errorf(
+			"bor endpoint failover is not allowed for block producer validators: local signer %s maps to protected producer validator ID %d; configure this node with a single local bor endpoint",
+			signer,
+			localValidatorID,
+		)
+	}
+
+	app.Logger().Info(
+		"Bor endpoint failover allowed; local validator is not in the protected producer set",
+		"signer", signer,
+		"validatorID", localValidatorID,
+		"protectedProducerIDs", sortedProducerIDs(protectedProducerIDs),
+	)
+
+	return nil
+}
+
+func (app *HeimdallApp) validatorIDForSigner(ctx sdk.Context, signer string) (uint64, bool, error) {
+	validator, err := app.StakeKeeper.GetValidatorInfo(ctx, signer)
+	if errors.Is(err, collections.ErrNotFound) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to load local signer validator info for Bor failover BP guard: %w", err)
+	}
+
+	return validator.ValId, true, nil
+}
+
+func (app *HeimdallApp) borFailoverProtectedProducerIDs(ctx sdk.Context) (map[uint64]struct{}, error) {
+	protectedProducerIDs := make(map[uint64]struct{})
+	addProducerIDs(protectedProducerIDs, helper.GetProducerVotes())
+	addProducerIDs(protectedProducerIDs, helper.GetFallbackProducerVotes())
+
+	lastSpan, err := app.BorKeeper.GetLastSpan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load last span for Bor failover BP guard: %w", err)
+	}
+	for _, producer := range lastSpan.SelectedProducers {
+		protectedProducerIDs[producer.ValId] = struct{}{}
+	}
+
+	candidates, err := app.BorKeeper.CalculateProducerSet(ctx, helper.GetProducerSetLimit(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate producer set for Bor failover BP guard: %w", err)
+	}
+	if len(candidates) == 0 {
+		candidates = helper.GetFallbackProducerVotes()
+	}
+	addProducerIDs(protectedProducerIDs, candidates)
+
+	return protectedProducerIDs, nil
+}
+
+func addProducerIDs(dst map[uint64]struct{}, ids []uint64) {
+	for _, id := range ids {
+		dst[id] = struct{}{}
+	}
+}
+
+func sortedProducerIDs(producers map[uint64]struct{}) string {
+	ids := make([]uint64, 0, len(producers))
+	for id := range producers {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("%d", id))
+	}
+
+	return strings.Join(parts, ",")
+}

--- a/app/bor_failover_guard_test.go
+++ b/app/bor_failover_guard_test.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
+	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
+	stakeTypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
+)
+
+func TestBorFailoverProtectedProducerIDsDoesNotIncludeEveryValidator(t *testing.T) {
+	setup := SetupApp(t, 6)
+	app := setup.App
+	ctx := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
+	validators := app.StakeKeeper.GetCurrentValidators(ctx)
+	require.Len(t, validators, 6)
+	selectedProducer := requireValidatorByID(t, validators, 0)
+	nonProducer := requireValidatorByID(t, validators, 5)
+
+	require.NoError(t, app.BorKeeper.AddNewSpan(ctx, &borTypes.Span{
+		Id:                0,
+		StartBlock:        1,
+		EndBlock:          100,
+		ValidatorSet:      stakeTypes.ValidatorSet{Validators: validatorPointers(validators)},
+		SelectedProducers: []stakeTypes.Validator{selectedProducer},
+		BorChainId:        "bor",
+	}))
+
+	protectedProducerIDs, err := app.borFailoverProtectedProducerIDs(ctx)
+	require.NoError(t, err)
+
+	require.Contains(t, protectedProducerIDs, selectedProducer.ValId)
+	for _, producerID := range helper.GetFallbackProducerVotes() {
+		require.Contains(t, protectedProducerIDs, producerID)
+	}
+	require.NotContains(t, protectedProducerIDs, nonProducer.ValId)
+}
+
+func TestValidateBorFailoverBPGuard(t *testing.T) {
+	setup := SetupApp(t, 6)
+	app := setup.App
+	ctx := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
+	validators := app.StakeKeeper.GetCurrentValidators(ctx)
+	require.Len(t, validators, 6)
+	selectedProducer := requireValidatorByID(t, validators, 0)
+	fallbackProducer := requireValidatorByID(t, validators, 1)
+	nonProducer := requireValidatorByID(t, validators, 5)
+
+	require.NoError(t, app.BorKeeper.AddNewSpan(ctx, &borTypes.Span{
+		Id:                0,
+		StartBlock:        1,
+		EndBlock:          100,
+		ValidatorSet:      stakeTypes.ValidatorSet{Validators: validatorPointers(validators)},
+		SelectedProducers: []stakeTypes.Validator{selectedProducer},
+		BorChainId:        "bor",
+	}))
+
+	require.Error(t, app.validateBorFailoverBPGuard(ctx, selectedProducer.Signer))
+	require.Error(t, app.validateBorFailoverBPGuard(ctx, fallbackProducer.Signer))
+	require.NoError(t, app.validateBorFailoverBPGuard(ctx, nonProducer.Signer))
+	require.NoError(t, app.validateBorFailoverBPGuard(ctx, "0x0000000000000000000000000000000000000001"))
+
+	inactiveProducer := selectedProducer
+	inactiveProducer.VotingPower = 0
+	require.NoError(t, app.StakeKeeper.AddValidator(ctx, inactiveProducer))
+	require.Error(t, app.validateBorFailoverBPGuard(ctx, inactiveProducer.Signer))
+
+	jailedProducer := fallbackProducer
+	jailedProducer.Jailed = true
+	require.NoError(t, app.StakeKeeper.AddValidator(ctx, jailedProducer))
+	require.Error(t, app.validateBorFailoverBPGuard(ctx, jailedProducer.Signer))
+}
+
+func requireValidatorByID(t *testing.T, validators []stakeTypes.Validator, id uint64) stakeTypes.Validator {
+	t.Helper()
+	for _, validator := range validators {
+		if validator.ValId == id {
+			return validator
+		}
+	}
+	t.Fatalf("validator ID %d not found", id)
+	return stakeTypes.Validator{}
+}
+
+func validatorPointers(validators []stakeTypes.Validator) []*stakeTypes.Validator {
+	out := make([]*stakeTypes.Validator, 0, len(validators))
+	for i := range validators {
+		out = append(out, &validators[i])
+	}
+	return out
+}

--- a/app/bor_failover_guard_test.go
+++ b/app/bor_failover_guard_test.go
@@ -1,9 +1,16 @@
 package app
 
 import (
+	"encoding/json"
 	"testing"
 
+	"cosmossdk.io/log"
+	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/stretchr/testify/require"
 
 	"github.com/0xPolygon/heimdall-v2/helper"
@@ -72,6 +79,55 @@ func TestValidateBorFailoverBPGuard(t *testing.T) {
 	jailedProducer.Jailed = true
 	require.NoError(t, app.StakeKeeper.AddValidator(ctx, jailedProducer))
 	require.Error(t, app.validateBorFailoverBPGuard(ctx, jailedProducer.Signer))
+}
+
+// TestInitChainFailsClosedForGenesisBorFailoverProducer covers the fresh-DB /
+// pre-InitChain path: the startup guard in newStartApp runs before genesis state
+// exists, so a genesis producer's signer has no validator record yet. The
+// InitChainer re-check must catch it once InitGenesis has written validator and
+// span state. The sole genesis validator is necessarily the span-0 producer.
+func TestInitChainFailsClosedForGenesisBorFailoverProducer(t *testing.T) {
+	validatorPrivKeys, validators, accounts, balances := generateValidators(t, 1)
+
+	appCfg := helper.CustomAppConfig{
+		Config: *serverconfig.DefaultConfig(),
+		Custom: helper.GetDefaultHeimdallConfig(),
+	}
+	appCfg.Custom.BorRPCUrl = "http://primary:8545,http://fallback:8545"
+	helper.SetTestConfig(appCfg)
+	helper.SetTestPrivPubKey(validatorPrivKeys[0])
+	t.Cleanup(func() {
+		helper.SetTestConfig(helper.CustomAppConfig{
+			Config: *serverconfig.DefaultConfig(),
+			Custom: helper.GetDefaultHeimdallConfig(),
+		})
+	})
+
+	db := dbm.NewMemDB()
+	appOptions := make(simtestutil.AppOptionsMap)
+	appOptions[flags.FlagHome] = DefaultNodeHome
+	hApp := NewHeimdallApp(log.NewTestLogger(t), db, nil, true, appOptions)
+
+	genesisState := hApp.DefaultGenesis()
+	valSet := stakeTypes.NewValidatorSet(validators)
+	genesisState, err := GenesisStateWithValSet(hApp.AppCodec(), genesisState, valSet, accounts, balances...)
+	require.NoError(t, err)
+	// Build span 0 from the validator set (genFirstSpan), as a real genesis does;
+	// the sole validator becomes the span producer and thus a protected producer.
+	genesisState, err = borTypes.SetGenesisStateToAppState(hApp.AppCodec(), genesisState, *valSet)
+	require.NoError(t, err)
+	stateBytes, err := json.Marshal(genesisState)
+	require.NoError(t, err)
+
+	helper.SetTestInitialHeight(VoteExtBlockHeight)
+	_, err = hApp.InitChain(&abci.RequestInitChain{
+		Validators:      []abci.ValidatorUpdate{},
+		ConsensusParams: simtestutil.DefaultConsensusParams,
+		AppStateBytes:   stateBytes,
+		InitialHeight:   VoteExtBlockHeight,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "block producer")
 }
 
 func requireValidatorByID(t *testing.T, validators []stakeTypes.Validator, id uint64) stakeTypes.Validator {

--- a/bridge/broadcaster/broadcaster.go
+++ b/bridge/broadcaster/broadcaster.go
@@ -206,16 +206,15 @@ func updateAccountSequence(ctx context.Context, tb *TxBroadcaster) error {
 	return nil
 }
 
-// BroadcastToBorChain broadcasts a msg to the bor chain
-func (tb *TxBroadcaster) BroadcastToBorChain(msg ethereum.CallMsg) error {
+// BroadcastToBorChain broadcasts a msg to the bor chain.
+func (tb *TxBroadcaster) BroadcastToBorChain(ctx context.Context, msg ethereum.CallMsg) error {
 	tb.borMutex.Lock()
 	defer tb.borMutex.Unlock()
 
-	// get bor client
 	borClient := helper.GetBorClient()
+	borCallTimeout := helper.GetBorChainCallTimeout()
 
-	// get auth
-	auth, err := helper.GenerateAuthObj(borClient, *msg.To, msg.Data)
+	auth, err := helper.GenerateAuthObjWithContext(ctx, borCallTimeout, borClient, *msg.To, msg.Data)
 	if err != nil {
 		tb.logger.Error("Error generating auth object", "error", err)
 		return err
@@ -240,12 +239,10 @@ func (tb *TxBroadcaster) BroadcastToBorChain(msg ethereum.CallMsg) error {
 
 	tb.logger.Info("Sending transaction to bor", "txHash", signedTx.Hash())
 
-	// create a context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), helper.GetConfig().BorRPCTimeout)
+	sendCtx, cancel := context.WithTimeout(ctx, borCallTimeout)
 	defer cancel()
 
-	// broadcast transaction
-	if err = borClient.SendTransaction(ctx, signedTx); err != nil {
+	if err = borClient.SendTransaction(sendCtx, signedTx); err != nil {
 		tb.logger.Error("Error while broadcasting the transaction to bor chain", "error", err)
 		return err
 	}

--- a/bridge/service/bridge.go
+++ b/bridge/service/bridge.go
@@ -220,7 +220,7 @@ func waitUntilSynced(ctx context.Context, clientCtx client.Context, d time.Durat
 // runServices starts all the bridge services and handles graceful shutdown.
 // Uses errgroup.WithContext so that a service Start() failure cancels the
 // group context, which unblocks the shutdown controller and other goroutines.
-func runServices(ctx context.Context, services []common.Service, httpClient stoppable, qc workerStopper) error {
+func runServices(ctx context.Context, services []common.Service, httpClient stopper, qc workerStopper) error {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	// start each service
@@ -255,18 +255,18 @@ func runServices(ctx context.Context, services []common.Service, httpClient stop
 	return nil
 }
 
-// stoppable and workerStopper are the minimal behaviors stopBridge needs from
+// stopper and workerStopper are the minimal behaviors stopBridge needs from
 // the comet RPC client and the queue connector, so the shutdown path is
 // unit-testable with fakes.
 type (
-	stoppable     interface{ Stop() error }
+	stopper       interface{ Stop() error }
 	workerStopper interface{ StopWorker() }
 )
 
 // stopBridge tears down the bridge services, the comet client, the DB, and the
 // Bor failover clients. Called by runServices's shutdown controller once the
 // group context is cancelled.
-func stopBridge(services []common.Service, httpClient stoppable, qc workerStopper) error {
+func stopBridge(services []common.Service, httpClient stopper, qc workerStopper) error {
 	qc.StopWorker()
 
 	for _, s := range services {

--- a/bridge/service/bridge.go
+++ b/bridge/service/bridge.go
@@ -244,7 +244,7 @@ func runServices(ctx context.Context, services []common.Service, httpClient stop
 		<-gCtx.Done()
 		// mutator-disable-next-line operator log, removing it changes no behavior
 		logger().Info("Bridge: received stop signal - stopping all heimdall bridge services")
-		return stopBridge(services, httpClient, qc)
+		return stopBridge(services, httpClient, qc, closeBridgeResources)
 	})
 
 	if err := g.Wait(); err != nil {
@@ -263,10 +263,21 @@ type (
 	workerStopper interface{ StopWorker() }
 )
 
+// closeBridgeResources runs cleanup that should happen even when an earlier
+// service stop returns an error.
+func closeBridgeResources() {
+	// mutator-disable-next-line statement-deletion shutdown cleanup
+	util.CloseBridgeDBInstance()
+	// mutator-disable-next-line statement-deletion shutdown cleanup
+	helper.CloseBorChainClients()
+}
+
 // stopBridge tears down the bridge services, the comet client, the DB, and the
 // Bor failover clients. Called by runServices's shutdown controller once the
 // group context is cancelled.
-func stopBridge(services []common.Service, httpClient stopper, qc workerStopper) error {
+func stopBridge(services []common.Service, httpClient stopper, qc workerStopper, cleanup func()) error {
+	defer cleanup()
+
 	qc.StopWorker()
 
 	for _, s := range services {
@@ -285,12 +296,5 @@ func stopBridge(services []common.Service, httpClient stopper, qc workerStopper)
 		return err
 	}
 
-	util.CloseBridgeDBInstance()
-
-	// stop the Bor failover background probers and close the Bor clients.
-	// Shutdown-only cleanup whose effect (goroutine teardown) is observable only
-	// at process exit, so deleting it is not unit-testable here.
-	// mutator-disable-next-line statement-deletion shutdown cleanup
-	helper.CloseBorChainClients()
 	return nil
 }

--- a/bridge/service/bridge.go
+++ b/bridge/service/bridge.go
@@ -220,7 +220,7 @@ func waitUntilSynced(ctx context.Context, clientCtx client.Context, d time.Durat
 // runServices starts all the bridge services and handles graceful shutdown.
 // Uses errgroup.WithContext so that a service Start() failure cancels the
 // group context, which unblocks the shutdown controller and other goroutines.
-func runServices(ctx context.Context, services []common.Service, httpClient *rpchttp.HTTP, qc *queue.Connector) error {
+func runServices(ctx context.Context, services []common.Service, httpClient stoppable, qc workerStopper) error {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	// start each service
@@ -242,34 +242,55 @@ func runServices(ctx context.Context, services []common.Service, httpClient *rpc
 	// shutdown controller: triggers on parent ctx cancellation OR first goroutine error
 	g.Go(func() error {
 		<-gCtx.Done()
+		// mutator-disable-next-line operator log, removing it changes no behavior
 		logger().Info("Bridge: received stop signal - stopping all heimdall bridge services")
-
-		qc.StopWorker()
-
-		// stop services
-		for _, s := range services {
-			if s.IsRunning() {
-				if err := s.Stop(); err != nil {
-					logger().Error("Bridge: service.Stop failed", "err", err)
-					return err
-				}
-			}
-		}
-
-		// stop comet client
-		if err := httpClient.Stop(); err != nil {
-			logger().Error("Bridge: httpClient.Stop failed", "err", err)
-			return err
-		}
-
-		// close DB
-		util.CloseBridgeDBInstance()
-		return nil
+		return stopBridge(services, httpClient, qc)
 	})
 
 	if err := g.Wait(); err != nil {
+		// mutator-disable-next-line operator log, err is returned below
 		logger().Error("Bridge: stopped", "err", err)
 		return err
 	}
+	return nil
+}
+
+// stoppable and workerStopper are the minimal behaviors stopBridge needs from
+// the comet RPC client and the queue connector, so the shutdown path is
+// unit-testable with fakes.
+type (
+	stoppable     interface{ Stop() error }
+	workerStopper interface{ StopWorker() }
+)
+
+// stopBridge tears down the bridge services, the comet client, the DB, and the
+// Bor failover clients. Called by runServices's shutdown controller once the
+// group context is cancelled.
+func stopBridge(services []common.Service, httpClient stoppable, qc workerStopper) error {
+	qc.StopWorker()
+
+	for _, s := range services {
+		if s.IsRunning() {
+			if err := s.Stop(); err != nil {
+				// mutator-disable-next-line operator log, err is returned below
+				logger().Error("Bridge: service.Stop failed", "err", err)
+				return err
+			}
+		}
+	}
+
+	if err := httpClient.Stop(); err != nil {
+		// mutator-disable-next-line operator log, err is returned below
+		logger().Error("Bridge: httpClient.Stop failed", "err", err)
+		return err
+	}
+
+	util.CloseBridgeDBInstance()
+
+	// stop the Bor failover background probers and close the Bor clients.
+	// Shutdown-only cleanup whose effect (goroutine teardown) is observable only
+	// at process exit, so deleting it is not unit-testable here.
+	// mutator-disable-next-line statement-deletion shutdown cleanup
+	helper.CloseBorChainClients()
 	return nil
 }

--- a/bridge/service/bridge_test.go
+++ b/bridge/service/bridge_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	common "github.com/cometbft/cometbft/libs/service"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeService satisfies common.Service via the embedded (nil) interface;
+// only the lifecycle methods runServices/stopBridge call are overridden.
+type fakeService struct {
+	common.Service
+	running  bool
+	startErr error
+	stopErr  error
+	stopped  bool
+	quit     chan struct{}
+}
+
+func (f *fakeService) Start() error    { return f.startErr }
+func (f *fakeService) IsRunning() bool { return f.running }
+func (f *fakeService) Stop() error     { f.stopped = true; return f.stopErr }
+func (f *fakeService) Quit() <-chan struct{} {
+	if f.quit == nil {
+		f.quit = make(chan struct{})
+	}
+	return f.quit
+}
+
+type fakeStoppable struct {
+	err    error
+	called bool
+}
+
+func (f *fakeStoppable) Stop() error { f.called = true; return f.err }
+
+type fakeWorkerStopper struct{ called bool }
+
+func (f *fakeWorkerStopper) StopWorker() { f.called = true }
+
+func TestStopBridge_StopsRunningServicesAndClients(t *testing.T) {
+	running := &fakeService{running: true}
+	idle := &fakeService{running: false}
+	qc := &fakeWorkerStopper{}
+	hc := &fakeStoppable{}
+
+	require.NoError(t, stopBridge([]common.Service{running, idle}, hc, qc))
+	require.True(t, qc.called)       // worker stopped
+	require.True(t, running.stopped) // running service stopped
+	require.False(t, idle.stopped)   // non-running service skipped
+	require.True(t, hc.called)       // comet client stopped
+}
+
+func TestStopBridge_ReturnsServiceStopError(t *testing.T) {
+	boom := errors.New("service stop failed")
+	bad := &fakeService{running: true, stopErr: boom}
+	hc := &fakeStoppable{}
+
+	require.ErrorIs(t, stopBridge([]common.Service{bad}, hc, &fakeWorkerStopper{}), boom)
+	require.False(t, hc.called) // returns before stopping the comet client
+}
+
+func TestStopBridge_ReturnsHTTPClientStopError(t *testing.T) {
+	boom := errors.New("http client stop failed")
+	hc := &fakeStoppable{err: boom}
+
+	require.ErrorIs(t, stopBridge(nil, hc, &fakeWorkerStopper{}), boom)
+}
+
+func TestRunServices_PropagatesShutdownError(t *testing.T) {
+	boom := errors.New("service stop failed")
+	svc := &fakeService{running: true, stopErr: boom, quit: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }() // trigger the shutdown controller
+
+	err := runServices(ctx, []common.Service{svc}, &fakeStoppable{}, &fakeWorkerStopper{})
+	require.ErrorIs(t, err, boom) // the shutdown error propagates out of runServices
+	require.True(t, svc.stopped)
+}
+
+func TestRunServices_PropagatesServiceStartError(t *testing.T) {
+	boom := errors.New("service start failed")
+	svc := &fakeService{startErr: boom, quit: make(chan struct{})}
+
+	err := runServices(context.Background(), []common.Service{svc}, &fakeStoppable{}, &fakeWorkerStopper{})
+	require.ErrorIs(t, err, boom) // a service Start failure cancels the group and surfaces
+}

--- a/bridge/service/bridge_test.go
+++ b/bridge/service/bridge_test.go
@@ -47,28 +47,34 @@ func TestStopBridge_StopsRunningServicesAndClients(t *testing.T) {
 	idle := &fakeService{running: false}
 	qc := &fakeWorkerStopper{}
 	hc := &fakeStoppable{}
+	cleaned := false
 
-	require.NoError(t, stopBridge([]common.Service{running, idle}, hc, qc))
+	require.NoError(t, stopBridge([]common.Service{running, idle}, hc, qc, func() { cleaned = true }))
 	require.True(t, qc.called)       // worker stopped
 	require.True(t, running.stopped) // running service stopped
 	require.False(t, idle.stopped)   // non-running service skipped
 	require.True(t, hc.called)       // comet client stopped
+	require.True(t, cleaned)         // shutdown cleanup runs on success
 }
 
 func TestStopBridge_ReturnsServiceStopError(t *testing.T) {
 	boom := errors.New("service stop failed")
 	bad := &fakeService{running: true, stopErr: boom}
 	hc := &fakeStoppable{}
+	cleaned := false
 
-	require.ErrorIs(t, stopBridge([]common.Service{bad}, hc, &fakeWorkerStopper{}), boom)
+	require.ErrorIs(t, stopBridge([]common.Service{bad}, hc, &fakeWorkerStopper{}, func() { cleaned = true }), boom)
 	require.False(t, hc.called) // returns before stopping the comet client
+	require.True(t, cleaned)    // Bor/DB cleanup still runs on the error path
 }
 
 func TestStopBridge_ReturnsHTTPClientStopError(t *testing.T) {
 	boom := errors.New("http client stop failed")
 	hc := &fakeStoppable{err: boom}
+	cleaned := false
 
-	require.ErrorIs(t, stopBridge(nil, hc, &fakeWorkerStopper{}), boom)
+	require.ErrorIs(t, stopBridge(nil, hc, &fakeWorkerStopper{}, func() { cleaned = true }), boom)
+	require.True(t, cleaned) // Bor/DB cleanup still runs on the error path
 }
 
 func TestRunServices_PropagatesShutdownError(t *testing.T) {

--- a/cmd/heimdalld/cmd/bor_failover_guard_test.go
+++ b/cmd/heimdalld/cmd/bor_failover_guard_test.go
@@ -2,11 +2,14 @@ package heimdalld
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"cosmossdk.io/log"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 type fakeGuardedApp struct {
@@ -71,4 +74,19 @@ func TestMustApplyBorFailoverBPGuard(t *testing.T) {
 		})
 		require.False(t, fake.closeCalled)
 	})
+}
+
+func TestRegisterBorChainClientCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var g errgroup.Group
+	var closed atomic.Bool
+
+	registerBorChainClientCleanup(ctx, &g, func() {
+		closed.Store(true)
+	})
+
+	require.False(t, closed.Load())
+	cancel()
+	require.NoError(t, g.Wait())
+	require.True(t, closed.Load())
 }

--- a/cmd/heimdalld/cmd/bor_failover_guard_test.go
+++ b/cmd/heimdalld/cmd/bor_failover_guard_test.go
@@ -1,0 +1,74 @@
+package heimdalld
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGuardedApp struct {
+	guardErr    error
+	closeErr    error
+	closeCalled bool
+}
+
+func (f *fakeGuardedApp) EnforceBorFailoverBPGuard() error { return f.guardErr }
+
+func (f *fakeGuardedApp) Close() error {
+	f.closeCalled = true
+	return f.closeErr
+}
+
+func TestApplyBorFailoverBPGuard(t *testing.T) {
+	guardErr := errors.New("bp guard tripped")
+
+	t.Run("guard passes: app not closed, no error", func(t *testing.T) {
+		var buf bytes.Buffer
+		fake := &fakeGuardedApp{}
+
+		require.NoError(t, applyBorFailoverBPGuard(log.NewLogger(&buf), fake))
+		require.False(t, fake.closeCalled)
+		require.NotContains(t, buf.String(), "failed to close app")
+	})
+
+	t.Run("guard fails: app closed, guard error returned", func(t *testing.T) {
+		var buf bytes.Buffer
+		fake := &fakeGuardedApp{guardErr: guardErr}
+
+		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake)
+		require.ErrorIs(t, err, guardErr)
+		require.True(t, fake.closeCalled)
+		require.NotContains(t, buf.String(), "failed to close app")
+	})
+
+	t.Run("guard fails and close fails: guard error returned, close error logged", func(t *testing.T) {
+		var buf bytes.Buffer
+		fake := &fakeGuardedApp{guardErr: guardErr, closeErr: errors.New("close boom")}
+
+		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake)
+		require.ErrorIs(t, err, guardErr)
+		require.True(t, fake.closeCalled)
+		require.Contains(t, buf.String(), "failed to close app")
+	})
+}
+
+func TestMustApplyBorFailoverBPGuard(t *testing.T) {
+	t.Run("guard fails: start path panics (fails closed)", func(t *testing.T) {
+		fake := &fakeGuardedApp{guardErr: errors.New("bp guard tripped")}
+		require.Panics(t, func() {
+			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake)
+		})
+		require.True(t, fake.closeCalled)
+	})
+
+	t.Run("guard passes: start path proceeds", func(t *testing.T) {
+		fake := &fakeGuardedApp{}
+		require.NotPanics(t, func() {
+			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake)
+		})
+		require.False(t, fake.closeCalled)
+	})
+}

--- a/cmd/heimdalld/cmd/bor_failover_guard_test.go
+++ b/cmd/heimdalld/cmd/bor_failover_guard_test.go
@@ -31,29 +31,41 @@ func TestApplyBorFailoverBPGuard(t *testing.T) {
 	t.Run("guard passes: app not closed, no error", func(t *testing.T) {
 		var buf bytes.Buffer
 		fake := &fakeGuardedApp{}
+		var borClientsClosed atomic.Bool
 
-		require.NoError(t, applyBorFailoverBPGuard(log.NewLogger(&buf), fake))
+		require.NoError(t, applyBorFailoverBPGuard(log.NewLogger(&buf), fake, func() {
+			borClientsClosed.Store(true)
+		}))
 		require.False(t, fake.closeCalled)
+		require.False(t, borClientsClosed.Load())
 		require.NotContains(t, buf.String(), "failed to close app")
 	})
 
 	t.Run("guard fails: app closed, guard error returned", func(t *testing.T) {
 		var buf bytes.Buffer
 		fake := &fakeGuardedApp{guardErr: guardErr}
+		var borClientsClosed atomic.Bool
 
-		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake)
+		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake, func() {
+			borClientsClosed.Store(true)
+		})
 		require.ErrorIs(t, err, guardErr)
 		require.True(t, fake.closeCalled)
+		require.True(t, borClientsClosed.Load())
 		require.NotContains(t, buf.String(), "failed to close app")
 	})
 
 	t.Run("guard fails and close fails: guard error returned, close error logged", func(t *testing.T) {
 		var buf bytes.Buffer
 		fake := &fakeGuardedApp{guardErr: guardErr, closeErr: errors.New("close boom")}
+		var borClientsClosed atomic.Bool
 
-		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake)
+		err := applyBorFailoverBPGuard(log.NewLogger(&buf), fake, func() {
+			borClientsClosed.Store(true)
+		})
 		require.ErrorIs(t, err, guardErr)
 		require.True(t, fake.closeCalled)
+		require.True(t, borClientsClosed.Load())
 		require.Contains(t, buf.String(), "failed to close app")
 	})
 }
@@ -61,18 +73,26 @@ func TestApplyBorFailoverBPGuard(t *testing.T) {
 func TestMustApplyBorFailoverBPGuard(t *testing.T) {
 	t.Run("guard fails: start path panics (fails closed)", func(t *testing.T) {
 		fake := &fakeGuardedApp{guardErr: errors.New("bp guard tripped")}
+		var borClientsClosed atomic.Bool
 		require.Panics(t, func() {
-			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake)
+			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake, func() {
+				borClientsClosed.Store(true)
+			})
 		})
 		require.True(t, fake.closeCalled)
+		require.True(t, borClientsClosed.Load())
 	})
 
 	t.Run("guard passes: start path proceeds", func(t *testing.T) {
 		fake := &fakeGuardedApp{}
+		var borClientsClosed atomic.Bool
 		require.NotPanics(t, func() {
-			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake)
+			mustApplyBorFailoverBPGuard(log.NewNopLogger(), fake, func() {
+				borClientsClosed.Store(true)
+			})
 		})
 		require.False(t, fake.closeCalled)
+		require.False(t, borClientsClosed.Load())
 	})
 }
 

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -175,7 +175,7 @@ func initRootCmd(
 		MigrateCommand(),
 	)
 
-	AddCommandsWithStartCmdOptions(rootCmd, app.DefaultNodeHome, newApp, appExport, server.StartCmdOptions{
+	AddCommandsWithStartCmdOptions(rootCmd, app.DefaultNodeHome, newApp, newStartApp, appExport, server.StartCmdOptions{
 		AddFlags: func(startCmd *cobra.Command) {
 			startCmd.Flags().Bool(helper.RestServerFlag, true, "Enable the REST server")
 			startCmd.Flags().Bool(helper.BridgeFlag, false, "Enable the bridge server")
@@ -339,7 +339,14 @@ func checkServerStatus(ctx context.Context, url string, resultChan chan<- string
 }
 
 // AddCommandsWithStartCmdOptions adds server commands with the provided StartCmdOptions.
-func AddCommandsWithStartCmdOptions(rootCmd *cobra.Command, defaultNodeHome string, appCreator servertypes.AppCreator, appExport servertypes.AppExporter, opts server.StartCmdOptions) {
+func AddCommandsWithStartCmdOptions(
+	rootCmd *cobra.Command,
+	defaultNodeHome string,
+	appCreator servertypes.AppCreator,
+	startAppCreator servertypes.AppCreator,
+	appExport servertypes.AppExporter,
+	opts server.StartCmdOptions,
+) {
 	cometCmd := &cobra.Command{
 		Use:     "comet",
 		Aliases: []string{"cometbft", "tendermint"},
@@ -357,7 +364,7 @@ func AddCommandsWithStartCmdOptions(rootCmd *cobra.Command, defaultNodeHome stri
 		server.BootstrapStateCmd(appCreator),
 	)
 
-	startCmd := server.StartCmdWithOptions(appCreator, defaultNodeHome, opts)
+	startCmd := server.StartCmdWithOptions(startAppCreator, defaultNodeHome, opts)
 
 	rootCmd.AddCommand(
 		startCmd,
@@ -433,6 +440,48 @@ func newApp(
 		appOpts,
 		baseappOptions...,
 	)
+}
+
+// borFailoverGuardedApp is the minimal surface applyBorFailoverBPGuard needs, so
+// the guard-and-close decision is unit-testable without building a full app.
+type borFailoverGuardedApp interface {
+	EnforceBorFailoverBPGuard() error
+	Close() error
+}
+
+// applyBorFailoverBPGuard runs the Bor failover BP guard and, on failure, closes
+// the app and returns the guard error so the start path fails closed. The guard
+// error is always the one returned; a Close failure is only logged.
+func applyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp) error {
+	if err := hApp.EnforceBorFailoverBPGuard(); err != nil {
+		if closeErr := hApp.Close(); closeErr != nil {
+			logger.Error("failed to close app after Bor failover BP guard failure", "error", closeErr)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// mustApplyBorFailoverBPGuard panics when the Bor failover BP guard fails, so the
+// start path fails closed: a protected block producer with failover configured
+// never proceeds to serve.
+func mustApplyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp) {
+	if err := applyBorFailoverBPGuard(logger, hApp); err != nil {
+		panic(err)
+	}
+}
+
+func newStartApp(
+	logger log.Logger,
+	db dbm.DB,
+	traceStore io.Writer,
+	appOpts servertypes.AppOptions,
+) servertypes.Application {
+	hApp := newApp(logger, db, traceStore, appOpts).(*app.HeimdallApp)
+	mustApplyBorFailoverBPGuard(logger, hApp)
+
+	return hApp
 }
 
 // appExport creates a new heimdall app (optionally at a given height) and exports state.

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -185,9 +185,7 @@ func initRootCmd(
 		PostSetup: func(svrCtx *server.Context, clientCtx client.Context, ctx context.Context, g *errgroup.Group) error {
 			helper.InitHeimdallConfig("")
 			bridgeEnabled := viper.GetBool(helper.BridgeFlag)
-			if !bridgeEnabled {
-				registerBorChainClientCleanup(ctx, g, helper.CloseBorChainClients)
-			}
+			registerBorChainClientCleanup(ctx, g, helper.CloseBorChainClients)
 
 			// wait for the rest server to start.
 			resultChan := make(chan string, 1)
@@ -462,13 +460,15 @@ type borFailoverGuardedApp interface {
 }
 
 // applyBorFailoverBPGuard runs the Bor failover BP guard and, on failure, closes
-// the app and returns the guard error so the start path fails closed. The guard
-// error is always the one returned; a Close failure is only logged.
-func applyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp) error {
+// the app and Bor chain clients before returning the guard error so the start
+// path fails closed. The guard error is always the one returned; a Close failure
+// is only logged.
+func applyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp, closeBorClients func()) error {
 	if err := hApp.EnforceBorFailoverBPGuard(); err != nil {
 		if closeErr := hApp.Close(); closeErr != nil {
 			logger.Error("failed to close app after Bor failover BP guard failure", "error", closeErr)
 		}
+		closeBorClients()
 		return err
 	}
 
@@ -478,8 +478,8 @@ func applyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp) erro
 // mustApplyBorFailoverBPGuard panics when the Bor failover BP guard fails, so the
 // start path fails closed: a protected block producer with failover configured
 // never proceeds to serve.
-func mustApplyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp) {
-	if err := applyBorFailoverBPGuard(logger, hApp); err != nil {
+func mustApplyBorFailoverBPGuard(logger log.Logger, hApp borFailoverGuardedApp, closeBorClients func()) {
+	if err := applyBorFailoverBPGuard(logger, hApp, closeBorClients); err != nil {
 		panic(err)
 	}
 }
@@ -491,7 +491,7 @@ func newStartApp(
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
 	hApp := newApp(logger, db, traceStore, appOpts).(*app.HeimdallApp)
-	mustApplyBorFailoverBPGuard(logger, hApp)
+	mustApplyBorFailoverBPGuard(logger, hApp, helper.CloseBorChainClients)
 
 	return hApp
 }

--- a/cmd/heimdalld/cmd/commands.go
+++ b/cmd/heimdalld/cmd/commands.go
@@ -184,6 +184,10 @@ func initRootCmd(
 		},
 		PostSetup: func(svrCtx *server.Context, clientCtx client.Context, ctx context.Context, g *errgroup.Group) error {
 			helper.InitHeimdallConfig("")
+			bridgeEnabled := viper.GetBool(helper.BridgeFlag)
+			if !bridgeEnabled {
+				registerBorChainClientCleanup(ctx, g, helper.CloseBorChainClients)
+			}
 
 			// wait for the rest server to start.
 			resultChan := make(chan string, 1)
@@ -242,7 +246,7 @@ func initRootCmd(
 				WithChainID(chainParam.ChainParams.HeimdallChainId)
 
 			// start bridge
-			if viper.GetBool(helper.BridgeFlag) {
+			if bridgeEnabled {
 				bridge.AdjustDBValue(rootCmd)
 				g.Go(func() error {
 					return bridge.StartWithCtx(ctx, clientCtx)
@@ -372,6 +376,14 @@ func AddCommandsWithStartCmdOptions(
 		server.ExportCmd(appExport, defaultNodeHome),
 		server.NewRollbackCmd(appCreator, defaultNodeHome),
 	)
+}
+
+func registerBorChainClientCleanup(ctx context.Context, g *errgroup.Group, closeBorClients func()) {
+	g.Go(func() error {
+		<-ctx.Done()
+		closeBorClients()
+		return nil
+	})
 }
 
 func queryCommand() *cobra.Command {

--- a/docs/bor-failover.md
+++ b/docs/bor-failover.md
@@ -44,7 +44,10 @@ A fallback is **never served traffic until a probe confirms its chain identity**
 matches the expected chain:
 
 - HTTP validates the **chain ID** (`eth_chainId`).
-- gRPC validates the **genesis block hash** (the gRPC API has no chain-id call).
+- gRPC validates the **genesis block hash** (the gRPC API has no chain-id call)
+  and, when HTTP Bor is available, a recent-block **HTTP/gRPC hash parity**
+  check. This keeps a same-chain but wrong-version gRPC fallback from becoming a
+  candidate when its recent header hashes diverge from HTTP.
 
 This is the guard against a misconfigured fallback that points at the wrong Bor
 network feeding bad data into consensus-critical reads.

--- a/docs/bor-failover.md
+++ b/docs/bor-failover.md
@@ -1,0 +1,202 @@
+# Bor endpoint failover
+
+Heimdall talks to Bor over HTTP JSON-RPC and (optionally) gRPC. Both transports
+support **multiple priority-ordered endpoints with automatic failover and
+switchback**, so a single Bor outage doesn't stall Heimdall's Bor-dependent
+reads (span/producer lookups, root hashes, milestone votes, block headers).
+
+The logic is a transport-agnostic state machine in
+[`x/bor/failover`](../x/bor/failover), shared by the HTTP client
+([`helper/bor_failover_http.go`](../helper/bor_failover_http.go)) and the gRPC
+client ([`x/bor/grpc/failover.go`](../x/bor/grpc/failover.go)).
+
+## Configuration
+
+`bor_rpc_url` and `bor_grpc_url` accept a **comma-separated, priority-ordered**
+list. Index 0 is the primary; the rest are fallbacks in descending priority.
+
+```toml
+# Failover across three Bor RPC endpoints (first = primary).
+bor_rpc_url = "http://localhost:8545,https://bor-b.internal:8545,https://bor-c.internal:8545"
+
+bor_grpc_flag  = "true"
+# Remote gRPC endpoints need an explicit http:// or https:// scheme; a bare
+# host:port is accepted only for localhost.
+bor_grpc_url   = "localhost:3131,https://bor-b.internal:3131"
+bor_grpc_token = "" # Bearer token for gRPC auth; put gRPC credentials here, not in the URL.
+
+# Per-attempt timeout (also the unit the in-call budget is built from).
+bor_rpc_timeout = "1s"
+```
+
+A **single endpoint keeps the previous behavior exactly**: a plain dial, no
+background prober, no failover machinery.
+
+HTTP endpoint URLs may carry credentials (userinfo or `?apikey=...`); these are
+masked in the HTTP failover logs — userinfo password and query values, though a
+path-embedded token cannot be detected generically. gRPC authentication uses the
+separate `bor_grpc_token` (a Bearer token), not the URL; the gRPC client logs its
+configured address as-is, so do not embed secrets in `bor_grpc_url`.
+
+## Identity validation
+
+A fallback is **never served traffic until a probe confirms its chain identity**
+matches the expected chain:
+
+- HTTP validates the **chain ID** (`eth_chainId`).
+- gRPC validates the **genesis block hash** (the gRPC API has no chain-id call).
+
+This is the guard against a misconfigured fallback that points at the wrong Bor
+network feeding bad data into consensus-critical reads.
+
+The **primary owns the expected identity whenever it is reachable**:
+
+- Normally the primary establishes it (captured best-effort at startup, then on
+  its first probe).
+- If the primary has **never** been reachable, a reachable fallback may
+  *provisionally* anchor the expectation — but only after the primary has failed
+  `primaryAnchorFailureThreshold` (2) consecutive probes — so failover still
+  engages when the primary is down at boot. Probes run concurrently, so whichever
+  reachable fallback validates first wins the anchor; this is not
+  priority-ordered.
+- Once the primary answers, it **reclaims** the expectation, becomes active
+  immediately, and **demotes every other endpoint** (they must re-validate
+  against the reclaimed identity before they can be used again). The real
+  primary is therefore never rejected, and any fallback that had validated
+  against a provisional identity is dropped from the candidate set at once.
+
+The only window in which a wrong-network fallback can serve is one where the
+primary has *never* been reachable. Once the primary is reachable even once,
+that window closes.
+
+## Failover rules
+
+The active endpoint always receives the request first (even if it is currently
+flagged unhealthy — the flag governs candidacy and proactive switching, not
+whether the current active is tried).
+
+### In-call cascade
+
+On a **retriable** failure of the active endpoint, the call cascades to the next
+validated endpoint and promotes the first that succeeds.
+
+- **HTTP** cascades on a transport error, a per-attempt timeout, or an HTTP
+  **5xx**. It does **not** cascade on a 4xx — that is returned as-is (a fallback
+  would answer identically). Application-level JSON-RPC errors arrive as HTTP 200
+  and are not failover triggers. If every endpoint returns 5xx, the last real
+  response is preserved and returned.
+- **gRPC** cascades only on transport-style status codes: `Unavailable`,
+  `DeadlineExceeded`, `ResourceExhausted`. Logical errors (NotFound / validation,
+  surfacing as `Unknown`) are returned as-is, never retried.
+
+Candidate selection:
+
+- Only **currently-healthy** endpoints (identity-validated and not recently
+  failed) are candidates.
+- Ordered **cooled first, then uncooled, each in priority (index) order** — a
+  cooled higher-priority fallback is preferred over an uncooled one within a
+  single call.
+- A failed endpoint is marked unhealthy (dropped from candidates until a probe
+  re-confirms it). The first candidate that succeeds is **promoted to active**,
+  so subsequent calls start there until switchback.
+- The cascade stops early if the **caller context is done** (deadline or
+  cancellation).
+
+### Time budget
+
+- Per-attempt timeout is `bor_rpc_timeout`.
+- The caller-side budget for one Bor call is:
+
+  ```
+  budget = bor_rpc_timeout × clamp( bor_grpc_flag ? max(httpCount, grpcCount) : httpCount , 1, maxBudgetedEndpoints )
+  ```
+
+  with `maxBudgetedEndpoints = 3`. This is a **time budget, not a hard attempt
+  counter**: the deadline stops the cascade, so fast-failing endpoints beyond the
+  cap may still be tried within the budget, while slow ones beyond it are reached
+  on later calls (by then the prober has typically switched active away from a
+  dead endpoint). The cap keeps one call's worst case under CometBFT's ~10s ABCI
+  budget. When `bor_grpc_flag = true` the budget is sized by the larger of the
+  HTTP and gRPC counts (the HTTP client used by the broadcaster and the gRPC
+  client used by side handlers share it); when gRPC is disabled it is the HTTP
+  count alone.
+
+`SendTransaction` (the bridge broadcaster) also rides the HTTP failover client; a
+cascade re-broadcasts the same signed transaction, which is idempotent (same tx
+hash), so failover on writes is safe.
+
+### Proactive switch (background prober)
+
+Independently of any call, the background prober switches the active endpoint off
+an **unhealthy** active before the next call has to discover the failure. It
+moves to the best healthy alternative: highest priority, preferring a cooled
+endpoint but using an **uncooled** one in an emergency. If nothing healthy
+exists, it stays put (it never routes to an unvalidated endpoint).
+
+## Switchback rules
+
+- **Reclaim (immediate):** when the primary recovers and reclaims chain identity,
+  it becomes active at once, bypassing the threshold and cooldown (and demoting
+  the other endpoints). This is the only immediate switchback.
+- **Ordinary same-network recovery (gated):** the prober reverts to a recovered
+  higher-priority endpoint only after it has accrued `consecutiveThreshold` (3)
+  consecutive successful probes **and** stayed healthy for the
+  `promotionCooldown` (60s). It reverts to the **highest-priority** endpoint
+  (scanning from index 0 up to the active index) that qualifies.
+
+The asymmetry is deliberate: **fail away fast, switch back slow.** Moving down to
+a healthy fallback is cheap; moving back up to a higher-priority endpoint waits
+out the cooldown to avoid flapping. Switching *off* a dead active (proactive
+switch) may use an uncooled endpoint in an emergency; reverting *up* to a merely
+recovered endpoint requires it to be cooled.
+
+Because reclaim demotes all other endpoints, a correct same-chain fallback that
+was demoted is briefly unavailable for in-call failover (~`consecutiveThreshold`
+probes ≈ 30s) until it re-validates — deliberately chosen over ever serving a
+possibly-wrong-network fallback.
+
+## Timing constants
+
+Hardcoded defaults in [`x/bor/failover/health.go`](../x/bor/failover/health.go)
+(not operator-tunable; `SetTuning` exists for tests only).
+
+| Constant | Default | Meaning |
+| --- | --- | --- |
+| `bor_rpc_timeout` (config) | `1s` | Per-attempt timeout; unit of the in-call budget |
+| `maxBudgetedEndpoints` | `3` | Cap on the in-call time budget multiplier |
+| `DefaultCheckInterval` | `10s` | Background prober cycle period |
+| `DefaultConsecutiveThreshold` | `3` | Consecutive good probes for a fallback to become healthy |
+| `DefaultPromotionCooldown` | `60s` | Continuous-health duration before revert-to-higher-priority |
+| `DefaultProbeTimeout` | `3s` | Per-probe timeout (separate from `bor_rpc_timeout`) |
+| `primaryAnchorFailureThreshold` | `2` | Consecutive primary probe failures before a fallback may provisionally anchor identity |
+
+Each prober cycle runs `probeAll → maybePromote → maybeProactiveSwitch`.
+
+## Expected latencies (defaults)
+
+| Event | Latency |
+| --- | --- |
+| Reactive fail-over off a failing active | within one call (budget ≥ 2 endpoints) |
+| Proactive switch off a dead active | ≤ ~1 cycle once a healthy alternative exists; otherwise after fallback validation (~30s) |
+| A recovered fallback becomes a usable candidate | ~3 good probes ≈ ~30s |
+| Switchback to a recovered primary (ordinary) | healthy (~30s) + cooldown (60s) ≈ 60–90s |
+| Switchback to the primary on identity reclaim | immediate (~1 probe interval) |
+
+## Scope and safety
+
+These are **per-node read-routing** rules feeding Heimdall's side handlers
+(`ExtendVote`), never consensus state. The worst case for a node briefly routed
+to a lagging but same-chain fallback is its own NO/UNSPECIFIED vote on a side
+transaction — not a chain split. A wrong-network or unvalidated endpoint is never
+a candidate and never active, except the narrow provisional-anchor window
+described above, which the primary's reclaim ends.
+
+## Metrics
+
+Labeled by transport (`http` / `grpc`), see
+[`metrics/borfailover.go`](../metrics/borfailover.go):
+
+- `*_bor_failover_switches_total` — in-call cascade switches
+- `*_bor_failover_proactive_switches_total` — background-prober switches (incl. revert-to-primary)
+- `*_bor_failover_active_index` — index of the currently active endpoint (0 = primary)
+- `*_bor_failover_healthy_endpoints` — number of endpoints currently healthy

--- a/docs/bor-failover.md
+++ b/docs/bor-failover.md
@@ -32,6 +32,20 @@ bor_rpc_timeout = "1s"
 A **single endpoint keeps the previous behavior exactly**: a plain dial, no
 background prober, no failover machinery.
 
+## Block producer restriction
+
+Bor endpoint failover is rejected at startup for Heimdall nodes whose local
+signer maps to a validator ID in the protected block-producer set. The
+protected set is built from the configured producer list (`producer_votes`,
+defaulting by network, e.g. mainnet `91,92,93,94`), the current span's selected
+producer(s), and the current VEBLOP producer candidate set.
+
+This restriction is intentionally narrower than "all validators": active
+validators outside the protected producer set may use Bor failover. Block
+producers must use a single local/self Bor endpoint so their milestone votes do
+not mask local Bor downtime and keep them eligible for span rotation when they
+cannot actually produce blocks.
+
 HTTP endpoint URLs may carry credentials (userinfo or `?apikey=...`); these are
 masked in the HTTP failover logs — userinfo password and query values, though a
 path-embedded token cannot be detected generically. gRPC authentication uses the

--- a/docs/bor-failover.md
+++ b/docs/bor-failover.md
@@ -26,6 +26,8 @@ bor_grpc_url   = "localhost:3131,https://bor-b.internal:3131"
 bor_grpc_token = "" # Bearer token for gRPC auth; put gRPC credentials here, not in the URL.
 
 # Per-attempt timeout (also the unit the in-call budget is built from).
+# Clamped to MaxBorRPCTimeout (3s) at config load so the in-call budget stays
+# under CometBFT's ~10s ABCI window.
 bor_rpc_timeout = "1s"
 ```
 
@@ -121,7 +123,8 @@ Candidate selection:
 
 ### Time budget
 
-- Per-attempt timeout is `bor_rpc_timeout`.
+- Per-attempt timeout is `bor_rpc_timeout`, clamped at config load to
+  `MaxBorRPCTimeout` (`3s`).
 - The caller-side budget for one Bor call is:
 
   ```
@@ -133,7 +136,11 @@ Candidate selection:
   cap may still be tried within the budget, while slow ones beyond it are reached
   on later calls (by then the prober has typically switched active away from a
   dead endpoint). The cap keeps one call's worst case under CometBFT's ~10s ABCI
-  budget. When `bor_grpc_flag = true` the budget is sized by the larger of the
+  budget; because `bor_rpc_timeout` is itself clamped to `MaxBorRPCTimeout`
+  (`maxBorChainCallBudget / maxBudgetedEndpoints` = `3s`), the worst-case budget
+  is bounded at `9s` regardless of the configured value, so a slow Bor can't
+  stall a milestone/checkpoint vote extension into a missed vote. When
+  `bor_grpc_flag = true` the budget is sized by the larger of the
   HTTP and gRPC counts (the HTTP client used by the broadcaster and the gRPC
   client used by side handlers share it); when gRPC is disabled it is the HTTP
   count alone.
@@ -174,12 +181,17 @@ possibly-wrong-network fallback.
 
 ## Timing constants
 
-Hardcoded defaults in [`x/bor/failover/health.go`](../x/bor/failover/health.go)
-(not operator-tunable; `SetTuning` exists for tests only).
+Sources vary: `bor_rpc_timeout` is operator config (clamped to `MaxBorRPCTimeout`
+at load); `MaxBorRPCTimeout` and `maxBudgetedEndpoints` are constants in
+[`helper/bor_failover_http.go`](../helper/bor_failover_http.go); the remaining
+prober defaults are hardcoded in
+[`x/bor/failover/health.go`](../x/bor/failover/health.go) and are not
+operator-tunable (`SetTuning` exists for tests only).
 
 | Constant | Default | Meaning |
 | --- | --- | --- |
-| `bor_rpc_timeout` (config) | `1s` | Per-attempt timeout; unit of the in-call budget |
+| `bor_rpc_timeout` (config) | `1s` | Per-attempt timeout (clamped to `MaxBorRPCTimeout`); unit of the in-call budget |
+| `MaxBorRPCTimeout` | `3s` | Upper bound enforced on `bor_rpc_timeout` (`maxBorChainCallBudget / maxBudgetedEndpoints`) |
 | `maxBudgetedEndpoints` | `3` | Cap on the in-call time budget multiplier |
 | `DefaultCheckInterval` | `10s` | Background prober cycle period |
 | `DefaultConsecutiveThreshold` | `3` | Consecutive good probes for a fallback to become healthy |

--- a/helper/bor_failover_config.go
+++ b/helper/bor_failover_config.go
@@ -33,6 +33,15 @@ func parseURLs(s string) []string {
 	return out
 }
 
+// BorFailoverConfigured reports whether the Bor client config enables
+// multi-endpoint failover on either transport.
+func BorFailoverConfigured(cfg CustomConfig) bool {
+	httpFailover := len(parseURLs(cfg.BorRPCUrl)) >= 2
+	grpcFailover := cfg.BorGRPCFlag && len(parseURLs(cfg.BorGRPCUrl)) >= 2
+
+	return httpFailover || grpcFailover
+}
+
 // initBorRPCClient sets the borRPCClient/borClient globals. A comma-separated
 // bor_rpc_url enables HTTP failover across the priority-ordered endpoints
 // (index 0 = primary); a single URL keeps the plain dial path unchanged. It

--- a/helper/bor_failover_config.go
+++ b/helper/bor_failover_config.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -71,7 +72,7 @@ func initBorGRPCClient() {
 		log.Fatal("bor gRPC is enabled but bor_grpc_url is empty")
 	}
 
-	primaryGRPC, grpcClient, err := buildBorGRPCClient(grpcURLs, conf.Custom.BorGRPCToken, conf.Custom.BorRPCTimeout)
+	primaryGRPC, grpcClient, err := buildBorGRPCClient(grpcURLs, conf.Custom.BorGRPCToken, conf.Custom.BorRPCTimeout, borClient)
 	if err != nil {
 		log.Fatal("unable to create bor gRPC client", "URL", redactURLs(conf.Custom.BorGRPCUrl), "error", err)
 	}
@@ -89,7 +90,7 @@ func initBorGRPCClient() {
 // configured, or a failover wrapper when several are. The configured primary
 // must stay at index 0 so identity anchoring remains authoritative; invalid
 // fallbacks are skipped so a single bad fallback can't block startup.
-func buildBorGRPCClient(urls []string, token string, attemptTimeout time.Duration) (*borgrpc.BorGRPCClient, borgrpc.Client, error) {
+func buildBorGRPCClient(urls []string, token string, attemptTimeout time.Duration, httpClient parityHTTPFetcher) (*borgrpc.BorGRPCClient, borgrpc.Client, error) {
 	clients := make([]*borgrpc.BorGRPCClient, 0, len(urls))
 	for i, u := range urls {
 		c, err := borgrpc.NewBorGRPCClient(u, token, Logger)
@@ -111,5 +112,28 @@ func buildBorGRPCClient(urls []string, token string, attemptTimeout time.Duratio
 		return clients[0], clients[0], nil
 	}
 
-	return clients[0], borgrpc.NewMultiBorGRPCClient(clients, Logger, metrics.BorFailover("grpc"), attemptTimeout), nil
+	return clients[0], borgrpc.NewMultiBorGRPCClient(
+		clients, Logger, metrics.BorFailover("grpc"), attemptTimeout,
+		borGRPCParityValidators(httpClient, attemptTimeout)...,
+	), nil
+}
+
+func borGRPCParityValidators(httpClient parityHTTPFetcher, timeout time.Duration) []borgrpc.EndpointValidator {
+	if httpClient == nil {
+		return nil
+	}
+	return []borgrpc.EndpointValidator{borGRPCParityValidator(httpClient, timeout)}
+}
+
+func borGRPCParityValidator(httpClient parityHTTPFetcher, timeout time.Duration) borgrpc.EndpointValidator {
+	return func(_ context.Context, i int, grpcClient borgrpc.EndpointHeaderFetcher) error {
+		ok, mismatch := checkBorGRPCHashParityOnceQuiet(httpClient, grpcClient, timeout)
+		if ok {
+			return nil
+		}
+		if mismatch {
+			return fmt.Errorf("bor gRPC endpoint %d hash mismatch with HTTP", i)
+		}
+		return fmt.Errorf("bor gRPC endpoint %d hash parity unavailable", i)
+	}
 }

--- a/helper/bor_failover_config.go
+++ b/helper/bor_failover_config.go
@@ -40,18 +40,22 @@ func initBorRPCClient() {
 	var err error
 
 	borRPCUrls := parseURLs(conf.Custom.BorRPCUrl)
+	borRPCLogURL := conf.Custom.BorRPCUrl
 	if len(borRPCUrls) >= 2 {
 		if borRPCClient, borClient, err = newBorHTTPFailoverClient(borRPCUrls, conf.Custom.BorRPCTimeout); err != nil {
 			log.Fatal("unable to set up bor RPC failover client", "URLs", redactURLs(conf.Custom.BorRPCUrl), "error", err)
 		}
-	} else {
-		if borRPCClient, err = rpc.Dial(conf.Custom.BorRPCUrl); err != nil {
-			log.Fatal("unable to dial bor chain RPC client", "URL", redactURL(conf.Custom.BorRPCUrl), "error", err)
+	} else if len(borRPCUrls) == 1 {
+		borRPCLogURL = borRPCUrls[0]
+		if borRPCClient, err = rpc.Dial(borRPCUrls[0]); err != nil {
+			log.Fatal("unable to dial bor chain RPC client", "URL", redactURL(borRPCUrls[0]), "error", err)
 		}
 		borClient = ethclient.NewClient(borRPCClient)
+	} else {
+		log.Fatal("bor_rpc_url is empty")
 	}
 
-	warnIfBorRPCInaccessible(borClient, conf.Custom.BorRPCTimeout, redactURLs(conf.Custom.BorRPCUrl))
+	warnIfBorRPCInaccessible(borClient, conf.Custom.BorRPCTimeout, redactURLs(borRPCLogURL))
 }
 
 // initBorGRPCClient sets the borGRPCClient global when bor gRPC is enabled,
@@ -82,14 +86,17 @@ func initBorGRPCClient() {
 // buildBorGRPCClient dials each priority-ordered gRPC URL and returns the
 // primary concrete client (for the startup reachability and hash-parity checks)
 // plus the client that serves traffic: the single client when one URL is
-// configured, or a failover wrapper when several are. An invalid/undialable URL
-// is skipped (mirroring the HTTP path) so a single bad fallback can't block
-// startup; it errors only when no endpoint survives.
+// configured, or a failover wrapper when several are. The configured primary
+// must stay at index 0 so identity anchoring remains authoritative; invalid
+// fallbacks are skipped so a single bad fallback can't block startup.
 func buildBorGRPCClient(urls []string, token string, attemptTimeout time.Duration) (*borgrpc.BorGRPCClient, borgrpc.Client, error) {
 	clients := make([]*borgrpc.BorGRPCClient, 0, len(urls))
-	for _, u := range urls {
+	for i, u := range urls {
 		c, err := borgrpc.NewBorGRPCClient(u, token, Logger)
 		if err != nil {
+			if i == primaryEndpoint {
+				return nil, nil, fmt.Errorf("invalid primary bor gRPC URL %s: %w", redactURL(u), err)
+			}
 			Logger.Warn("bor failover: skipping invalid bor gRPC URL", "url", redactURL(u), "error", err)
 			continue
 		}

--- a/helper/bor_failover_config.go
+++ b/helper/bor_failover_config.go
@@ -1,0 +1,108 @@
+package helper
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/0xPolygon/heimdall-v2/metrics"
+	borgrpc "github.com/0xPolygon/heimdall-v2/x/bor/grpc"
+)
+
+// parseURLs splits a comma-separated URL string into a trimmed, non-empty,
+// priority-ordered slice (first = primary). Used for the Bor RPC/gRPC failover
+// endpoint lists; a single URL yields a one-element slice (no failover).
+func parseURLs(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+
+	return out
+}
+
+// initBorRPCClient sets the borRPCClient/borClient globals. A comma-separated
+// bor_rpc_url enables HTTP failover across the priority-ordered endpoints
+// (index 0 = primary); a single URL keeps the plain dial path unchanged. It
+// warns (never fatals) if the primary is unreachable at startup.
+func initBorRPCClient() {
+	var err error
+
+	borRPCUrls := parseURLs(conf.Custom.BorRPCUrl)
+	if len(borRPCUrls) >= 2 {
+		if borRPCClient, borClient, err = newBorHTTPFailoverClient(borRPCUrls, conf.Custom.BorRPCTimeout); err != nil {
+			log.Fatal("unable to set up bor RPC failover client", "URLs", redactURLs(conf.Custom.BorRPCUrl), "error", err)
+		}
+	} else {
+		if borRPCClient, err = rpc.Dial(conf.Custom.BorRPCUrl); err != nil {
+			log.Fatal("unable to dial bor chain RPC client", "URL", redactURL(conf.Custom.BorRPCUrl), "error", err)
+		}
+		borClient = ethclient.NewClient(borRPCClient)
+	}
+
+	warnIfBorRPCInaccessible(borClient, conf.Custom.BorRPCTimeout, redactURLs(conf.Custom.BorRPCUrl))
+}
+
+// initBorGRPCClient sets the borGRPCClient global when bor gRPC is enabled,
+// supporting comma-separated bor_grpc_url failover, and runs the primary's
+// startup reachability and HTTP/gRPC hash-parity checks.
+func initBorGRPCClient() {
+	if !conf.Custom.BorGRPCFlag {
+		return
+	}
+
+	grpcURLs := parseURLs(conf.Custom.BorGRPCUrl)
+	if len(grpcURLs) == 0 {
+		log.Fatal("bor gRPC is enabled but bor_grpc_url is empty")
+	}
+
+	primaryGRPC, grpcClient, err := buildBorGRPCClient(grpcURLs, conf.Custom.BorGRPCToken, conf.Custom.BorRPCTimeout)
+	if err != nil {
+		log.Fatal("unable to create bor gRPC client", "URL", redactURLs(conf.Custom.BorGRPCUrl), "error", err)
+	}
+
+	borGRPCClient = grpcClient
+	warnIfBorGRPCInaccessible(primaryGRPC, conf.Custom.BorRPCTimeout, redactURL(grpcURLs[0]))
+	// Fire-and-forget parity goroutine; removal is only observable in production init.
+	// mutator-disable-next-line statement-deletion in production init
+	verifyBorGRPCHashParity(borClient, primaryGRPC, conf.Custom.BorRPCTimeout)
+}
+
+// buildBorGRPCClient dials each priority-ordered gRPC URL and returns the
+// primary concrete client (for the startup reachability and hash-parity checks)
+// plus the client that serves traffic: the single client when one URL is
+// configured, or a failover wrapper when several are. An invalid/undialable URL
+// is skipped (mirroring the HTTP path) so a single bad fallback can't block
+// startup; it errors only when no endpoint survives.
+func buildBorGRPCClient(urls []string, token string, attemptTimeout time.Duration) (*borgrpc.BorGRPCClient, borgrpc.Client, error) {
+	clients := make([]*borgrpc.BorGRPCClient, 0, len(urls))
+	for _, u := range urls {
+		c, err := borgrpc.NewBorGRPCClient(u, token, Logger)
+		if err != nil {
+			Logger.Warn("bor failover: skipping invalid bor gRPC URL", "url", redactURL(u), "error", err)
+			continue
+		}
+		clients = append(clients, c)
+	}
+
+	if len(clients) == 0 {
+		return nil, nil, fmt.Errorf("no valid bor gRPC endpoints among %d configured", len(urls))
+	}
+
+	if len(clients) == 1 {
+		return clients[0], clients[0], nil
+	}
+
+	return clients[0], borgrpc.NewMultiBorGRPCClient(clients, Logger, metrics.BorFailover("grpc"), attemptTimeout), nil
+}

--- a/helper/bor_failover_config.go
+++ b/helper/bor_failover_config.go
@@ -122,18 +122,31 @@ func borGRPCParityValidators(httpClient parityHTTPFetcher, timeout time.Duration
 	if httpClient == nil {
 		return nil
 	}
-	return []borgrpc.EndpointValidator{borGRPCParityValidator(httpClient, timeout)}
+	return []borgrpc.EndpointValidator{borGRPCParityValidator(httpClient, timeout, borGRPCParityFatalFunc)}
 }
 
-func borGRPCParityValidator(httpClient parityHTTPFetcher, timeout time.Duration) borgrpc.EndpointValidator {
-	return func(_ context.Context, i int, grpcClient borgrpc.EndpointHeaderFetcher) error {
-		ok, mismatch := checkBorGRPCHashParityOnceQuiet(httpClient, grpcClient, timeout)
-		if ok {
-			return nil
+// borGRPCParityValidator returns a probe-time validator comparing each gRPC
+// endpoint's recent header hash against HTTP. A confirmed mismatch keeps the
+// endpoint out of the healthy set; a transient HTTP-side read failure (parity
+// unavailable) is not the gRPC endpoint's fault and does not demote it, matching
+// the boot-time streak-reset behavior. To mirror the boot-time fatal contract at
+// runtime, a sustained mismatch streak on the primary calls fatalFunc — without
+// it, a fleet-wide downgrade to a wrong-version bor after startup would keep
+// feeding wrong Header hashes through the always-tried-first active endpoint.
+func borGRPCParityValidator(httpClient parityHTTPFetcher, timeout time.Duration, fatalFunc func(msg string, keysAndValues ...interface{})) borgrpc.EndpointValidator {
+	var primaryMismatches int
+	return func(ctx context.Context, i int, grpcClient borgrpc.EndpointHeaderFetcher) error {
+		_, mismatch := checkBorGRPCHashParityOnceQuiet(ctx, httpClient, grpcClient, timeout)
+		if i == primaryEndpoint {
+			next, fatal := updateParityMismatchStreak(primaryMismatches, mismatch, borGRPCParityMismatchStreak)
+			primaryMismatches = next
+			if fatal {
+				fatalFunc(borGRPCParityFatalMsg, "consecutiveMismatches", next)
+			}
 		}
 		if mismatch {
 			return fmt.Errorf("bor gRPC endpoint %d hash mismatch with HTTP", i)
 		}
-		return fmt.Errorf("bor gRPC endpoint %d hash parity unavailable", i)
+		return nil
 	}
 }

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -28,6 +28,27 @@ func (p *fakeChainIDProbe) Close() {
 	p.closed = true
 }
 
+func preserveBorClients(t *testing.T) {
+	t.Helper()
+
+	oldRPC := borRPCClient
+	oldBor := borClient
+	oldHTTP := borRPCFailoverTransport
+	oldGRPC := borGRPCClient
+	t.Cleanup(func() {
+		if borRPCClient != nil && borRPCClient != oldRPC {
+			borRPCClient.Close()
+		}
+		if borRPCFailoverTransport != nil && borRPCFailoverTransport != oldHTTP {
+			borRPCFailoverTransport.Close()
+		}
+		borRPCClient = oldRPC
+		borClient = oldBor
+		borRPCFailoverTransport = oldHTTP
+		borGRPCClient = oldGRPC
+	})
+}
+
 func TestParseURLs(t *testing.T) {
 	require.Nil(t, parseURLs(""))
 	require.Equal(t, []string{"http://a"}, parseURLs("http://a"))
@@ -90,22 +111,7 @@ func TestGetBorChainCallTimeout(t *testing.T) {
 }
 
 func TestInitBorRPCClient_SingleAndFailover(t *testing.T) {
-	oldRPC := borRPCClient
-	oldBor := borClient
-	oldHTTP := borRPCFailoverTransport
-	oldGRPC := borGRPCClient
-	t.Cleanup(func() {
-		if borRPCClient != nil && borRPCClient != oldRPC {
-			borRPCClient.Close()
-		}
-		if borRPCFailoverTransport != nil && borRPCFailoverTransport != oldHTTP {
-			borRPCFailoverTransport.Close()
-		}
-		borRPCClient = oldRPC
-		borClient = oldBor
-		borRPCFailoverTransport = oldHTTP
-		borGRPCClient = oldGRPC
-	})
+	preserveBorClients(t)
 	borGRPCClient = nil
 
 	s1 := fakeBorRPC(t, "0x1", new(int32))
@@ -142,6 +148,29 @@ func TestInitBorRPCClient_SingleAndFailover(t *testing.T) {
 	require.Equal(t, int64(1), id.Int64())
 }
 
+func TestInitBorRPCClient_UsesParsedSingleURL(t *testing.T) {
+	preserveBorClients(t)
+
+	s1 := fakeBorRPC(t, "0x1", new(int32))
+	defer s1.Close()
+
+	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
+	cfg.Custom.BorRPCTimeout = 100 * time.Millisecond
+	cfg.Custom.BorRPCUrl = s1.URL + ","
+	SetTestConfig(cfg)
+	borRPCClient = nil
+	borClient = nil
+	borRPCFailoverTransport = nil
+	initBorRPCClient()
+	require.NotNil(t, borRPCClient)
+	require.NotNil(t, borClient)
+	require.Nil(t, borRPCFailoverTransport)
+	id, err := borClient.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), id.Int64())
+	borRPCClient.Close()
+}
+
 func TestBuildBorGRPCClient(t *testing.T) {
 	primary, single, err := buildBorGRPCClient([]string{"localhost:3131"}, "", time.Second)
 	require.NoError(t, err)
@@ -157,6 +186,12 @@ func TestBuildBorGRPCClient(t *testing.T) {
 func TestBuildBorGRPCClient_DialError(t *testing.T) {
 	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131"}, "", time.Second)
 	require.Error(t, err)
+}
+
+func TestBuildBorGRPCClient_RejectsInvalidPrimary(t *testing.T) {
+	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131", "localhost:3131"}, "", time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid primary")
 }
 
 func TestBuildBorGRPCClient_SkipsInvalidAmongValid(t *testing.T) {

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -172,24 +172,24 @@ func TestInitBorRPCClient_UsesParsedSingleURL(t *testing.T) {
 }
 
 func TestBuildBorGRPCClient(t *testing.T) {
-	primary, single, err := buildBorGRPCClient([]string{"localhost:3131"}, "", time.Second)
+	primary, single, err := buildBorGRPCClient([]string{"localhost:3131"}, "", time.Second, nil)
 	require.NoError(t, err)
 	require.NotNil(t, primary)
 	require.IsType(t, &borgrpc.BorGRPCClient{}, single)
 
-	_, multi, err := buildBorGRPCClient([]string{"localhost:3131", "localhost:3132"}, "", time.Second)
+	_, multi, err := buildBorGRPCClient([]string{"localhost:3131", "localhost:3132"}, "", time.Second, nil)
 	require.NoError(t, err)
 	require.IsType(t, &borgrpc.MultiBorGRPCClient{}, multi)
 	multi.Close(log.NewNopLogger())
 }
 
 func TestBuildBorGRPCClient_DialError(t *testing.T) {
-	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131"}, "", time.Second)
+	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131"}, "", time.Second, nil)
 	require.Error(t, err)
 }
 
 func TestBuildBorGRPCClient_RejectsInvalidPrimary(t *testing.T) {
-	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131", "localhost:3131"}, "", time.Second)
+	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131", "localhost:3131"}, "", time.Second, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid primary")
 }
@@ -197,7 +197,7 @@ func TestBuildBorGRPCClient_RejectsInvalidPrimary(t *testing.T) {
 func TestBuildBorGRPCClient_SkipsInvalidAmongValid(t *testing.T) {
 	// "1.2.3.4:3131" is a non-localhost bare host:port (rejected by the dialer);
 	// the valid localhost endpoint survives, so startup proceeds with one client.
-	primary, client, err := buildBorGRPCClient([]string{"localhost:3131", "1.2.3.4:3131"}, "", time.Second)
+	primary, client, err := buildBorGRPCClient([]string{"localhost:3131", "1.2.3.4:3131"}, "", time.Second, nil)
 	require.NoError(t, err)
 	require.NotNil(t, primary)
 	require.IsType(t, &borgrpc.BorGRPCClient{}, client)

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -1,0 +1,172 @@
+package helper
+
+import (
+	"errors"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+	borgrpc "github.com/0xPolygon/heimdall-v2/x/bor/grpc"
+)
+
+func TestParseURLs(t *testing.T) {
+	require.Nil(t, parseURLs(""))
+	require.Equal(t, []string{"http://a"}, parseURLs("http://a"))
+	require.Equal(t, []string{"http://a", "http://b"}, parseURLs("http://a,http://b"))
+	require.Equal(t, []string{"http://a", "http://b"}, parseURLs(" http://a , , http://b "))
+	require.Empty(t, parseURLs(" , , "))
+}
+
+func TestRedactURLs(t *testing.T) {
+	require.Equal(t, "http://user:xxxxx@host:8545", redactURL("http://user:pass@host:8545"))
+	require.Equal(t, "https://host/rpc?apikey=xxxxx&token=xxxxx", redactURL("https://host/rpc?token=abc&apikey=secret"))
+	require.Equal(t, "<unparseable>", redactURL("://nope"))
+	require.Equal(t,
+		"http://u:xxxxx@a:8545,https://b/rpc?key=xxxxx",
+		redactURLs("http://u:p@a:8545, https://b/rpc?key=zzz"))
+}
+
+func TestGetBorChainCallTimeout(t *testing.T) {
+	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
+	cfg.Custom.BorRPCTimeout = time.Second
+
+	// 3 HTTP endpoints, at the in-call cascade cap.
+	cfg.Custom.BorGRPCFlag = false
+	cfg.Custom.BorRPCUrl = "http://a,http://b,http://c"
+	SetTestConfig(cfg)
+	require.Equal(t, 3*time.Second, GetBorChainCallTimeout())
+
+	// gRPC enabled with fewer gRPC endpoints than HTTP: sized by the larger count
+	// so the HTTP client (broadcaster) is never under-budgeted.
+	cfg.Custom.BorGRPCFlag = true
+	cfg.Custom.BorGRPCUrl = "localhost:1,localhost:2"
+	SetTestConfig(cfg)
+	require.Equal(t, 3*time.Second, GetBorChainCallTimeout()) // max(3 HTTP, 2 gRPC)
+
+	// Many endpoints are capped at the budgeted endpoint count.
+	cfg.Custom.BorGRPCFlag = false
+	cfg.Custom.BorRPCUrl = "http://a,http://b,http://c,http://d,http://e"
+	SetTestConfig(cfg)
+	require.Equal(t, maxBudgetedEndpoints*time.Second, GetBorChainCallTimeout())
+
+	// Single endpoint unchanged.
+	cfg.Custom.BorRPCUrl = "http://a"
+	SetTestConfig(cfg)
+	require.Equal(t, time.Second, GetBorChainCallTimeout())
+}
+
+func TestBuildBorGRPCClient(t *testing.T) {
+	primary, single, err := buildBorGRPCClient([]string{"localhost:3131"}, "", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.IsType(t, &borgrpc.BorGRPCClient{}, single)
+
+	_, multi, err := buildBorGRPCClient([]string{"localhost:3131", "localhost:3132"}, "", time.Second)
+	require.NoError(t, err)
+	require.IsType(t, &borgrpc.MultiBorGRPCClient{}, multi)
+	multi.Close(log.NewNopLogger())
+}
+
+func TestBuildBorGRPCClient_DialError(t *testing.T) {
+	_, _, err := buildBorGRPCClient([]string{"1.2.3.4:3131"}, "", time.Second)
+	require.Error(t, err)
+}
+
+func TestBuildBorGRPCClient_SkipsInvalidAmongValid(t *testing.T) {
+	// "1.2.3.4:3131" is a non-localhost bare host:port (rejected by the dialer);
+	// the valid localhost endpoint survives, so startup proceeds with one client.
+	primary, client, err := buildBorGRPCClient([]string{"localhost:3131", "1.2.3.4:3131"}, "", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.IsType(t, &borgrpc.BorGRPCClient{}, client)
+}
+
+func TestInitBorGRPCClient_DisabledByFlag(t *testing.T) {
+	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
+	cfg.Custom.BorGRPCFlag = false
+	cfg.Custom.BorGRPCUrl = "localhost:3131"
+	SetTestConfig(cfg)
+	borGRPCClient = nil
+
+	initBorGRPCClient()
+	require.Nil(t, borGRPCClient) // gRPC disabled → no client built
+}
+
+func TestInitBorGRPCClient_Enabled(t *testing.T) {
+	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
+	cfg.Custom.BorGRPCFlag = true
+	cfg.Custom.BorGRPCUrl = "localhost:3131"
+	cfg.Custom.BorRPCTimeout = 100 * time.Millisecond
+	SetTestConfig(cfg)
+	borClient = nil
+	borGRPCClient = nil
+
+	initBorGRPCClient()
+	require.NotNil(t, borGRPCClient) // gRPC enabled → client built (lazy dial)
+}
+
+func TestSucceeded(t *testing.T) {
+	require.True(t, succeeded(&http.Response{StatusCode: http.StatusOK}, nil))
+	require.True(t, succeeded(&http.Response{StatusCode: http.StatusNotFound}, nil))             // 4xx is returned as-is
+	require.False(t, succeeded(&http.Response{StatusCode: http.StatusInternalServerError}, nil)) // 500 → cascade
+	require.False(t, succeeded(&http.Response{StatusCode: http.StatusBadGateway}, nil))
+	require.False(t, succeeded(nil, errors.New("boom")))
+}
+
+func TestCheckChainID(t *testing.T) {
+	tr := &borHTTPFailoverTransport{}
+	require.Error(t, tr.checkChainID(1, big.NewInt(5)))   // expected unknown + fallback → rejected
+	require.NoError(t, tr.checkChainID(0, big.NewInt(5))) // primary establishes the expectation
+	require.Equal(t, int64(5), tr.expectedChainID.Load().Int64())
+	require.NoError(t, tr.checkChainID(1, big.NewInt(5))) // matches
+	require.Error(t, tr.checkChainID(2, big.NewInt(9)))   // mismatch
+}
+
+func TestCanAnchor(t *testing.T) {
+	tr := &borHTTPFailoverTransport{}
+	require.True(t, tr.canAnchor(primaryEndpoint))               // primary always anchors
+	require.False(t, tr.canAnchor(1))                            // fallback blocked while primary reachable
+	tr.primaryProbeFailures.Store(primaryAnchorFailureThreshold) // primary unreachable through startup
+	require.True(t, tr.canAnchor(1))                             // fallback may now anchor
+}
+
+func TestCheckChainID_FallbackAnchorsWhenPrimaryUnreachable(t *testing.T) {
+	tr := &borHTTPFailoverTransport{}
+	tr.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+
+	require.NoError(t, tr.checkChainID(1, big.NewInt(7))) // fallback provisionally establishes the expectation
+	require.Equal(t, int64(7), tr.expectedChainID.Load().Int64())
+	require.NoError(t, tr.checkChainID(2, big.NewInt(7))) // another fallback on the same chain matches
+	require.Error(t, tr.checkChainID(2, big.NewInt(9)))   // a mismatched endpoint is still rejected
+}
+
+func TestCheckChainID_PrimaryReclaimsProvisionalAnchor(t *testing.T) {
+	tr := &borHTTPFailoverTransport{}
+	tr.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+
+	require.NoError(t, tr.checkChainID(1, big.NewInt(7)))  // fallback provisionally anchors 7
+	require.NoError(t, tr.checkChainID(0, big.NewInt(11))) // primary reclaims with its own id, never rejected
+	require.Equal(t, int64(11), tr.expectedChainID.Load().Int64())
+	require.Error(t, tr.checkChainID(1, big.NewInt(7))) // the stale provisional fallback now mismatches the primary
+}
+
+func TestCloseBorChainClients(t *testing.T) {
+	// safe to call when neither Bor failover is configured
+	borRPCFailoverHealth = nil
+	borGRPCClient = nil
+	require.NotPanics(t, CloseBorChainClients)
+
+	// stops a running HTTP failover prober (CloseBorChainClients must return,
+	// i.e. join the prober goroutine, rather than hang)
+	h := failover.New(2, func(int) error { return nil }, failover.Metrics{}, log.NewNopLogger())
+	h.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	h.Start()
+	borRPCFailoverHealth = h
+	CloseBorChainClients()
+	borRPCFailoverHealth = nil
+}

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -184,6 +184,35 @@ func TestGetBorChainCallTimeout(t *testing.T) {
 	cfg.Custom.BorRPCUrl = "http://a"
 	SetTestConfig(cfg)
 	require.Equal(t, time.Second, GetBorChainCallTimeout())
+
+	// An over-max bor_rpc_timeout is clamped at the consumer so the budget stays
+	// bounded even if the value bypassed InitHeimdallConfigWith.
+	cfg.Custom.BorRPCTimeout = 5 * time.Second
+	cfg.Custom.BorRPCUrl = "http://a,http://b,http://c"
+	SetTestConfig(cfg)
+	require.Equal(t, maxBorChainCallBudget, GetBorChainCallTimeout()) // clamp(5s)=3s × 3
+}
+
+func TestClampBorRPCTimeout(t *testing.T) {
+	// The worst-case failover budget must stay within the ABCI window.
+	require.Equal(t, maxBorChainCallBudget, MaxBorRPCTimeout*maxBudgetedEndpoints)
+
+	tests := []struct {
+		name  string
+		given time.Duration
+		want  time.Duration
+	}{
+		{"zero falls back to default", 0, DefaultBorRPCTimeout},
+		{"negative falls back to default", -time.Second, DefaultBorRPCTimeout},
+		{"below max is unchanged", 2 * time.Second, 2 * time.Second},
+		{"at max is unchanged", MaxBorRPCTimeout, MaxBorRPCTimeout},
+		{"above max is clamped", 5 * time.Second, MaxBorRPCTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, clampBorRPCTimeout(tt.given))
+		})
+	}
 }
 
 func TestInitBorRPCClient_SingleAndFailover(t *testing.T) {

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"cosmossdk.io/log"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
@@ -378,21 +380,19 @@ func TestCheckChainID_PrimaryReclaimsProvisionalAnchor(t *testing.T) {
 }
 
 func TestCloseBorChainClients(t *testing.T) {
-	oldHTTP := borRPCFailoverTransport
-	oldGRPC := borGRPCClient
-	t.Cleanup(func() {
-		borRPCFailoverTransport = oldHTTP
-		borGRPCClient = oldGRPC
-	})
+	preserveBorClients(t)
 
-	// safe to call when neither Bor failover is configured
+	// safe to call when nothing is configured
 	borRPCFailoverTransport = nil
+	borRPCClient = nil
+	borClient = nil
 	borGRPCClient = nil
 	require.NotPanics(t, CloseBorChainClients)
 
 	// Stops a running HTTP failover prober and closes each endpoint's probe
 	// client (CloseBorChainClients must return, i.e. join the prober goroutine,
-	// rather than hang).
+	// rather than hang), closes the HTTP JSON-RPC and gRPC clients, and clears
+	// every global.
 	p0 := &fakeChainIDProbe{id: big.NewInt(1)}
 	p1 := &fakeChainIDProbe{id: big.NewInt(1)}
 	h := failover.New(2, func(int) error { return nil }, failover.Metrics{}, log.NewNopLogger())
@@ -402,12 +402,22 @@ func TestCloseBorChainClients(t *testing.T) {
 		endpoints: []httpEndpoint{{probe: p0}, {probe: p1}},
 		health:    h,
 	}
+	srv := fakeBorRPC(t, "0x1", new(int32))
+	defer srv.Close()
+	rc, err := rpc.Dial(srv.URL)
+	require.NoError(t, err)
+	borRPCClient = rc
+	borClient = ethclient.NewClient(rc)
 	grpcClient := &fakeBorGRPCClient{}
 	borGRPCClient = grpcClient
+
 	CloseBorChainClients()
+
 	require.True(t, p0.closed)
 	require.True(t, p1.closed)
 	require.True(t, grpcClient.closed)
 	require.Nil(t, borRPCFailoverTransport)
+	require.Nil(t, borRPCClient)
+	require.Nil(t, borClient)
 	require.Nil(t, borGRPCClient)
 }

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -373,8 +373,12 @@ func TestCloseBorChainClients(t *testing.T) {
 		endpoints: []httpEndpoint{{probe: p0}, {probe: p1}},
 		health:    h,
 	}
+	grpcClient := &fakeBorGRPCClient{}
+	borGRPCClient = grpcClient
 	CloseBorChainClients()
 	require.True(t, p0.closed)
 	require.True(t, p1.closed)
+	require.True(t, grpcClient.closed)
 	require.Nil(t, borRPCFailoverTransport)
+	require.Nil(t, borGRPCClient)
 }

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -57,6 +57,82 @@ func TestParseURLs(t *testing.T) {
 	require.Empty(t, parseURLs(" , , "))
 }
 
+func TestBorFailoverConfigured(t *testing.T) {
+	base := GetDefaultHeimdallConfig()
+
+	testCases := []struct {
+		name string
+		mut  func(*CustomConfig)
+		want bool
+	}{
+		{
+			name: "single HTTP endpoint",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a"
+			},
+			want: false,
+		},
+		{
+			name: "multi HTTP endpoint",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a,http://b"
+			},
+			want: true,
+		},
+		{
+			name: "trailing comma remains single HTTP endpoint",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a,"
+			},
+			want: false,
+		},
+		{
+			name: "multi gRPC ignored when disabled",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a"
+				cfg.BorGRPCFlag = false
+				cfg.BorGRPCUrl = "localhost:3131,localhost:3132"
+			},
+			want: false,
+		},
+		{
+			name: "single gRPC endpoint when enabled",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a"
+				cfg.BorGRPCFlag = true
+				cfg.BorGRPCUrl = "localhost:3131"
+			},
+			want: false,
+		},
+		{
+			name: "multi gRPC endpoint when enabled",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = "http://a"
+				cfg.BorGRPCFlag = true
+				cfg.BorGRPCUrl = "localhost:3131, localhost:3132"
+			},
+			want: true,
+		},
+		{
+			name: "empty endpoints",
+			mut: func(cfg *CustomConfig) {
+				cfg.BorRPCUrl = " , "
+				cfg.BorGRPCFlag = true
+				cfg.BorGRPCUrl = " , "
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.mut(&cfg)
+			require.Equal(t, tc.want, BorFailoverConfigured(cfg))
+		})
+	}
+}
+
 func TestRedactURLs(t *testing.T) {
 	require.Equal(t, "http://user:xxxxx@host:8545", redactURL("http://user:pass@host:8545"))
 	require.Equal(t, "https://host/rpc?apikey=xxxxx&token=xxxxx", redactURL("https://host/rpc?token=abc&apikey=secret"))

--- a/helper/bor_failover_config_test.go
+++ b/helper/bor_failover_config_test.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"net/http"
@@ -13,6 +14,19 @@ import (
 	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
 	borgrpc "github.com/0xPolygon/heimdall-v2/x/bor/grpc"
 )
+
+type fakeChainIDProbe struct {
+	id     *big.Int
+	closed bool
+}
+
+func (p *fakeChainIDProbe) ChainID(context.Context) (*big.Int, error) {
+	return p.id, nil
+}
+
+func (p *fakeChainIDProbe) Close() {
+	p.closed = true
+}
 
 func TestParseURLs(t *testing.T) {
 	require.Nil(t, parseURLs(""))
@@ -35,9 +49,24 @@ func TestGetBorChainCallTimeout(t *testing.T) {
 	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
 	cfg.Custom.BorRPCTimeout = time.Second
 
+	// Empty config has a floor of one endpoint budget.
+	cfg.Custom.BorGRPCFlag = false
+	cfg.Custom.BorRPCUrl = ""
+	cfg.Custom.BorGRPCUrl = ""
+	SetTestConfig(cfg)
+	require.Equal(t, time.Second, GetBorChainCallTimeout())
+
+	// When gRPC is disabled, gRPC URLs do not affect the HTTP caller budget.
+	cfg.Custom.BorGRPCFlag = false
+	cfg.Custom.BorRPCUrl = "http://a"
+	cfg.Custom.BorGRPCUrl = "localhost:1,localhost:2,localhost:3"
+	SetTestConfig(cfg)
+	require.Equal(t, time.Second, GetBorChainCallTimeout())
+
 	// 3 HTTP endpoints, at the in-call cascade cap.
 	cfg.Custom.BorGRPCFlag = false
 	cfg.Custom.BorRPCUrl = "http://a,http://b,http://c"
+	cfg.Custom.BorGRPCUrl = ""
 	SetTestConfig(cfg)
 	require.Equal(t, 3*time.Second, GetBorChainCallTimeout())
 
@@ -58,6 +87,59 @@ func TestGetBorChainCallTimeout(t *testing.T) {
 	cfg.Custom.BorRPCUrl = "http://a"
 	SetTestConfig(cfg)
 	require.Equal(t, time.Second, GetBorChainCallTimeout())
+}
+
+func TestInitBorRPCClient_SingleAndFailover(t *testing.T) {
+	oldRPC := borRPCClient
+	oldBor := borClient
+	oldHTTP := borRPCFailoverTransport
+	oldGRPC := borGRPCClient
+	t.Cleanup(func() {
+		if borRPCClient != nil && borRPCClient != oldRPC {
+			borRPCClient.Close()
+		}
+		if borRPCFailoverTransport != nil && borRPCFailoverTransport != oldHTTP {
+			borRPCFailoverTransport.Close()
+		}
+		borRPCClient = oldRPC
+		borClient = oldBor
+		borRPCFailoverTransport = oldHTTP
+		borGRPCClient = oldGRPC
+	})
+	borGRPCClient = nil
+
+	s1 := fakeBorRPC(t, "0x1", new(int32))
+	defer s1.Close()
+	s2 := fakeBorRPC(t, "0x1", new(int32))
+	defer s2.Close()
+
+	cfg := CustomAppConfig{Custom: GetDefaultHeimdallConfig()}
+	cfg.Custom.BorRPCTimeout = 100 * time.Millisecond
+
+	cfg.Custom.BorRPCUrl = s1.URL
+	SetTestConfig(cfg)
+	borRPCClient = nil
+	borClient = nil
+	borRPCFailoverTransport = nil
+	initBorRPCClient()
+	require.NotNil(t, borRPCClient)
+	require.NotNil(t, borClient)
+	require.Nil(t, borRPCFailoverTransport)
+	borRPCClient.Close()
+
+	cfg.Custom.BorRPCUrl = s1.URL + "," + s2.URL
+	SetTestConfig(cfg)
+	borRPCClient = nil
+	borClient = nil
+	borRPCFailoverTransport = nil
+	initBorRPCClient()
+	require.NotNil(t, borRPCClient)
+	require.NotNil(t, borClient)
+	require.NotNil(t, borRPCFailoverTransport)
+
+	id, err := borClient.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), id.Int64())
 }
 
 func TestBuildBorGRPCClient(t *testing.T) {
@@ -156,17 +238,32 @@ func TestCheckChainID_PrimaryReclaimsProvisionalAnchor(t *testing.T) {
 }
 
 func TestCloseBorChainClients(t *testing.T) {
+	oldHTTP := borRPCFailoverTransport
+	oldGRPC := borGRPCClient
+	t.Cleanup(func() {
+		borRPCFailoverTransport = oldHTTP
+		borGRPCClient = oldGRPC
+	})
+
 	// safe to call when neither Bor failover is configured
-	borRPCFailoverHealth = nil
+	borRPCFailoverTransport = nil
 	borGRPCClient = nil
 	require.NotPanics(t, CloseBorChainClients)
 
-	// stops a running HTTP failover prober (CloseBorChainClients must return,
-	// i.e. join the prober goroutine, rather than hang)
+	// Stops a running HTTP failover prober and closes each endpoint's probe
+	// client (CloseBorChainClients must return, i.e. join the prober goroutine,
+	// rather than hang).
+	p0 := &fakeChainIDProbe{id: big.NewInt(1)}
+	p1 := &fakeChainIDProbe{id: big.NewInt(1)}
 	h := failover.New(2, func(int) error { return nil }, failover.Metrics{}, log.NewNopLogger())
 	h.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
 	h.Start()
-	borRPCFailoverHealth = h
+	borRPCFailoverTransport = &borHTTPFailoverTransport{
+		endpoints: []httpEndpoint{{probe: p0}, {probe: p1}},
+		health:    h,
+	}
 	CloseBorChainClients()
-	borRPCFailoverHealth = nil
+	require.True(t, p0.closed)
+	require.True(t, p1.closed)
+	require.Nil(t, borRPCFailoverTransport)
 }

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,6 +44,12 @@ const (
 // CloseBorChainClients can stop its prober and close its per-endpoint probe
 // clients on shutdown; nil when HTTP failover is not configured.
 var borRPCFailoverTransport *borHTTPFailoverTransport
+
+// borChainClientsMu serializes CloseBorChainClients. On a --bridge=true SIGTERM
+// both the bridge shutdown path and the start-command cleanup goroutine reach
+// it on the same cancellation, so the read/write of the package-level client
+// pointers must be synchronized.
+var borChainClientsMu sync.Mutex
 
 type chainIDProbe interface {
 	ChainID(context.Context) (*big.Int, error)
@@ -445,6 +452,8 @@ func redactURLs(csv string) string {
 // path for those goroutines; wire it into Heimdall's shutdown. Safe to call when
 // neither failover is configured.
 func CloseBorChainClients() {
+	borChainClientsMu.Lock()
+	defer borChainClientsMu.Unlock()
 	if borRPCFailoverTransport != nil {
 		borRPCFailoverTransport.Close()
 		borRPCFailoverTransport = nil

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -1,0 +1,395 @@
+package helper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/0xPolygon/heimdall-v2/metrics"
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+const (
+	primaryEndpoint = 0
+
+	// primaryAnchorFailureThreshold is how many consecutive primary probe
+	// failures must accrue before a fallback may provisionally establish the
+	// expected Bor chain identity. The primary stays authoritative: once it is
+	// reachable it reclaims the expectation (see checkChainID), so this only
+	// lets failover engage during a window where the primary is unreachable.
+	primaryAnchorFailureThreshold = 2
+
+	// maxBudgetedEndpoints caps how many per-endpoint attempts a single Bor call's
+	// time budget covers (BorRPCTimeout each), so a large endpoint count can't push
+	// one call's worst case past CometBFT's ~10s ABCI budget. It is a time bound,
+	// not a hard attempt count: a cascade still tries currently-healthy candidates
+	// in priority order and may try more than this many if they fail fast enough to
+	// fit the budget; it is just never granted time for more than this many slow
+	// attempts. The deadline, not a counter, stops the cascade.
+	maxBudgetedEndpoints = 3
+)
+
+// borRPCFailoverHealth holds the running HTTP failover prober so
+// CloseBorChainClients can stop it on shutdown; nil when HTTP failover is not
+// configured.
+var borRPCFailoverHealth *failover.Health
+
+// httpEndpoint pairs a Bor HTTP JSON-RPC URL with a single-endpoint client used
+// only for health/identity probes (the actual traffic flows through the shared
+// rpc.Client whose transport is the failover one).
+type httpEndpoint struct {
+	url   *url.URL
+	probe *ethclient.Client
+}
+
+// borHTTPFailoverTransport is an http.RoundTripper that sends each Bor JSON-RPC
+// request to the active endpoint and, on a transport failure, a per-attempt
+// timeout, or a 5xx response, cascades to the next validated endpoint in
+// priority order. A background prober reverts to a higher-priority endpoint
+// once it recovers.
+type borHTTPFailoverTransport struct {
+	endpoints            []httpEndpoint
+	base                 http.RoundTripper
+	health               *failover.Health
+	attemptTimeout       time.Duration
+	expectedChainID      atomic.Pointer[big.Int]
+	expectedByPrimary    atomic.Bool
+	primaryProbeFailures atomic.Int32
+}
+
+func (t *borHTTPFailoverTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := drainRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	active := t.health.Active()
+	resp, err := t.attempt(req, body, active)
+	if succeeded(resp, err) || req.Context().Err() != nil {
+		return resp, err
+	}
+	t.markFailed(active, resp, err)
+
+	for _, i := range t.health.Candidates(active) {
+		drainAndClose(resp)
+		resp, err = t.attempt(req, body, i)
+		if succeeded(resp, err) {
+			t.health.Promote(active, i)
+			return resp, err
+		}
+		if req.Context().Err() != nil {
+			return resp, err
+		}
+		t.markFailed(i, resp, err)
+	}
+
+	return resp, err
+}
+
+// succeeded reports a usable response: a transport success whose status is not
+// a server-side (5xx) error. A 4xx is returned as-is (a fallback would answer
+// identically); a 5xx is treated as a failure worth cascading.
+func succeeded(resp *http.Response, err error) bool {
+	return err == nil && resp != nil && resp.StatusCode < http.StatusInternalServerError
+}
+
+func (t *borHTTPFailoverTransport) markFailed(i int, resp *http.Response, err error) {
+	if err == nil && resp != nil {
+		err = fmt.Errorf("bor endpoint returned http %d", resp.StatusCode)
+	}
+	t.health.MarkUnhealthy(i, err)
+}
+
+// attempt sends the request to endpoint i with its own attempt timeout. On
+// success the timeout context is tied to the response body's Close so it stays
+// alive while the caller reads the body.
+func (t *borHTTPFailoverTransport) attempt(req *http.Request, body []byte, i int) (*http.Response, error) {
+	ctx, cancel := failover.WithAttemptTimeout(req.Context(), t.attemptTimeout)
+	resp, err := t.send(req.WithContext(ctx), body, i)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	resp.Body = &cancelOnClose{body: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+func (t *borHTTPFailoverTransport) send(req *http.Request, body []byte, i int) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	ep := *t.endpoints[i].url
+	clone.URL = &ep
+	clone.Host = ep.Host
+	if body != nil {
+		clone.Body = io.NopCloser(bytes.NewReader(body))
+		clone.ContentLength = int64(len(body))
+	}
+
+	return t.base.RoundTrip(clone)
+}
+
+// cancelOnClose cancels the per-attempt context when the response body is
+// closed, mirroring how http.Client ties a request's timeout to its body.
+type cancelOnClose struct {
+	body   io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnClose) Read(p []byte) (int, error) { return c.body.Read(p) }
+
+func (c *cancelOnClose) Close() error {
+	c.cancel()
+	return c.body.Close()
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+func drainRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	defer req.Body.Close()
+
+	return io.ReadAll(req.Body)
+}
+
+// probe validates endpoint i for the background prober: it must answer and
+// report the expected Bor chain ID before it is treated as a healthy fallback.
+// It tracks consecutive primary failures so a fallback can anchor identity when
+// the primary is never reachable (see canAnchor).
+func (t *borHTTPFailoverTransport) probe(i int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), t.health.ProbeTimeout())
+	defer cancel()
+
+	id, err := t.endpoints[i].probe.ChainID(ctx)
+	if err != nil {
+		if i == primaryEndpoint {
+			t.primaryProbeFailures.Add(1)
+		}
+		return err
+	}
+	if i == primaryEndpoint {
+		t.primaryProbeFailures.Store(0)
+	}
+
+	reclaiming := i == primaryEndpoint && !t.expectedByPrimary.Load()
+	if err := t.checkChainID(i, id); err != nil {
+		return err
+	}
+	if reclaiming {
+		// The authoritative primary just (re)established the identity; if a stale
+		// fallback was the active endpoint during the outage it may be serving
+		// wrong-network data, so move traffic back to the primary at once instead
+		// of waiting out the promotion threshold. Reclaim also demotes the other
+		// endpoints so a fallback validated against the provisional identity can't
+		// remain an in-call candidate until re-validated.
+		t.health.Reclaim(primaryEndpoint)
+	}
+
+	return nil
+}
+
+// checkChainID compares endpoint i's chain ID against the expected one. The
+// primary is authoritative: whenever it answers it (re)establishes the
+// expectation, reclaiming a provisional one a fallback set while the primary was
+// unreachable — so the real primary is never rejected. A fallback may
+// provisionally anchor only after the primary has been unreachable for
+// primaryAnchorFailureThreshold probes (see canAnchor); every endpoint that does
+// not anchor must match the current expectation.
+func (t *borHTTPFailoverTransport) checkChainID(i int, id *big.Int) error {
+	if i == primaryEndpoint && !t.expectedByPrimary.Load() {
+		t.expectedChainID.Store(id)
+		t.expectedByPrimary.Store(true)
+		return nil
+	}
+
+	expected := t.expectedChainID.Load()
+	if expected == nil {
+		if !t.canAnchor(i) {
+			return fmt.Errorf("bor endpoint %d: expected chain id not yet known", i)
+		}
+		if t.expectedChainID.CompareAndSwap(nil, id) {
+			return nil
+		}
+		expected = t.expectedChainID.Load() // lost the race; compare against the winner
+	}
+
+	if expected.Cmp(id) != 0 {
+		return fmt.Errorf("bor endpoint %d chain id %s != expected %s", i, id, expected)
+	}
+
+	return nil
+}
+
+// canAnchor reports whether a fallback may provisionally establish the expected
+// chain identity: only after the primary has failed primaryAnchorFailureThreshold
+// consecutive probes, so failover still engages when the primary is never
+// reachable at boot. The primary itself anchors via checkChainID's reclaim path.
+func (t *borHTTPFailoverTransport) canAnchor(i int) bool {
+	return i == primaryEndpoint || t.primaryProbeFailures.Load() >= primaryAnchorFailureThreshold
+}
+
+// newBorHTTPFailoverClient builds a Bor HTTP JSON-RPC client that fails over
+// across the priority-ordered endpoints (index 0 = primary). The returned
+// *rpc.Client / *ethclient.Client are the same concrete types as a plain
+// rpc.Dial, so every existing Bor HTTP caller gets failover transparently.
+func newBorHTTPFailoverClient(rawURLs []string, attemptTimeout time.Duration) (*rpc.Client, *ethclient.Client, error) {
+	endpoints, err := dialHTTPEndpoints(rawURLs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tr := &borHTTPFailoverTransport{
+		endpoints:      endpoints,
+		base:           http.DefaultTransport,
+		attemptTimeout: attemptTimeout,
+	}
+	tr.captureExpectedChainID()
+	tr.health = failover.New(len(endpoints), tr.probe, metrics.BorFailover("http"), Logger)
+
+	rpcClient, err := rpc.DialOptions(context.Background(), endpoints[primaryEndpoint].url.String(),
+		rpc.WithHTTPClient(&http.Client{Transport: tr}))
+	if err != nil {
+		return nil, nil, fmt.Errorf("constructing bor failover rpc client: %w", err)
+	}
+
+	tr.health.Start()
+	borRPCFailoverHealth = tr.health
+
+	return rpcClient, ethclient.NewClient(rpcClient), nil
+}
+
+// captureExpectedChainID best-effort records the primary's chain ID at startup
+// so fallbacks can be validated before the first request. If the primary is
+// unreachable, the expectation is set later by the primary's first probe.
+func (t *borHTTPFailoverTransport) captureExpectedChainID() {
+	if id, ok := fetchChainID(t.endpoints[primaryEndpoint].probe, t.attemptTimeout); ok {
+		if t.expectedChainID.CompareAndSwap(nil, id) {
+			t.expectedByPrimary.Store(true)
+		}
+	}
+}
+
+func dialHTTPEndpoints(rawURLs []string) ([]httpEndpoint, error) {
+	out := make([]httpEndpoint, 0, len(rawURLs))
+	for _, raw := range rawURLs {
+		u, err := url.Parse(raw)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			Logger.Warn("bor failover: skipping invalid or non-HTTP bor RPC URL", "url", redactURL(raw))
+			continue
+		}
+
+		rc, derr := rpc.Dial(u.String())
+		if derr != nil {
+			Logger.Warn("bor failover: skipping undialable bor RPC URL", "url", redactURL(raw), "error", derr)
+			continue
+		}
+
+		out = append(out, httpEndpoint{url: u, probe: ethclient.NewClient(rc)})
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no valid http(s) bor RPC endpoints among %d configured", len(rawURLs))
+	}
+
+	return out, nil
+}
+
+func fetchChainID(c *ethclient.Client, timeout time.Duration) (*big.Int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	id, err := c.ChainID(ctx)
+	if err != nil || id == nil {
+		return nil, false
+	}
+
+	return id, true
+}
+
+// GetBorChainCallTimeout returns the time budget a caller should allow for a
+// single Bor call. With failover it is the per-endpoint timeout (BorRPCTimeout)
+// times the budgeted endpoint count, so a cascade can reach a fallback within one
+// caller-scoped context — go-ethereum's rpc.Client re-checks that context after
+// the request returns, so a budget of only one attempt would race a successful
+// fallback against the expired deadline. A single endpoint yields BorRPCTimeout
+// unchanged.
+//
+// The endpoint count is the larger of the HTTP and gRPC lists because both the
+// HTTP client (used by the broadcaster) and the gRPC client (used by side
+// handlers) share this single budget, and it is capped at maxBudgetedEndpoints so
+// a large count can't push one call past CometBFT's ~10s ABCI budget. The cap is
+// on the time budget, not the attempt count: the deadline stops the cascade, so
+// fast-failing endpoints beyond the cap may still be tried within the budget,
+// while slow ones beyond it are reached on later calls.
+func GetBorChainCallTimeout() time.Duration {
+	n := len(parseURLs(conf.Custom.BorRPCUrl))
+	if conf.Custom.BorGRPCFlag {
+		if g := len(parseURLs(conf.Custom.BorGRPCUrl)); g > n {
+			n = g
+		}
+	}
+	if n < 1 {
+		n = 1
+	}
+	if n > maxBudgetedEndpoints {
+		n = maxBudgetedEndpoints
+	}
+
+	return conf.Custom.BorRPCTimeout * time.Duration(n)
+}
+
+// redactURL masks secrets in raw for safe logging: query-parameter values
+// (providers commonly pass API keys as ?apikey=...) and userinfo passwords (via
+// url.Redacted). A path-embedded token cannot be detected generically and is
+// left as-is.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<unparseable>"
+	}
+	if q := u.Query(); len(q) > 0 {
+		for k := range q {
+			q.Set(k, "xxxxx")
+		}
+		u.RawQuery = q.Encode()
+	}
+	return u.Redacted()
+}
+
+// redactURLs redacts every URL in a comma-separated list for safe logging.
+func redactURLs(csv string) string {
+	parts := parseURLs(csv)
+	for i, p := range parts {
+		parts[i] = redactURL(p)
+	}
+	return strings.Join(parts, ",")
+}
+
+// CloseBorChainClients stops the Bor failover background probers (the HTTP
+// transport prober and the gRPC client prober) and closes the gRPC connections.
+// It is the termination path for those goroutines; wire it into Heimdall's
+// shutdown. Safe to call when neither failover is configured.
+func CloseBorChainClients() {
+	if borRPCFailoverHealth != nil {
+		borRPCFailoverHealth.Stop()
+	}
+	if borGRPCClient != nil {
+		borGRPCClient.Close(Logger)
+	}
+}

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -148,12 +148,22 @@ func (t *borHTTPFailoverTransport) send(req *http.Request, body []byte, i int) (
 	ep := *t.endpoints[i].url
 	clone.URL = &ep
 	clone.Host = ep.Host
+	setEndpointAuthorization(clone, ep.User)
 	if body != nil {
 		clone.Body = io.NopCloser(bytes.NewReader(body))
 		clone.ContentLength = int64(len(body))
 	}
 
 	return t.base.RoundTrip(clone)
+}
+
+func setEndpointAuthorization(req *http.Request, user *url.Userinfo) {
+	req.Header.Del("Authorization")
+	if user == nil {
+		return
+	}
+	password, _ := user.Password()
+	req.SetBasicAuth(user.Username(), password)
 }
 
 // cancelOnClose cancels the per-attempt context when the response body is
@@ -306,20 +316,17 @@ func (t *borHTTPFailoverTransport) captureExpectedChainID() {
 
 func dialHTTPEndpoints(rawURLs []string) ([]httpEndpoint, error) {
 	out := make([]httpEndpoint, 0, len(rawURLs))
-	for _, raw := range rawURLs {
-		u, err := url.Parse(raw)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			Logger.Warn("bor failover: skipping invalid or non-HTTP bor RPC URL", "url", redactURL(raw))
+	for i, raw := range rawURLs {
+		ep, err := dialHTTPEndpoint(raw)
+		if err != nil {
+			if i == primaryEndpoint {
+				return nil, fmt.Errorf("invalid primary bor RPC URL %s: %w", redactURL(raw), err)
+			}
+			Logger.Warn("bor failover: skipping invalid bor RPC URL", "url", redactURL(raw), "error", err)
 			continue
 		}
 
-		rc, derr := rpc.Dial(u.String())
-		if derr != nil {
-			Logger.Warn("bor failover: skipping undialable bor RPC URL", "url", redactURL(raw), "error", derr)
-			continue
-		}
-
-		out = append(out, httpEndpoint{url: u, probe: ethclient.NewClient(rc)})
+		out = append(out, ep)
 	}
 
 	if len(out) == 0 {
@@ -327,6 +334,23 @@ func dialHTTPEndpoints(rawURLs []string) ([]httpEndpoint, error) {
 	}
 
 	return out, nil
+}
+
+func dialHTTPEndpoint(raw string) (httpEndpoint, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return httpEndpoint{}, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return httpEndpoint{}, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+
+	rc, err := rpc.Dial(u.String())
+	if err != nil {
+		return httpEndpoint{}, fmt.Errorf("dialing endpoint: %w", err)
+	}
+
+	return httpEndpoint{url: u, probe: ethclient.NewClient(rc)}, nil
 }
 
 func fetchChainID(c chainIDProbe, timeout time.Duration) (*big.Int, bool) {

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -39,17 +39,22 @@ const (
 	maxBudgetedEndpoints = 3
 )
 
-// borRPCFailoverHealth holds the running HTTP failover prober so
-// CloseBorChainClients can stop it on shutdown; nil when HTTP failover is not
-// configured.
-var borRPCFailoverHealth *failover.Health
+// borRPCFailoverTransport holds the running HTTP failover transport so
+// CloseBorChainClients can stop its prober and close its per-endpoint probe
+// clients on shutdown; nil when HTTP failover is not configured.
+var borRPCFailoverTransport *borHTTPFailoverTransport
+
+type chainIDProbe interface {
+	ChainID(context.Context) (*big.Int, error)
+	Close()
+}
 
 // httpEndpoint pairs a Bor HTTP JSON-RPC URL with a single-endpoint client used
 // only for health/identity probes (the actual traffic flows through the shared
 // rpc.Client whose transport is the failover one).
 type httpEndpoint struct {
 	url   *url.URL
-	probe *ethclient.Client
+	probe chainIDProbe
 }
 
 // borHTTPFailoverTransport is an http.RoundTripper that sends each Bor JSON-RPC
@@ -65,6 +70,20 @@ type borHTTPFailoverTransport struct {
 	expectedChainID      atomic.Pointer[big.Int]
 	expectedByPrimary    atomic.Bool
 	primaryProbeFailures atomic.Int32
+}
+
+func (t *borHTTPFailoverTransport) Close() {
+	if t == nil {
+		return
+	}
+	if t.health != nil {
+		t.health.Stop()
+	}
+	for _, ep := range t.endpoints {
+		if ep.probe != nil {
+			ep.probe.Close()
+		}
+	}
 }
 
 func (t *borHTTPFailoverTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -269,7 +288,7 @@ func newBorHTTPFailoverClient(rawURLs []string, attemptTimeout time.Duration) (*
 	}
 
 	tr.health.Start()
-	borRPCFailoverHealth = tr.health
+	borRPCFailoverTransport = tr
 
 	return rpcClient, ethclient.NewClient(rpcClient), nil
 }
@@ -310,7 +329,7 @@ func dialHTTPEndpoints(rawURLs []string) ([]httpEndpoint, error) {
 	return out, nil
 }
 
-func fetchChainID(c *ethclient.Client, timeout time.Duration) (*big.Int, bool) {
+func fetchChainID(c chainIDProbe, timeout time.Duration) (*big.Int, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -381,13 +400,14 @@ func redactURLs(csv string) string {
 	return strings.Join(parts, ",")
 }
 
-// CloseBorChainClients stops the Bor failover background probers (the HTTP
-// transport prober and the gRPC client prober) and closes the gRPC connections.
-// It is the termination path for those goroutines; wire it into Heimdall's
-// shutdown. Safe to call when neither failover is configured.
+// CloseBorChainClients stops the Bor failover background probers, closes the
+// HTTP probe clients, and closes the gRPC connections. It is the termination
+// path for those goroutines; wire it into Heimdall's shutdown. Safe to call when
+// neither failover is configured.
 func CloseBorChainClients() {
-	if borRPCFailoverHealth != nil {
-		borRPCFailoverHealth.Stop()
+	if borRPCFailoverTransport != nil {
+		borRPCFailoverTransport.Close()
+		borRPCFailoverTransport = nil
 	}
 	if borGRPCClient != nil {
 		borGRPCClient.Close(Logger)

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -38,6 +38,14 @@ const (
 	// fit the budget; it is just never granted time for more than this many slow
 	// attempts. The deadline, not a counter, stops the cascade.
 	maxBudgetedEndpoints = 3
+
+	// maxBorChainCallBudget bounds the worst-case time a single Bor call may
+	// consume across a failover cascade, kept under CometBFT's ~10s ABCI budget so
+	// a slow Bor can't stall milestone/checkpoint vote extensions and miss votes.
+	maxBorChainCallBudget = 9 * time.Second
+	// MaxBorRPCTimeout caps bor_rpc_timeout so BorRPCTimeout × maxBudgetedEndpoints
+	// (the GetBorChainCallTimeout budget) stays within maxBorChainCallBudget.
+	MaxBorRPCTimeout = maxBorChainCallBudget / maxBudgetedEndpoints
 )
 
 // borRPCFailoverTransport holds the running HTTP failover transport so
@@ -389,12 +397,12 @@ func fetchChainID(c chainIDProbe, timeout time.Duration) (*big.Int, bool) {
 }
 
 // GetBorChainCallTimeout returns the time budget a caller should allow for a
-// single Bor call. With failover it is the per-endpoint timeout (BorRPCTimeout)
-// times the budgeted endpoint count, so a cascade can reach a fallback within one
-// caller-scoped context — go-ethereum's rpc.Client re-checks that context after
-// the request returns, so a budget of only one attempt would race a successful
-// fallback against the expired deadline. A single endpoint yields BorRPCTimeout
-// unchanged.
+// single Bor call. With failover it is the clamped per-endpoint timeout
+// (min(BorRPCTimeout, MaxBorRPCTimeout)) times the budgeted endpoint count, so a
+// cascade can reach a fallback within one caller-scoped context — go-ethereum's
+// rpc.Client re-checks that context after the request returns, so a budget of
+// only one attempt would race a successful fallback against the expired deadline.
+// A single endpoint yields the clamped BorRPCTimeout unchanged.
 //
 // The endpoint count is the larger of the HTTP and gRPC lists because both the
 // HTTP client (used by the broadcaster) and the gRPC client (used by side
@@ -417,7 +425,22 @@ func GetBorChainCallTimeout() time.Duration {
 		n = maxBudgetedEndpoints
 	}
 
-	return conf.Custom.BorRPCTimeout * time.Duration(n)
+	// Clamp defensively so the budget is bounded by maxBorChainCallBudget even if
+	// conf.Custom.BorRPCTimeout was set without going through InitHeimdallConfigWith.
+	return clampBorRPCTimeout(conf.Custom.BorRPCTimeout) * time.Duration(n)
+}
+
+// clampBorRPCTimeout normalizes the per-endpoint Bor RPC timeout: a non-positive
+// value falls back to the default, and a value above MaxBorRPCTimeout is clamped
+// so the GetBorChainCallTimeout budget stays under the ABCI window.
+func clampBorRPCTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return DefaultBorRPCTimeout
+	}
+	if timeout > MaxBorRPCTimeout {
+		return MaxBorRPCTimeout
+	}
+	return timeout
 }
 
 // redactURL masks secrets in raw for safe logging: query-parameter values

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -103,12 +103,20 @@ func (t *borHTTPFailoverTransport) RoundTrip(req *http.Request) (*http.Response,
 	}
 	t.markFailed(active, resp, err)
 
+	return t.cascade(req, body, active, resp, err)
+}
+
+func (t *borHTTPFailoverTransport) cascade(req *http.Request, body []byte, active int, resp *http.Response, err error) (*http.Response, error) {
 	for _, i := range t.health.Candidates(active) {
 		drainAndClose(resp)
 		resp, err = t.attempt(req, body, i)
 		if succeeded(resp, err) {
-			t.health.Promote(active, i)
-			return resp, err
+			if t.health.Promote(active, i) {
+				return resp, err
+			}
+			drainAndClose(resp)
+			resp, err = nil, fmt.Errorf("bor endpoint %d no longer healthy", i)
+			continue
 		}
 		if req.Context().Err() != nil {
 			return resp, err

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -148,6 +148,10 @@ func (t *borHTTPFailoverTransport) attempt(req *http.Request, body []byte, i int
 	ctx, cancel := failover.WithAttemptTimeout(req.Context(), t.attemptTimeout)
 	resp, err := t.send(req.WithContext(ctx), body, i)
 	if err != nil {
+		// http.DefaultTransport returns a nil response on error, but base is a
+		// pluggable RoundTripper; drain any response a custom one returns
+		// alongside the error so its body/connection isn't leaked.
+		drainAndClose(resp)
 		cancel()
 		return nil, err
 	}

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -447,5 +447,6 @@ func CloseBorChainClients() {
 	}
 	if borGRPCClient != nil {
 		borGRPCClient.Close(Logger)
+		borGRPCClient = nil
 	}
 }

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -237,6 +237,11 @@ func (t *borHTTPFailoverTransport) probe(i int) error {
 	defer cancel()
 
 	id, err := t.endpoints[i].probe.ChainID(ctx)
+	if err == nil && id == nil {
+		// A nil chain id with no error would poison the expected id (primary) or
+		// panic in checkChainID's Cmp; treat it as a probe failure.
+		err = fmt.Errorf("bor endpoint %d returned nil chain id", i)
+	}
 	if err != nil {
 		if i == primaryEndpoint {
 			t.primaryProbeFailures.Add(1)
@@ -471,15 +476,21 @@ func redactURLs(csv string) string {
 }
 
 // CloseBorChainClients stops the Bor failover background probers, closes the
-// HTTP probe clients, and closes the gRPC connections. It is the termination
-// path for those goroutines; wire it into Heimdall's shutdown. Safe to call when
-// neither failover is configured.
+// HTTP probe clients and the HTTP JSON-RPC client, and closes the gRPC
+// connections. It is the termination path for those goroutines; wire it into
+// Heimdall's shutdown. Safe to call when neither failover is configured.
 func CloseBorChainClients() {
 	borChainClientsMu.Lock()
 	defer borChainClientsMu.Unlock()
 	if borRPCFailoverTransport != nil {
 		borRPCFailoverTransport.Close()
 		borRPCFailoverTransport = nil
+	}
+	if borRPCClient != nil {
+		// borClient wraps the same underlying rpc.Client, so this closes both.
+		borRPCClient.Close()
+		borRPCClient = nil
+		borClient = nil
 	}
 	if borGRPCClient != nil {
 		borGRPCClient.Close(Logger)

--- a/helper/bor_failover_http.go
+++ b/helper/bor_failover_http.go
@@ -94,7 +94,11 @@ func (t *borHTTPFailoverTransport) RoundTrip(req *http.Request) (*http.Response,
 
 	active := t.health.Active()
 	resp, err := t.attempt(req, body, active)
-	if succeeded(resp, err) || req.Context().Err() != nil {
+	if succeeded(resp, err) {
+		t.health.MarkSuccess(active)
+		return resp, err
+	}
+	if req.Context().Err() != nil {
 		return resp, err
 	}
 	t.markFailed(active, resp, err)

--- a/helper/bor_failover_http_auth_test.go
+++ b/helper/bor_failover_http_auth_test.go
@@ -1,0 +1,58 @@
+package helper
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+func TestBorHTTPFailover_RewritesBasicAuthPerEndpoint(t *testing.T) {
+	var calls int
+	base := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok)
+		if calls == 1 {
+			require.Equal(t, "primary.example", r.URL.Host)
+			require.Equal(t, "primary-user", user)
+			require.Equal(t, "primary-pass", pass)
+			return nil, errors.New("primary down")
+		}
+
+		require.Equal(t, "fallback.example", r.URL.Host)
+		require.Equal(t, "fallback-user", user)
+		require.Equal(t, "fallback-pass", pass)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)),
+			Request:    r,
+		}, nil
+	})
+
+	tr := &borHTTPFailoverTransport{
+		endpoints: []httpEndpoint{
+			mustEndpointURL(t, "https://primary-user:primary-pass@primary.example"),
+			mustEndpointURL(t, "https://fallback-user:fallback-pass@fallback.example"),
+		},
+		base:           base,
+		attemptTimeout: time.Second,
+	}
+	tr.health = failover.New(2, tr.probe, failover.Metrics{}, log.NewNopLogger())
+	tr.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	tr.health.MarkSuccess(1)
+
+	resp, err := (&http.Client{Transport: tr}).Do(jsonRPCPost(t, "https://primary-user:primary-pass@primary.example", dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, calls)
+}

--- a/helper/bor_failover_http_race_test.go
+++ b/helper/bor_failover_http_race_test.go
@@ -1,0 +1,46 @@
+package helper
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+func TestBorHTTPFailover_SkipsCandidateDemotedBeforePromotion(t *testing.T) {
+	tr := &borHTTPFailoverTransport{
+		endpoints: []httpEndpoint{
+			mustEndpointURL(t, "https://primary.example"),
+			mustEndpointURL(t, "https://fallback.example"),
+		},
+		attemptTimeout: time.Second,
+	}
+	tr.base = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host == "fallback.example" {
+			tr.health.Reclaim(0) // prober reclaimed while the fallback attempt was in flight
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)),
+				Request:    r,
+			}, nil
+		}
+		return nil, errors.New("primary down")
+	})
+	tr.health = failover.New(2, tr.probe, failover.Metrics{}, log.NewNopLogger())
+	tr.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	tr.health.MarkSuccess(1)
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, "https://primary.example", dummyReq))
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, 0, tr.health.Active())
+	require.Empty(t, tr.health.Candidates(0))
+}

--- a/helper/bor_failover_http_race_test.go
+++ b/helper/bor_failover_http_race_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +14,40 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+	borgrpc "github.com/0xPolygon/heimdall-v2/x/bor/grpc"
 )
+
+// closeCountingGRPCClient embeds borgrpc.Client so it satisfies the interface
+// without implementing every method; only Close is exercised here.
+type closeCountingGRPCClient struct {
+	borgrpc.Client
+	closes atomic.Int32
+}
+
+func (c *closeCountingGRPCClient) Close(log.Logger) { c.closes.Add(1) }
+
+// TestCloseBorChainClients_ConcurrentIsRaceFree drives the two shutdown paths
+// (bridge teardown and the start-command cleanup goroutine) that reach
+// CloseBorChainClients on the same SIGTERM. The package-level client pointers
+// are read and written there, so without synchronization this trips -race.
+func TestCloseBorChainClients_ConcurrentIsRaceFree(t *testing.T) {
+	fake := &closeCountingGRPCClient{}
+	borGRPCClient = fake
+	t.Cleanup(func() { borGRPCClient = nil })
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			CloseBorChainClients()
+		}()
+	}
+	wg.Wait()
+
+	require.Nil(t, borGRPCClient)
+	require.Equal(t, int32(1), fake.closes.Load(), "set-to-nil under the lock must make the second call a no-op")
+}
 
 func TestBorHTTPFailover_SkipsCandidateDemotedBeforePromotion(t *testing.T) {
 	tr := &borHTTPFailoverTransport{

--- a/helper/bor_failover_http_test.go
+++ b/helper/bor_failover_http_test.go
@@ -336,6 +336,19 @@ func TestBorHTTPTransport_ProbeValidatesChainID(t *testing.T) {
 	require.Error(t, tr.probe(2))   // mismatched chain id → rejected
 }
 
+func TestBorHTTPTransport_ProbeRejectsNilChainID(t *testing.T) {
+	primary := fakeBorRPC(t, "0x5", new(int32))
+	defer primary.Close()
+
+	tr := newTestTransport(mustEndpoint(t, primary.URL), mustEndpoint(t, primary.URL))
+	require.NoError(t, tr.probe(0)) // primary establishes the expected chain id
+
+	// A fallback answering with a nil chain id (no error) must be rejected, not
+	// fed into checkChainID's Cmp (which would panic against the non-nil expected).
+	tr.endpoints[1].probe = &fakeChainIDProbe{id: nil}
+	require.Error(t, tr.probe(1))
+}
+
 func TestBorHTTPTransport_PrimaryReclaimAdoptsActive(t *testing.T) {
 	primary := fakeBorRPC(t, "0x1", new(int32))
 	defer primary.Close()

--- a/helper/bor_failover_http_test.go
+++ b/helper/bor_failover_http_test.go
@@ -398,14 +398,27 @@ func TestNewBorHTTPFailoverClient_ErrorWhenNoValidEndpoints(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDialHTTPEndpoints_SkipsInvalidScheme(t *testing.T) {
+func TestDialHTTPEndpoints_SkipsInvalidFallbackScheme(t *testing.T) {
 	s1 := fakeBorRPC(t, "0x1", new(int32))
 	defer s1.Close()
 
 	// "://bad" fails url.Parse (nil URL); "ws://" parses but is the wrong scheme.
-	got, err := dialHTTPEndpoints([]string{"://bad", "ws://localhost:8546", s1.URL})
+	got, err := dialHTTPEndpoints([]string{s1.URL, "://bad", "ws://localhost:8546"})
 	require.NoError(t, err)
 	require.Len(t, got, 1)
+}
+
+func TestDialHTTPEndpoints_RejectsInvalidPrimary(t *testing.T) {
+	s1 := fakeBorRPC(t, "0x1", new(int32))
+	defer s1.Close()
+
+	_, err := dialHTTPEndpoints([]string{"ws://localhost:8546", s1.URL})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid primary")
+
+	_, err = dialHTTPEndpoints([]string{"://bad", s1.URL})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid primary")
 
 	_, err = dialHTTPEndpoints([]string{"ws://localhost:8546"})
 	require.Error(t, err)

--- a/helper/bor_failover_http_test.go
+++ b/helper/bor_failover_http_test.go
@@ -1,0 +1,459 @@
+package helper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+func fakeBorRPC(t *testing.T, chainHex string, hits *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":%q}`, chainHex)
+	}))
+}
+
+func server5xx(t *testing.T, hits *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+}
+
+// slowServer replies only after d (or when the client gives up), so the
+// caller's shorter per-attempt timeout fires first. d is bounded so the test's
+// server cleanup never blocks indefinitely.
+func slowServer(t *testing.T, d time.Duration) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(d):
+		case <-r.Context().Done():
+		}
+	}))
+}
+
+func mustEndpoint(t *testing.T, rawurl string) httpEndpoint {
+	t.Helper()
+	u, err := url.Parse(rawurl)
+	require.NoError(t, err)
+	rc, err := rpc.Dial(rawurl)
+	require.NoError(t, err)
+	return httpEndpoint{url: u, probe: ethclient.NewClient(rc)}
+}
+
+func mustEndpointURL(t *testing.T, rawurl string) httpEndpoint {
+	t.Helper()
+	u, err := url.Parse(rawurl)
+	require.NoError(t, err)
+	return httpEndpoint{url: u}
+}
+
+func jsonRPCPost(t *testing.T, rawurl, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, rawurl, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func newTestTransport(eps ...httpEndpoint) *borHTTPFailoverTransport {
+	tr := &borHTTPFailoverTransport{endpoints: eps, base: http.DefaultTransport, attemptTimeout: time.Second}
+	tr.health = failover.New(len(eps), tr.probe, failover.Metrics{}, log.NewNopLogger())
+	tr.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	return tr
+}
+
+const dummyReq = `{"jsonrpc":"2.0","id":1,"method":"eth_chainId"}`
+
+func TestDrainRequestBody(t *testing.T) {
+	noBody, _ := http.NewRequest(http.MethodPost, "http://x", nil)
+	b, err := drainRequestBody(noBody)
+	require.NoError(t, err)
+	require.Nil(t, b)
+
+	withBody := jsonRPCPost(t, "http://x", "hello")
+	b, err = drainRequestBody(withBody)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), b)
+}
+
+func TestBorHTTPFailover_CascadesOnTransportError(t *testing.T) {
+	var h2 int32
+	good := fakeBorRPC(t, "0x1", &h2)
+	defer good.Close()
+	down := fakeBorRPC(t, "0x1", new(int32))
+	downURL := down.URL
+	down.Close() // connections now refused
+
+	tr := newTestTransport(mustEndpoint(t, downURL), mustEndpoint(t, good.URL))
+	tr.health.MarkSuccess(1) // secondary is a validated candidate
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, downURL, dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, tr.health.Active())
+	require.Positive(t, atomic.LoadInt32(&h2))
+}
+
+func TestBorHTTPFailover_CascadesOn5xx(t *testing.T) {
+	var bad, good int32
+	bad5xx := server5xx(t, &bad)
+	defer bad5xx.Close()
+	healthy := fakeBorRPC(t, "0x1", &good)
+	defer healthy.Close()
+
+	tr := newTestTransport(mustEndpoint(t, bad5xx.URL), mustEndpoint(t, healthy.URL))
+	tr.health.MarkSuccess(1)
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, bad5xx.URL, dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode) // failed over off the 503
+	require.Equal(t, 1, tr.health.Active())
+	require.Positive(t, atomic.LoadInt32(&bad)) // primary was tried and 5xx'd
+}
+
+func TestBorHTTPFailover_UsesFallbackURLQueryAndUser(t *testing.T) {
+	var calls int
+	base := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			require.Equal(t, "primary.example", r.URL.Host)
+			require.Equal(t, "/primary", r.URL.Path)
+			require.Equal(t, "token=primary", r.URL.RawQuery)
+			return nil, errors.New("primary down")
+		}
+
+		require.Equal(t, "fallback.example", r.URL.Host)
+		require.Equal(t, "fallback.example", r.Host)
+		require.Equal(t, "/fallback", r.URL.Path)
+		require.Equal(t, "token=fallback", r.URL.RawQuery)
+		user := r.URL.User
+		require.NotNil(t, user)
+		require.Equal(t, "fallback-user", user.Username())
+		password, ok := user.Password()
+		require.True(t, ok)
+		require.Equal(t, "fallback-pass", password)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)),
+			Request:    r,
+		}, nil
+	})
+
+	tr := &borHTTPFailoverTransport{
+		endpoints: []httpEndpoint{
+			mustEndpointURL(t, "https://primary-user:primary-pass@primary.example/primary?token=primary"),
+			mustEndpointURL(t, "https://fallback-user:fallback-pass@fallback.example/fallback?token=fallback"),
+		},
+		base:           base,
+		attemptTimeout: time.Second,
+	}
+	tr.health = failover.New(2, tr.probe, failover.Metrics{}, log.NewNopLogger())
+	tr.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	tr.health.MarkSuccess(1)
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, "https://primary-user:primary-pass@primary.example/primary?token=primary", dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, calls)
+}
+
+func TestBorHTTPFailover_All5xxPreservesLastResponse(t *testing.T) {
+	s1 := server5xx(t, new(int32))
+	defer s1.Close()
+	s2 := server5xx(t, new(int32))
+	defer s2.Close()
+
+	tr := newTestTransport(mustEndpoint(t, s1.URL), mustEndpoint(t, s2.URL))
+	tr.health.MarkSuccess(1)
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, s1.URL, dummyReq))
+	require.NoError(t, err) // not a transport error — the real 5xx is preserved
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestBorHTTPFailover_PerAttemptTimeoutCascades(t *testing.T) {
+	slow := slowServer(t, 300*time.Millisecond)
+	defer slow.Close()
+	var good int32
+	healthy := fakeBorRPC(t, "0x1", &good)
+	defer healthy.Close()
+
+	tr := newTestTransport(mustEndpoint(t, slow.URL), mustEndpoint(t, healthy.URL))
+	tr.attemptTimeout = 30 * time.Millisecond // primary stalls past this
+	tr.health.MarkSuccess(1)
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, slow.URL, dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, tr.health.Active())
+}
+
+func TestBorHTTPFailover_IntegrationCascadeThroughRPCClient(t *testing.T) {
+	// Exercises the real path: ethclient -> rpc.Client.CallContext -> our
+	// transport. After the transport fails over, rpc.Client.op.wait re-checks the
+	// caller's context, so the caller budget must span the whole cascade (as
+	// GetBorChainCallTimeout sizes it) or a successful fallback races an expired
+	// deadline.
+	slow := slowServer(t, 200*time.Millisecond)
+	defer slow.Close()
+	healthy := fakeBorRPC(t, "0x1", new(int32))
+	defer healthy.Close()
+
+	tr := newTestTransport(mustEndpoint(t, slow.URL), mustEndpoint(t, healthy.URL))
+	tr.attemptTimeout = 40 * time.Millisecond
+	tr.health.MarkSuccess(1)
+
+	rc, err := rpc.DialOptions(context.Background(), tr.endpoints[0].url.String(),
+		rpc.WithHTTPClient(&http.Client{Transport: tr}))
+	require.NoError(t, err)
+	ec := ethclient.NewClient(rc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*40*time.Millisecond) // per-attempt x endpoint count
+	defer cancel()
+	id, err := ec.ChainID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), id.Int64())
+	require.Equal(t, 1, tr.health.Active())
+}
+
+func TestBorHTTPFailover_NoCascadeWhenCallerCtxDone(t *testing.T) {
+	down := fakeBorRPC(t, "0x1", new(int32))
+	downURL := down.URL
+	down.Close()
+	var h2 int32
+	s2 := fakeBorRPC(t, "0x1", &h2)
+	defer s2.Close()
+
+	tr := newTestTransport(mustEndpoint(t, downURL), mustEndpoint(t, s2.URL))
+	tr.health.MarkSuccess(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := tr.RoundTrip(jsonRPCPost(t, downURL, dummyReq).WithContext(ctx))
+	require.Error(t, err)
+	require.Zero(t, atomic.LoadInt32(&h2)) // secondary never tried after cancellation
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestBorHTTPFailover_StopsCascadeOnMidLoopCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int32
+	base := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&calls, 1) == 2 {
+			cancel() // caller abandons the call mid-cascade
+		}
+		return nil, errors.New("transport down")
+	})
+
+	tr := &borHTTPFailoverTransport{
+		endpoints:      []httpEndpoint{mustEndpoint(t, "http://a.invalid"), mustEndpoint(t, "http://b.invalid"), mustEndpoint(t, "http://c.invalid")},
+		base:           base,
+		attemptTimeout: time.Second,
+	}
+	tr.health = failover.New(3, tr.probe, failover.Metrics{}, log.NewNopLogger())
+	tr.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	tr.health.MarkSuccess(1)
+	tr.health.MarkSuccess(2)
+
+	_, err := tr.RoundTrip(jsonRPCPost(t, "http://a.invalid", dummyReq).WithContext(ctx))
+	require.Error(t, err)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls)) // third endpoint never tried after cancel
+}
+
+func TestBorHTTPFailover_NoCascadeToUnvalidatedFallback(t *testing.T) {
+	down := fakeBorRPC(t, "0x1", new(int32))
+	downURL := down.URL
+	down.Close()
+	var h2 int32
+	s2 := fakeBorRPC(t, "0x1", &h2) // never marked healthy (e.g., failed identity)
+	defer s2.Close()
+
+	tr := newTestTransport(mustEndpoint(t, downURL), mustEndpoint(t, s2.URL))
+
+	_, err := tr.RoundTrip(jsonRPCPost(t, downURL, dummyReq))
+	require.Error(t, err)
+	require.Zero(t, atomic.LoadInt32(&h2)) // unvalidated fallback is never used
+}
+
+func TestBorHTTPTransport_ProbeValidatesChainID(t *testing.T) {
+	primary := fakeBorRPC(t, "0x5", new(int32))
+	defer primary.Close()
+	match := fakeBorRPC(t, "0x5", new(int32))
+	defer match.Close()
+	wrong := fakeBorRPC(t, "0x63", new(int32)) // different chain id
+	defer wrong.Close()
+
+	tr := newTestTransport(mustEndpoint(t, primary.URL), mustEndpoint(t, match.URL), mustEndpoint(t, wrong.URL))
+
+	require.NoError(t, tr.probe(0)) // primary establishes the expected chain id
+	require.NoError(t, tr.probe(1)) // same chain id → ok
+	require.Error(t, tr.probe(2))   // mismatched chain id → rejected
+}
+
+func TestBorHTTPTransport_PrimaryReclaimAdoptsActive(t *testing.T) {
+	primary := fakeBorRPC(t, "0x1", new(int32))
+	defer primary.Close()
+	fallback := fakeBorRPC(t, "0x2", new(int32)) // different (wrong) network
+	defer fallback.Close()
+
+	tr := newTestTransport(mustEndpoint(t, primary.URL), mustEndpoint(t, fallback.URL))
+	// Boot window: the primary was unreachable, so the fallback provisionally
+	// anchored its own identity and became the active endpoint.
+	tr.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+	require.NoError(t, tr.probe(1))
+	tr.health.SetActive(1)
+	require.Equal(t, 1, tr.health.Active())
+
+	// The primary recovers: its probe reclaims identity and moves traffic back at once.
+	require.NoError(t, tr.probe(0))
+	require.Equal(t, 0, tr.health.Active())
+}
+
+func TestBorHTTPTransport_ProbeRejectsUnreachable(t *testing.T) {
+	down := fakeBorRPC(t, "0x1", new(int32))
+	downURL := down.URL
+	down.Close()
+
+	tr := newTestTransport(mustEndpoint(t, downURL))
+	require.Error(t, tr.probe(0))
+}
+
+func TestBorHTTPFailover_RPCClientRoutesAndCascades(t *testing.T) {
+	var h1, h2 int32
+	s1 := fakeBorRPC(t, "0x1", &h1)
+	s2 := fakeBorRPC(t, "0x1", &h2)
+	defer s2.Close()
+
+	tr := newTestTransport(mustEndpoint(t, s1.URL), mustEndpoint(t, s2.URL))
+	tr.health.MarkSuccess(1)
+
+	rc, err := rpc.DialOptions(context.Background(), tr.endpoints[0].url.String(),
+		rpc.WithHTTPClient(&http.Client{Transport: tr}))
+	require.NoError(t, err)
+	ec := ethclient.NewClient(rc)
+
+	id, err := ec.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), id.Int64())
+
+	s1.Close() // primary down → next call cascades in-line
+	id, err = ec.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), id.Int64())
+	require.Equal(t, 1, tr.health.Active())
+	require.Positive(t, atomic.LoadInt32(&h2))
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReader) Close() error             { return nil }
+
+func TestRoundTrip_BodyReadError(t *testing.T) {
+	s := fakeBorRPC(t, "0x1", new(int32))
+	defer s.Close()
+
+	tr := newTestTransport(mustEndpoint(t, s.URL))
+	req, err := http.NewRequest(http.MethodPost, s.URL, errReader{})
+	require.NoError(t, err)
+
+	_, err = tr.RoundTrip(req)
+	require.Error(t, err)
+}
+
+func TestNewBorHTTPFailoverClient_ErrorWhenNoValidEndpoints(t *testing.T) {
+	_, _, err := newBorHTTPFailoverClient([]string{"ws://x", "ftp://y"}, time.Second)
+	require.Error(t, err)
+}
+
+func TestDialHTTPEndpoints_SkipsInvalidScheme(t *testing.T) {
+	s1 := fakeBorRPC(t, "0x1", new(int32))
+	defer s1.Close()
+
+	// "://bad" fails url.Parse (nil URL); "ws://" parses but is the wrong scheme.
+	got, err := dialHTTPEndpoints([]string{"://bad", "ws://localhost:8546", s1.URL})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	_, err = dialHTTPEndpoints([]string{"ws://localhost:8546"})
+	require.Error(t, err)
+}
+
+func TestFetchChainID(t *testing.T) {
+	s := fakeBorRPC(t, "0x9", new(int32))
+	defer s.Close()
+	id, ok := fetchChainID(mustEndpoint(t, s.URL).probe, time.Second)
+	require.True(t, ok)
+	require.Equal(t, int64(9), id.Int64())
+
+	down := fakeBorRPC(t, "0x9", new(int32))
+	downURL := down.URL
+	down.Close()
+	id2, ok2 := fetchChainID(mustEndpoint(t, downURL).probe, 200*time.Millisecond)
+	require.False(t, ok2)
+	require.Nil(t, id2)
+}
+
+func TestCaptureExpectedChainID(t *testing.T) {
+	s := fakeBorRPC(t, "0x7", new(int32))
+	defer s.Close()
+	tr := &borHTTPFailoverTransport{endpoints: []httpEndpoint{mustEndpoint(t, s.URL)}, attemptTimeout: time.Second}
+	tr.captureExpectedChainID()
+	require.NotNil(t, tr.expectedChainID.Load())
+	require.Equal(t, int64(7), tr.expectedChainID.Load().Int64())
+
+	down := fakeBorRPC(t, "0x7", new(int32))
+	downURL := down.URL
+	down.Close()
+	tr2 := &borHTTPFailoverTransport{endpoints: []httpEndpoint{mustEndpoint(t, downURL)}, attemptTimeout: 200 * time.Millisecond}
+	tr2.captureExpectedChainID()
+	require.Nil(t, tr2.expectedChainID.Load()) // unreachable primary → nothing captured
+}
+
+type trackCloser struct{ closed bool }
+
+func (c *trackCloser) Read([]byte) (int, error) { return 0, io.EOF }
+func (c *trackCloser) Close() error             { c.closed = true; return errors.New("close boom") }
+
+func TestCancelOnClose(t *testing.T) {
+	var cancelled bool
+	body := &trackCloser{}
+	c := &cancelOnClose{body: body, cancel: func() { cancelled = true }}
+
+	err := c.Close()
+	require.Error(t, err)        // the underlying body's Close error is propagated
+	require.True(t, cancelled)   // the per-attempt context is cancelled
+	require.True(t, body.closed) // the underlying body is closed
+}

--- a/helper/bor_failover_http_test.go
+++ b/helper/bor_failover_http_test.go
@@ -117,6 +117,20 @@ func TestBorHTTPFailover_CascadesOnTransportError(t *testing.T) {
 	require.Positive(t, atomic.LoadInt32(&h2))
 }
 
+func TestBorHTTPFailover_MarksActiveSuccess(t *testing.T) {
+	s := fakeBorRPC(t, "0x1", new(int32))
+	defer s.Close()
+
+	tr := newTestTransport(mustEndpoint(t, s.URL))
+	tr.health.MarkUnhealthy(0, errors.New("transient"))
+
+	resp, err := tr.RoundTrip(jsonRPCPost(t, s.URL, dummyReq))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, []int{0}, tr.health.Candidates(1))
+}
+
 func TestBorHTTPFailover_CascadesOn5xx(t *testing.T) {
 	var bad, good int32
 	bad5xx := server5xx(t, &bad)

--- a/helper/call.go
+++ b/helper/call.go
@@ -169,7 +169,7 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 	contractCallerObj.MainChainClient = GetMainClient()
 	contractCallerObj.MainChainTimeout = config.EthRPCTimeout
 	contractCallerObj.BorChainClient = GetBorClient()
-	contractCallerObj.BorChainTimeout = config.BorRPCTimeout
+	contractCallerObj.BorChainTimeout = GetBorChainCallTimeout()
 	contractCallerObj.MainChainRPCClient = GetMainChainRPCClient()
 	contractCallerObj.BorChainRPCClient = GetBorRPCClient()
 	contractCallerObj.BorChainGrpcFlag = config.BorGRPCFlag

--- a/helper/call_grpc_author_test.go
+++ b/helper/call_grpc_author_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/log"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -20,6 +21,7 @@ type fakeBorGRPCClient struct {
 	authorAddr *common.Address
 	authorErr  error
 	calls      int
+	closed     bool
 }
 
 func (f *fakeBorGRPCClient) GetAuthor(_ context.Context, _ *big.Int) (*common.Address, error) {
@@ -53,6 +55,9 @@ func (f *fakeBorGRPCClient) TransactionReceipt(_ context.Context, _ common.Hash)
 }
 func (f *fakeBorGRPCClient) BorBlockReceipt(_ context.Context, _ common.Hash) (*ethTypes.Receipt, error) {
 	panic("fakeBorGRPCClient.BorBlockReceipt: unexpected call")
+}
+func (f *fakeBorGRPCClient) Close(log.Logger) {
+	f.closed = true
 }
 
 // TestGetBorChainBlockAuthor_GRPC_HappyPath ensures that when the gRPC client

--- a/helper/config.go
+++ b/helper/config.go
@@ -152,6 +152,14 @@ const (
 	// HTTP and gRPC reads). Requiring N-in-a-row at the same height with
 	// stable HTTP re-reads virtually rules that out.
 	borGRPCParityMismatchStreak = 3
+
+	// borGRPCParityFatalMsg is shared by the boot-time parity check and the
+	// runtime per-probe validator so both report the same actionable reason.
+	borGRPCParityFatalMsg = "FATAL: bor gRPC hash mismatch with HTTP confirmed across " +
+		"multiple consecutive checks. The operator is likely running a new heimdall " +
+		"with BorGRPCFlag=true against a bor that doesn't populate the full proto Header. " +
+		"Continuing would corrupt milestone propositions on this node. " +
+		"Either upgrade bor to a matching version or disable BorGRPCFlag."
 )
 
 func init() {
@@ -597,11 +605,16 @@ func runBorGRPCHashParityCheck(httpClient *ethclient.Client, grpcClient *borgrpc
 	runBorGRPCHashParityCheckWith(
 		httpClient, grpcClient, timeout,
 		borGRPCParityMaxAttempts, borGRPCParityRetryInterval,
-		func(msg string, keysAndValues ...interface{}) {
-			Logger.Error(msg, keysAndValues...)
-			os.Exit(1)
-		},
+		borGRPCParityFatalFunc,
 	)
+}
+
+// borGRPCParityFatalFunc is the production fatal action for a confirmed parity
+// mismatch streak: log the reason and exit so the node stops voting rather than
+// feeding wrong-version Header hashes into side-handler reads.
+func borGRPCParityFatalFunc(msg string, keysAndValues ...interface{}) {
+	Logger.Error(msg, keysAndValues...)
+	os.Exit(1)
 }
 
 // runBorGRPCHashParityCheckWith is the core of runBorGRPCHashParityCheck.
@@ -623,13 +636,7 @@ func runBorGRPCHashParityCheckWith(
 		}
 		next, fatal := updateParityMismatchStreak(mismatches, mismatch, borGRPCParityMismatchStreak)
 		if fatal {
-			fatalFunc("FATAL: bor gRPC hash mismatch with HTTP confirmed across "+
-				"multiple consecutive checks. The operator is likely running a new heimdall "+
-				"with BorGRPCFlag=true against a bor that doesn't populate the full proto Header. "+
-				"Continuing would corrupt milestone propositions on this node. "+
-				"Either upgrade bor to a matching version or disable BorGRPCFlag.",
-				"consecutiveMismatches", next,
-			)
+			fatalFunc(borGRPCParityFatalMsg, "consecutiveMismatches", next)
 			// Return so control flow does not depend on fatalFunc exiting the
 			// process.
 			return
@@ -673,15 +680,15 @@ func updateParityMismatchStreak(current int, mismatch bool, streakLimit int) (ne
 //   - Ok=false, mismatch=true: both transports returned headers but with different hashes → count toward
 //     mismatch streak; the caller logs fatal only after borGRPCParityMismatchStreak consecutive mismatches
 func checkBorGRPCHashParityOnceWith(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration) (ok, mismatch bool) {
-	return checkBorGRPCHashParityOnce(httpClient, grpcClient, timeout, true)
+	return checkBorGRPCHashParityOnce(context.Background(), httpClient, grpcClient, timeout, true)
 }
 
-func checkBorGRPCHashParityOnceQuiet(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration) (ok, mismatch bool) {
-	return checkBorGRPCHashParityOnce(httpClient, grpcClient, timeout, false)
+func checkBorGRPCHashParityOnceQuiet(ctx context.Context, httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration) (ok, mismatch bool) {
+	return checkBorGRPCHashParityOnce(ctx, httpClient, grpcClient, timeout, false)
 }
 
-func checkBorGRPCHashParityOnce(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration, emitLogs bool) (ok, mismatch bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func checkBorGRPCHashParityOnce(parent context.Context, httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration, emitLogs bool) (ok, mismatch bool) {
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	targetNum, okDepth := resolveParityTargetHeight(ctx, httpClient)

--- a/helper/config.go
+++ b/helper/config.go
@@ -416,10 +416,16 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 		conf.Custom.EthRPCTimeout = DefaultEthRPCTimeout
 	}
 
-	if conf.Custom.BorRPCTimeout == 0 {
-		// fallback to default
-		Logger.Debug("Missing BOR RPC timeout or invalid value provided, falling back to default", "timeout", DefaultBorRPCTimeout)
-		conf.Custom.BorRPCTimeout = DefaultBorRPCTimeout
+	if clamped := clampBorRPCTimeout(conf.Custom.BorRPCTimeout); clamped != conf.Custom.BorRPCTimeout {
+		if conf.Custom.BorRPCTimeout <= 0 {
+			Logger.Debug("Missing BOR RPC timeout or invalid value provided, falling back to default", "timeout", DefaultBorRPCTimeout)
+		} else {
+			// GetBorChainCallTimeout multiplies this by up to maxBudgetedEndpoints for
+			// the failover cascade; cap it so one Bor call in a milestone/checkpoint
+			// vote extension can't run past CometBFT's ~10s ABCI budget and miss votes.
+			Logger.Warn("bor_rpc_timeout exceeds maximum; clamping", "configured", conf.Custom.BorRPCTimeout, "max", MaxBorRPCTimeout)
+		}
+		conf.Custom.BorRPCTimeout = clamped
 	}
 
 	if conf.Custom.SHStateSyncedInterval == 0 {

--- a/helper/config.go
+++ b/helper/config.go
@@ -231,7 +231,7 @@ var (
 var (
 	borClient     *ethclient.Client
 	borRPCClient  *rpc.Client
-	borGRPCClient *borgrpc.BorGRPCClient
+	borGRPCClient borgrpc.Client
 )
 
 // private key object
@@ -452,26 +452,8 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFlag string) {
 
 	mainChainClient = ethclient.NewClient(mainRPCClient)
 
-	if borRPCClient, err = rpc.Dial(conf.Custom.BorRPCUrl); err != nil {
-		log.Fatal("unable to dial bor chain RPC client", "URL", conf.Custom.BorRPCUrl, "error", err)
-	}
-
-	borClient = ethclient.NewClient(borRPCClient)
-	warnIfBorRPCInaccessible(borClient, conf.Custom.BorRPCTimeout, conf.Custom.BorRPCUrl)
-
-	if conf.Custom.BorGRPCFlag && conf.Custom.BorGRPCUrl != "" {
-		client, err := borgrpc.NewBorGRPCClient(conf.Custom.BorGRPCUrl, conf.Custom.BorGRPCToken, Logger)
-		if err != nil {
-			log.Fatal("unable to create bor gRPC client", "URL", conf.Custom.BorGRPCUrl, "error", err)
-		}
-		borGRPCClient = client
-		warnIfBorGRPCInaccessible(borGRPCClient, conf.Custom.BorRPCTimeout, conf.Custom.BorGRPCUrl)
-		// Fire-and-forget parity goroutine; removal is only observable in production init.
-		// mutator-disable-next-line statement-deletion in production init
-		verifyBorGRPCHashParity(borClient, borGRPCClient, conf.Custom.BorRPCTimeout)
-	} else if conf.Custom.BorGRPCFlag && conf.Custom.BorGRPCUrl == "" {
-		log.Fatal("bor gRPC is enabled but bor_grpc_url is empty")
-	}
+	initBorRPCClient()
+	initBorGRPCClient()
 
 	// Set default producers based on the chain if not already set by config or flags
 	if conf.Custom.ProducerVotes == "" {
@@ -1557,7 +1539,7 @@ func GetLogsWriter(logsWriterFile string) io.Writer {
 }
 
 // GetBorGRPCClient returns bor gRPC client
-func GetBorGRPCClient() *borgrpc.BorGRPCClient {
+func GetBorGRPCClient() borgrpc.Client {
 	return borGRPCClient
 }
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -673,6 +673,14 @@ func updateParityMismatchStreak(current int, mismatch bool, streakLimit int) (ne
 //   - Ok=false, mismatch=true: both transports returned headers but with different hashes → count toward
 //     mismatch streak; the caller logs fatal only after borGRPCParityMismatchStreak consecutive mismatches
 func checkBorGRPCHashParityOnceWith(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration) (ok, mismatch bool) {
+	return checkBorGRPCHashParityOnce(httpClient, grpcClient, timeout, true)
+}
+
+func checkBorGRPCHashParityOnceQuiet(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration) (ok, mismatch bool) {
+	return checkBorGRPCHashParityOnce(httpClient, grpcClient, timeout, false)
+}
+
+func checkBorGRPCHashParityOnce(httpClient parityHTTPFetcher, grpcClient parityGRPCFetcher, timeout time.Duration, emitLogs bool) (ok, mismatch bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -686,24 +694,28 @@ func checkBorGRPCHashParityOnceWith(httpClient parityHTTPFetcher, grpcClient par
 	}
 
 	if grpcHeader.Hash() != httpHeader.Hash() {
-		// Statement_deletion drops an advisory log; the (false, true) return below still signals a mismatch.
-		// mutator-disable-next-line operator-log line
-		Logger.Warn("Bor gRPC hash mismatch with HTTP for the same block — counting toward mismatch streak before fatal",
-			"block", httpHeader.Number.String(),
-			"httpHash", httpHeader.Hash().Hex(),
-			"grpcHash", grpcHeader.Hash().Hex(),
-		)
+		if emitLogs {
+			// Statement_deletion drops an advisory log; the (false, true) return below still signals a mismatch.
+			// mutator-disable-next-line operator-log line
+			Logger.Warn("Bor gRPC hash mismatch with HTTP for the same block — counting toward mismatch streak before fatal",
+				"block", httpHeader.Number.String(),
+				"httpHash", httpHeader.Hash().Hex(),
+				"grpcHash", grpcHeader.Hash().Hex(),
+			)
+		}
 		// Streak bookkeeping is covered directly via updateParityMismatchStreak tests.
 		// mutator-disable-next-line boolean_substitution on mismatch signal
 		return false, true
 	}
 
-	// Statement_deletion drops a success message; no branch logic affected.
-	// mutator-disable-next-line operator-log line
-	Logger.Info("Bor gRPC hash parity check passed",
-		"block", httpHeader.Number.String(),
-		"hash", httpHeader.Hash().Hex(),
-	)
+	if emitLogs {
+		// Statement_deletion drops a success message; no branch logic affected.
+		// mutator-disable-next-line operator-log line
+		Logger.Info("Bor gRPC hash parity check passed",
+			"block", httpHeader.Number.String(),
+			"hash", httpHeader.Hash().Hex(),
+		)
+	}
 	// Ok-signal flip is observable only via runBorGRPCHashParityCheckWith's caller-side early-return, which is tested directly.
 	// mutator-disable-next-line boolean_substitution on ok signal
 	return true, false

--- a/helper/parity_check_test.go
+++ b/helper/parity_check_test.go
@@ -364,13 +364,24 @@ func TestBorGRPCParityValidator(t *testing.T) {
 	t.Parallel()
 
 	timeout := time.Second
+	noFatal := func(string, ...interface{}) { panic("unexpected parity fatal") }
+
+	// repeatHeaders builds n parity-check worth of identical HTTP responses
+	// (each check consumes resolve + two stability reads).
+	repeatHeaders := func(h *ethTypes.Header, checks int) []*ethTypes.Header {
+		out := make([]*ethTypes.Header, 0, checks*3)
+		for i := 0; i < checks*3; i++ {
+			out = append(out, h)
+		}
+		return out
+	}
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
 		h := makeHeader(100)
 		http := &stubHTTPFetcher{calls: []*ethTypes.Header{h, h, h}}
-		validator := borGRPCParityValidator(http, timeout)
+		validator := borGRPCParityValidator(http, timeout, noFatal)
 
 		require.NoError(t, validator(context.Background(), 1, &stubGRPCFetcher{header: makeHeader(100)}))
 	})
@@ -382,25 +393,56 @@ func TestBorGRPCParityValidator(t *testing.T) {
 		grpcHdr := makeHeader(100)
 		grpcHdr.GasLimit = 123
 		http := &stubHTTPFetcher{calls: []*ethTypes.Header{httpHdr, httpHdr, httpHdr}}
-		validator := borGRPCParityValidator(http, timeout)
+		validator := borGRPCParityValidator(http, timeout, noFatal)
 
 		err := validator(context.Background(), 1, &stubGRPCFetcher{header: grpcHdr})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "hash mismatch")
 	})
 
-	t.Run("unavailable", func(t *testing.T) {
+	t.Run("transient does not demote", func(t *testing.T) {
 		t.Parallel()
 
 		http := &stubHTTPFetcher{
 			calls: []*ethTypes.Header{nil},
 			errs:  []error{errors.New("transient")},
 		}
-		validator := borGRPCParityValidator(http, timeout)
+		validator := borGRPCParityValidator(http, timeout, noFatal)
 
-		err := validator(context.Background(), 1, &stubGRPCFetcher{header: makeHeader(100)})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "hash parity unavailable")
+		// A transient HTTP-side read failure is not the gRPC endpoint's fault.
+		require.NoError(t, validator(context.Background(), 1, &stubGRPCFetcher{header: makeHeader(100)}))
+	})
+
+	t.Run("primary mismatch streak fatals", func(t *testing.T) {
+		t.Parallel()
+
+		httpHdr := makeHeader(100)
+		grpcHdr := makeHeader(100)
+		grpcHdr.GasLimit = 123
+		http := &stubHTTPFetcher{calls: repeatHeaders(httpHdr, borGRPCParityMismatchStreak)}
+		var fatals int
+		validator := borGRPCParityValidator(http, timeout, func(string, ...interface{}) { fatals++ })
+
+		for n := 1; n <= borGRPCParityMismatchStreak; n++ {
+			require.Error(t, validator(context.Background(), primaryEndpoint, &stubGRPCFetcher{header: grpcHdr}))
+		}
+		require.Equal(t, 1, fatals) // fatal once the primary streak hits the threshold
+	})
+
+	t.Run("fallback mismatch never fatals", func(t *testing.T) {
+		t.Parallel()
+
+		httpHdr := makeHeader(100)
+		grpcHdr := makeHeader(100)
+		grpcHdr.GasLimit = 123
+		http := &stubHTTPFetcher{calls: repeatHeaders(httpHdr, borGRPCParityMismatchStreak+1)}
+		var fatals int
+		validator := borGRPCParityValidator(http, timeout, func(string, ...interface{}) { fatals++ })
+
+		for n := 0; n <= borGRPCParityMismatchStreak; n++ {
+			require.Error(t, validator(context.Background(), 1, &stubGRPCFetcher{header: grpcHdr}))
+		}
+		require.Zero(t, fatals) // a non-primary endpoint is only demoted, never fatal
 	})
 }
 

--- a/helper/parity_check_test.go
+++ b/helper/parity_check_test.go
@@ -354,6 +354,56 @@ func TestCheckBorGRPCHashParityOnceWith(t *testing.T) {
 	})
 }
 
+func TestBorGRPCParityValidators(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, borGRPCParityValidators(nil, time.Second))
+}
+
+func TestBorGRPCParityValidator(t *testing.T) {
+	t.Parallel()
+
+	timeout := time.Second
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		h := makeHeader(100)
+		http := &stubHTTPFetcher{calls: []*ethTypes.Header{h, h, h}}
+		validator := borGRPCParityValidator(http, timeout)
+
+		require.NoError(t, validator(context.Background(), 1, &stubGRPCFetcher{header: makeHeader(100)}))
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		httpHdr := makeHeader(100)
+		grpcHdr := makeHeader(100)
+		grpcHdr.GasLimit = 123
+		http := &stubHTTPFetcher{calls: []*ethTypes.Header{httpHdr, httpHdr, httpHdr}}
+		validator := borGRPCParityValidator(http, timeout)
+
+		err := validator(context.Background(), 1, &stubGRPCFetcher{header: grpcHdr})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hash mismatch")
+	})
+
+	t.Run("unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		http := &stubHTTPFetcher{
+			calls: []*ethTypes.Header{nil},
+			errs:  []error{errors.New("transient")},
+		}
+		validator := borGRPCParityValidator(http, timeout)
+
+		err := validator(context.Background(), 1, &stubGRPCFetcher{header: makeHeader(100)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hash parity unavailable")
+	})
+}
+
 // TestFetchStableHeadersAtHeight covers all stability / error branches.
 func TestFetchStableHeadersAtHeight(t *testing.T) {
 	t.Parallel()

--- a/helper/toml.go
+++ b/helper/toml.go
@@ -17,13 +17,16 @@ const DefaultConfigTemplate = `
 # RPC endpoint for ethereum chain
 eth_rpc_url = "{{ .Custom.EthRPCUrl }}"
 
-# RPC endpoint for bor chain
+# RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
+# list for failover (first = primary; heimdall reverts to it once it recovers).
+# A single URL keeps the previous single-endpoint behavior.
 bor_rpc_url = "{{ .Custom.BorRPCUrl }}"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "{{ .Custom.BorGRPCFlag }}"
 
-# GRPC endpoint for bor chain
+# GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
+# priority-ordered list for failover.
 bor_grpc_url = "{{ .Custom.BorGRPCUrl }}"
 
 # Bearer token for bor gRPC authentication (empty disables auth)

--- a/helper/tx.go
+++ b/helper/tx.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -34,14 +35,26 @@ type EthClient interface {
 
 // GenerateAuthObj creates a transaction auth object with EIP-1559 gas pricing.
 func GenerateAuthObj(client *ethclient.Client, address common.Address, data []byte) (auth *bind.TransactOpts, err error) {
-	return generateAuthObjWithClient(client, address, data)
+	return GenerateAuthObjWithContext(context.Background(), GetConfig().EthRPCTimeout, client, address, data)
+}
+
+// GenerateAuthObjWithContext creates a transaction auth object using ctx as the
+// parent cancellation signal and timeout as the budget for each RPC call.
+func GenerateAuthObjWithContext(ctx context.Context, timeout time.Duration, client *ethclient.Client, address common.Address, data []byte) (auth *bind.TransactOpts, err error) {
+	return generateAuthObjWithClient(ctx, timeout, client, address, data)
+}
+
+type authRPCData struct {
+	latestBlock     *types.Block
+	suggestedTipCap *big.Int
+	nonce           uint64
+	gasLimit        uint64
+	chainID         *big.Int
 }
 
 // generateAuthObjWithClient creates a transaction auth object using the EthClient interface.
 // This function is used internally and allows for easier testing with mock clients.
-func generateAuthObjWithClient(client EthClient, address common.Address, data []byte) (auth *bind.TransactOpts, err error) {
-	ctx := context.Background()
-
+func generateAuthObjWithClient(ctx context.Context, timeout time.Duration, client EthClient, address common.Address, data []byte) (auth *bind.TransactOpts, err error) {
 	callMsg := ethereum.CallMsg{
 		To:   &address,
 		Data: data,
@@ -55,41 +68,55 @@ func generateAuthObjWithClient(client EthClient, address common.Address, data []
 
 	// Get the from address.
 	fromAddress := common.BytesToAddress(pkObject.PubKey().Address().Bytes())
+	callMsg.From = fromAddress
 
-	// Get the configured gas fee cap and tip cap.
-	configGasFeeCap := GetConfig().MainChainGasFeeCap
-	if configGasFeeCap <= 0 {
-		configGasFeeCap = DefaultMainChainGasFeeCap
-	}
-
-	configGasTipCap := GetConfig().MainChainGasTipCap
-	if configGasTipCap <= 0 {
-		configGasTipCap = DefaultMainChainGasTipCap
-	}
-
-	// Get the latest block to retrieve baseFee.
-	latestBlock, err := client.BlockByNumber(ctx, nil)
+	rpcData, err := fetchAuthRPCData(ctx, timeout, client, fromAddress, callMsg)
 	if err != nil {
-		Logger.Error("unable to fetch latest block", "error", err)
 		return
 	}
 
-	baseFee := latestBlock.BaseFee()
+	baseFee := rpcData.latestBlock.BaseFee()
+	gasFeeCap, gasTipCap, err := calculateEIP1559Caps(baseFee, rpcData.suggestedTipCap)
+	if err != nil {
+		return
+	}
+
+	auth, err = bind.NewKeyedTransactorWithChainID(ecdsaPrivateKey, rpcData.chainID)
+	if err != nil {
+		Logger.Error(errUnableToCreateAuthObj, "error", err)
+		return
+	}
+
+	auth.Nonce = big.NewInt(int64(rpcData.nonce))
+	auth.GasLimit = rpcData.gasLimit
+	auth.GasFeeCap = gasFeeCap
+	auth.GasTipCap = gasTipCap
+
+	Logger.Debug("created EIP-1559 transaction auth",
+		"nonce", rpcData.nonce,
+		"gasLimit", rpcData.gasLimit,
+		"gasFeeCap", gasFeeCap,
+		"gasTipCap", gasTipCap,
+		"baseFee", baseFee,
+	)
+
+	return
+}
+
+func calculateEIP1559Caps(baseFee, suggestedTipCap *big.Int) (*big.Int, *big.Int, error) {
 	if baseFee == nil {
-		err = errors.New("baseFee is nil, EIP-1559 not supported")
+		err := errors.New("baseFee is nil, EIP-1559 not supported")
 		Logger.Error("EIP-1559 not supported on this chain", "error", err)
-		return
+		return nil, nil, err
 	}
-
-	// Get suggested tip cap from the network.
-	suggestedTipCap, err := client.SuggestGasTipCap(ctx)
-	if err != nil {
+	if suggestedTipCap == nil {
+		err := errors.New("suggested gas tip cap is nil")
 		Logger.Error("unable to fetch suggested gas tip cap", "error", err)
-		return
+		return nil, nil, err
 	}
 
-	// Use the lower of suggested tip or configured tip cap to prioritize lower fees.
-	// The configured tip cap acts as a maximum we're willing to pay.
+	configGasFeeCap, configGasTipCap := configuredGasCaps()
+
 	gasTipCap := suggestedTipCap
 	if gasTipCap.Cmp(big.NewInt(configGasTipCap)) > 0 {
 		Logger.Warn(
@@ -118,45 +145,93 @@ func generateAuthObjWithClient(client EthClient, address common.Address, data []
 		gasTipCap = gasFeeCap
 	}
 
-	// Use PendingNonceAt to account for pending transactions in the mempool.
-	nonce, err := client.PendingNonceAt(ctx, fromAddress)
+	return gasFeeCap, gasTipCap, nil
+}
+
+func configuredGasCaps() (int64, int64) {
+	configGasFeeCap := GetConfig().MainChainGasFeeCap
+	if configGasFeeCap <= 0 {
+		configGasFeeCap = DefaultMainChainGasFeeCap
+	}
+	configGasTipCap := GetConfig().MainChainGasTipCap
+	if configGasTipCap <= 0 {
+		configGasTipCap = DefaultMainChainGasTipCap
+	}
+	return configGasFeeCap, configGasTipCap
+}
+
+func fetchAuthRPCData(ctx context.Context, timeout time.Duration, client EthClient, fromAddress common.Address, callMsg ethereum.CallMsg) (authRPCData, error) {
+	var out authRPCData
+	var err error
+
+	out.latestBlock, err = fetchAuthLatestBlock(ctx, timeout, client)
 	if err != nil {
-		return
+		return out, err
 	}
 
-	callMsg.From = fromAddress
-	gasLimit, err := client.EstimateGas(ctx, callMsg)
+	out.suggestedTipCap, err = callWithTimeout(ctx, timeout, client.SuggestGasTipCap)
+	if err != nil {
+		Logger.Error("unable to fetch suggested gas tip cap", "error", err)
+		return out, err
+	}
+
+	out.nonce, err = callWithTimeout(ctx, timeout, func(callCtx context.Context) (uint64, error) {
+		return client.PendingNonceAt(callCtx, fromAddress)
+	})
+	if err != nil {
+		return out, err
+	}
+
+	out.gasLimit, err = callWithTimeout(ctx, timeout, func(callCtx context.Context) (uint64, error) {
+		return client.EstimateGas(callCtx, callMsg)
+	})
 	if err != nil {
 		Logger.Error("Unable to estimate gas", "error", err)
-		return
+		return out, err
 	}
 
-	chainId, err := client.ChainID(ctx)
+	out.chainID, err = callWithTimeout(ctx, timeout, client.ChainID)
 	if err != nil {
 		Logger.Error("Unable to fetch ChainID", "error", err)
-		return
+		return out, err
+	}
+	if out.chainID == nil {
+		return out, errors.New("chain ID is nil")
 	}
 
-	auth, err = bind.NewKeyedTransactorWithChainID(ecdsaPrivateKey, chainId)
+	return out, nil
+}
+
+func fetchAuthLatestBlock(ctx context.Context, timeout time.Duration, client EthClient) (*types.Block, error) {
+	latestBlock, err := callWithTimeout(ctx, timeout, func(callCtx context.Context) (*types.Block, error) {
+		return client.BlockByNumber(callCtx, nil)
+	})
 	if err != nil {
-		Logger.Error(errUnableToCreateAuthObj, "error", err)
-		return
+		Logger.Error("unable to fetch latest block", "error", err)
+		return nil, err
 	}
+	if latestBlock == nil {
+		return nil, errors.New("latest block is nil")
+	}
+	if latestBlock.BaseFee() == nil {
+		err := errors.New("baseFee is nil, EIP-1559 not supported")
+		Logger.Error("EIP-1559 not supported on this chain", "error", err)
+		return nil, err
+	}
+	return latestBlock, nil
+}
 
-	auth.Nonce = big.NewInt(int64(nonce))
-	auth.GasLimit = gasLimit
-	auth.GasFeeCap = gasFeeCap
-	auth.GasTipCap = gasTipCap
+func rpcCallContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		timeout = DefaultEthRPCTimeout
+	}
+	return context.WithTimeout(parent, timeout)
+}
 
-	Logger.Debug("created EIP-1559 transaction auth",
-		"nonce", nonce,
-		"gasLimit", gasLimit,
-		"gasFeeCap", gasFeeCap,
-		"gasTipCap", gasTipCap,
-		"baseFee", baseFee,
-	)
-
-	return
+func callWithTimeout[T any](parent context.Context, timeout time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	callCtx, cancel := rpcCallContext(parent, timeout)
+	defer cancel()
+	return fn(callCtx)
 }
 
 // SendCheckpoint sends checkpoint to rootChain contract.

--- a/helper/tx_test.go
+++ b/helper/tx_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -114,7 +115,7 @@ func TestGenerateAuthObj_NormalEIP1559Flow(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 
@@ -157,7 +158,7 @@ func TestGenerateAuthObj_BaseFeeNil(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 
 	assert.Error(t, err, "Should return error when baseFee is nil")
 	assert.Nil(t, auth, "Auth should be nil when baseFee is nil")
@@ -186,7 +187,7 @@ func TestGenerateAuthObj_FeeCapExceedsConfiguredMaximum(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 
@@ -217,7 +218,7 @@ func TestGenerateAuthObj_TipCapExceedsConfiguredMaximum(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 
@@ -255,7 +256,7 @@ func TestGenerateAuthObj_TipCapExceedsFeeCap(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 
@@ -282,7 +283,7 @@ func TestGenerateAuthObj_BlockByNumberError(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 
 	assert.Error(t, err, "Should return error when BlockByNumber fails")
 	assert.Nil(t, auth, "Auth should be nil when BlockByNumber fails")
@@ -313,8 +314,43 @@ func TestGenerateAuthObj_SuggestGasTipCapError(t *testing.T) {
 	address := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	data := []byte("test data")
 
-	auth, err := generateAuthObjWithClient(mockClient, address, data)
+	auth, err := generateAuthObjWithClient(context.Background(), time.Second, mockClient, address, data)
 
 	assert.Error(t, err, "Should return error when SuggestGasTipCap fails")
 	assert.Nil(t, auth, "Auth should be nil when SuggestGasTipCap fails")
+}
+
+func TestGenerateAuthObj_PropagatesCallerCancellation(t *testing.T) {
+	InitTestHeimdallConfig("")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockClient := &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	auth, err := generateAuthObjWithClient(ctx, time.Hour, mockClient, common.Address{}, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, auth)
+}
+
+func TestGenerateAuthObj_AppliesPerRPCTimeout(t *testing.T) {
+	InitTestHeimdallConfig("")
+
+	mockClient := &mockEthClient{
+		blockByNumberFn: func(ctx context.Context, number *big.Int) (*types.Block, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	start := time.Now()
+	auth, err := generateAuthObjWithClient(context.Background(), 10*time.Millisecond, mockClient, common.Address{}, nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, auth)
+	require.Less(t, time.Since(start), time.Second)
 }

--- a/metrics/borfailover.go
+++ b/metrics/borfailover.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+// Bor endpoint-failover metrics. Labeled by transport ("http" or "grpc") so a
+// single dashboard shows failover behavior across both Bor client paths.
+// Counter names use the _total suffix per Prometheus convention.
+var (
+	BorFailoverSwitches = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "bor_failover",
+		Name:      "switches_total",
+		Help:      "Total in-call failover switches of the active Bor endpoint, by transport",
+	}, []string{"transport"})
+
+	BorFailoverProactiveSwitches = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "bor_failover",
+		Name:      "proactive_switches_total",
+		Help:      "Total background-prober switches of the active Bor endpoint (including revert-to-primary), by transport",
+	}, []string{"transport"})
+
+	BorFailoverActiveIndex = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "bor_failover",
+		Name:      "active_index",
+		Help:      "Index of the currently active Bor endpoint (0 = primary), by transport",
+	}, []string{"transport"})
+
+	BorFailoverHealthyEndpoints = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "bor_failover",
+		Name:      "healthy_endpoints",
+		Help:      "Number of Bor endpoints currently considered healthy, by transport",
+	}, []string{"transport"})
+)
+
+// BorFailover wires the failover state machine's metric hooks to the labeled
+// Prometheus vectors for the given transport ("http" or "grpc").
+func BorFailover(transport string) failover.Metrics {
+	return failover.Metrics{
+		Switch:          func() { BorFailoverSwitches.WithLabelValues(transport).Inc() },
+		ProactiveSwitch: func() { BorFailoverProactiveSwitches.WithLabelValues(transport).Inc() },
+		ActiveIndex:     func(i int) { BorFailoverActiveIndex.WithLabelValues(transport).Set(float64(i)) },
+		HealthyCount:    func(c int) { BorFailoverHealthyEndpoints.WithLabelValues(transport).Set(float64(c)) },
+	}
+}

--- a/metrics/borfailover_test.go
+++ b/metrics/borfailover_test.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBorFailover_AllHooksWired(t *testing.T) {
+	m := BorFailover("unit")
+
+	require.NotNil(t, m.Switch)
+	require.NotNil(t, m.ProactiveSwitch)
+	require.NotNil(t, m.ActiveIndex)
+	require.NotNil(t, m.HealthyCount)
+
+	require.NotPanics(t, func() {
+		m.Switch()
+		m.ProactiveSwitch()
+		m.ActiveIndex(1)
+		m.HealthyCount(2)
+	})
+}

--- a/packaging/templates/config/amoy/app.toml
+++ b/packaging/templates/config/amoy/app.toml
@@ -250,14 +250,16 @@ eth_rpc_url = "http://localhost:9545"
 
 # RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
 # list for failover (first = primary; heimdall reverts to it once it recovers).
-# A single URL keeps the previous single-endpoint behavior.
+# Multi-endpoint failover is rejected at startup for protected BP validator IDs;
+# BP nodes must use a single local/self Bor endpoint. A single URL keeps the
+# previous single-endpoint behavior.
 bor_rpc_url = "http://localhost:8545"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "false"
 
 # GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
-# priority-ordered list for failover.
+# priority-ordered list for failover and is rejected on protected BP nodes.
 bor_grpc_url = "http://localhost:3131"
 
 # Bearer token for bor gRPC authentication (empty disables auth)

--- a/packaging/templates/config/amoy/app.toml
+++ b/packaging/templates/config/amoy/app.toml
@@ -248,13 +248,16 @@ bor_rpc_timeout = "1s"
 # RPC endpoint for ethereum chain
 eth_rpc_url = "http://localhost:9545"
 
-# RPC endpoint for bor chain
+# RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
+# list for failover (first = primary; heimdall reverts to it once it recovers).
+# A single URL keeps the previous single-endpoint behavior.
 bor_rpc_url = "http://localhost:8545"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "false"
 
-# GRPC endpoint for bor chain
+# GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
+# priority-ordered list for failover.
 bor_grpc_url = "http://localhost:3131"
 
 # Bearer token for bor gRPC authentication (empty disables auth)

--- a/packaging/templates/config/mainnet/app.toml
+++ b/packaging/templates/config/mainnet/app.toml
@@ -250,14 +250,16 @@ eth_rpc_url = "http://localhost:9545"
 
 # RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
 # list for failover (first = primary; heimdall reverts to it once it recovers).
-# A single URL keeps the previous single-endpoint behavior.
+# Multi-endpoint failover is rejected at startup for protected BP validator IDs;
+# BP nodes must use a single local/self Bor endpoint. A single URL keeps the
+# previous single-endpoint behavior.
 bor_rpc_url = "http://localhost:8545"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "false"
 
 # GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
-# priority-ordered list for failover.
+# priority-ordered list for failover and is rejected on protected BP nodes.
 bor_grpc_url = "http://localhost:3131"
 
 # Bearer token for bor gRPC authentication (empty disables auth)

--- a/packaging/templates/config/mainnet/app.toml
+++ b/packaging/templates/config/mainnet/app.toml
@@ -248,13 +248,16 @@ bor_rpc_timeout = "1s"
 # RPC endpoint for ethereum chain
 eth_rpc_url = "http://localhost:9545"
 
-# RPC endpoint for bor chain
+# RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
+# list for failover (first = primary; heimdall reverts to it once it recovers).
+# A single URL keeps the previous single-endpoint behavior.
 bor_rpc_url = "http://localhost:8545"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "false"
 
-# GRPC endpoint for bor chain
+# GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
+# priority-ordered list for failover.
 bor_grpc_url = "http://localhost:3131"
 
 # Bearer token for bor gRPC authentication (empty disables auth)

--- a/x/bor/failover/health.go
+++ b/x/bor/failover/health.go
@@ -204,7 +204,11 @@ func (h *Health) Reclaim(i int) {
 	h.health[i].consecutiveSuccess = h.consecutiveThreshold
 	h.health[i].healthySince = time.Now()
 	h.health[i].lastErr = nil
+	prev := h.active
 	h.setActiveLocked(i)
+	if prev != i {
+		h.metric.onProactiveSwitch()
+	}
 }
 
 // Candidates returns the in-call failover targets to try after `failed` failed:
@@ -249,6 +253,7 @@ func Call[T any](h *Health, ctx context.Context, attemptTimeout time.Duration, f
 	active := h.Active()
 	res, err := callOnce(ctx, attemptTimeout, active, fn)
 	if err == nil {
+		h.MarkSuccess(active)
 		return res, nil
 	}
 	if ctx.Err() != nil || !retriable(err) {

--- a/x/bor/failover/health.go
+++ b/x/bor/failover/health.go
@@ -1,0 +1,288 @@
+// Package failover provides a transport-agnostic endpoint failover state
+// machine shared by Heimdall's Bor HTTP and gRPC clients. It tracks N
+// priority-ordered endpoints (index 0 is the primary), cascades to the next
+// reachable endpoint when the active one fails, and a background prober reverts
+// to a higher-priority endpoint once it recovers.
+//
+// Fallback endpoints are only used after a probe has confirmed their identity
+// against the expected chain. The primary owns that expectation whenever it is
+// reachable, so a wrong-network fallback cannot serve while the primary is up.
+// The one exception is a window where the primary has never been reachable: the
+// highest-priority reachable fallback may then provisionally define the expected
+// identity so failover still engages, which means a misconfigured wrong-network
+// fallback could serve during that window. Once the primary becomes reachable it
+// reclaims the expectation and demotes every other endpoint (see Reclaim),
+// ending the window.
+package failover
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+// Prober timing defaults. Hardcoded rather than operator config to keep the
+// config surface small; revisit if operators ask to tune them. The probe
+// timeout stays well under CometBFT's ~10s ABCI budget.
+const (
+	DefaultCheckInterval        = 10 * time.Second
+	DefaultConsecutiveThreshold = 3
+	DefaultPromotionCooldown    = 60 * time.Second
+	DefaultProbeTimeout         = 3 * time.Second
+)
+
+type endpointHealth struct {
+	healthy            bool
+	consecutiveSuccess int
+	healthySince       time.Time
+	lastErr            error
+}
+
+// Metrics holds optional, nil-safe metric hooks. This package carries no
+// metrics-library dependency; callers wire concrete counters/gauges.
+type Metrics struct {
+	Switch          func()    // in-call cascade switched the active endpoint
+	ProactiveSwitch func()    // background prober switched (incl. revert-to-primary)
+	ActiveIndex     func(int) // active endpoint index changed
+	HealthyCount    func(int) // number of healthy endpoints after a probe cycle
+}
+
+func (m Metrics) onSwitch() {
+	if m.Switch != nil {
+		m.Switch()
+	}
+}
+
+func (m Metrics) onProactiveSwitch() {
+	if m.ProactiveSwitch != nil {
+		m.ProactiveSwitch()
+	}
+}
+
+func (m Metrics) onActiveIndex(i int) {
+	if m.ActiveIndex != nil {
+		m.ActiveIndex(i)
+	}
+}
+
+func (m Metrics) onHealthyCount(c int) {
+	if m.HealthyCount != nil {
+		m.HealthyCount(c)
+	}
+}
+
+// Health is a failover state machine for n priority-ordered endpoints. All
+// exported methods are safe for concurrent use.
+type Health struct {
+	mu     sync.Mutex
+	health []endpointHealth
+	active int
+	n      int
+
+	checkInterval        time.Duration
+	consecutiveThreshold int
+	promotionCooldown    time.Duration
+	probeTimeout         time.Duration
+
+	probe  func(i int) error
+	metric Metrics
+	logger log.Logger
+
+	quit      chan struct{}
+	done      chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+// New builds a Health for n endpoints. probe tests reachability and identity of
+// endpoint i. The primary (index 0) is trusted at boot; a fallback only becomes
+// healthy — and thus a failover candidate — after an identity-validating probe.
+func New(n int, probe func(i int) error, m Metrics, logger log.Logger) *Health {
+	hs := make([]endpointHealth, n)
+	hs[0] = endpointHealth{healthy: true}
+	return &Health{
+		health:               hs,
+		n:                    n,
+		checkInterval:        DefaultCheckInterval,
+		consecutiveThreshold: DefaultConsecutiveThreshold,
+		promotionCooldown:    DefaultPromotionCooldown,
+		probeTimeout:         DefaultProbeTimeout,
+		probe:                probe,
+		metric:               m,
+		logger:               logger,
+		quit:                 make(chan struct{}),
+		done:                 make(chan struct{}),
+	}
+}
+
+// SetTuning overrides the prober timings. Call before Start; tests use it to
+// compress intervals while production keeps the defaults.
+func (h *Health) SetTuning(check time.Duration, threshold int, cooldown, probeTimeout time.Duration) {
+	h.checkInterval = check
+	h.consecutiveThreshold = threshold
+	h.promotionCooldown = cooldown
+	h.probeTimeout = probeTimeout
+}
+
+// ProbeTimeout exposes the per-probe timeout for callers whose probe closures
+// need to bound their own context.
+func (h *Health) ProbeTimeout() time.Duration { return h.probeTimeout }
+
+// Active returns the current active endpoint index.
+func (h *Health) Active() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.active
+}
+
+// SetActive records a new active endpoint and updates the gauge.
+func (h *Health) SetActive(i int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.setActiveLocked(i)
+}
+
+func (h *Health) setActiveLocked(i int) {
+	if h.active == i {
+		return
+	}
+	h.active = i
+	h.metric.onActiveIndex(i)
+}
+
+// MarkUnhealthy flags endpoint i as failed, removing it from the failover
+// candidate set until a probe re-confirms it.
+func (h *Health) MarkUnhealthy(i int, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.health[i].healthy = false
+	h.health[i].consecutiveSuccess = 0
+	h.health[i].lastErr = err
+}
+
+// MarkSuccess records a successful use of endpoint i, promoting it to healthy
+// once it clears the consecutive-success threshold.
+func (h *Health) MarkSuccess(i int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.markSuccessLocked(i)
+}
+
+func (h *Health) markSuccessLocked(i int) {
+	h.health[i].consecutiveSuccess++
+	h.health[i].lastErr = nil
+	if !h.health[i].healthy && h.health[i].consecutiveSuccess >= h.consecutiveThreshold {
+		h.health[i].healthy = true
+		h.health[i].healthySince = time.Now()
+	}
+}
+
+// Reclaim makes endpoint i the sole trusted endpoint: healthy and active at once
+// (bypassing the consecutive-success threshold), and marks every other endpoint
+// unhealthy so it must re-validate before it can be used again. It is called when
+// the authoritative primary reclaims the chain identity after an outage: other
+// endpoints may have been validated against a now-overwritten provisional
+// identity, so their health is stale and must not be trusted — including as an
+// in-call failover candidate — until a fresh probe re-confirms them against the
+// reclaimed identity.
+func (h *Health) Reclaim(i int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for j := range h.health {
+		if j == i {
+			continue
+		}
+		h.health[j].healthy = false
+		h.health[j].consecutiveSuccess = 0
+	}
+	h.health[i].healthy = true
+	h.health[i].consecutiveSuccess = h.consecutiveThreshold
+	h.health[i].healthySince = time.Now()
+	h.health[i].lastErr = nil
+	h.setActiveLocked(i)
+}
+
+// Candidates returns the in-call failover targets to try after `failed` failed:
+// only currently-healthy endpoints, ordered cooled (past the promotion cooldown)
+// then uncooled, each in priority (index) order. A fallback is healthy only
+// after an identity-validating probe, so a wrong-network or down endpoint is
+// never a candidate.
+func (h *Health) Candidates(failed int) []int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var cooled, uncooled []int
+	for i := 0; i < h.n; i++ {
+		if i == failed || !h.health[i].healthy {
+			continue
+		}
+		if time.Since(h.health[i].healthySince) >= h.promotionCooldown {
+			cooled = append(cooled, i)
+		} else {
+			uncooled = append(uncooled, i)
+		}
+	}
+	return append(cooled, uncooled...)
+}
+
+// Promote records a successful in-call failover switch from one endpoint to
+// another, updating active, health, the switch metric, and the log.
+func (h *Health) Promote(from, to int) {
+	h.SetActive(to)
+	h.MarkSuccess(to)
+	h.metric.onSwitch()
+	h.logger.Info("bor failover: switched active endpoint", "from", from, "to", to)
+}
+
+// Call executes fn against the active endpoint. On a retriable error it marks
+// the active endpoint unhealthy and cascades through Candidates (validated
+// endpoints only), promoting the first that succeeds. Each attempt is bounded
+// by attemptTimeout; the cascade stops once ctx is done (caller deadline or
+// cancellation). The caller must therefore budget more than one attemptTimeout
+// for a cascade to reach a fallback — ContractCaller uses GetBorChainCallTimeout
+// (attemptTimeout times the endpoint count) for exactly that.
+func Call[T any](h *Health, ctx context.Context, attemptTimeout time.Duration, fn func(context.Context, int) (T, error), retriable func(error) bool) (T, error) {
+	active := h.Active()
+	res, err := callOnce(ctx, attemptTimeout, active, fn)
+	if err == nil {
+		return res, nil
+	}
+	if ctx.Err() != nil || !retriable(err) {
+		return res, err
+	}
+
+	h.MarkUnhealthy(active, err)
+	lastErr := err
+	var zero T
+	for _, i := range h.Candidates(active) {
+		res, err := callOnce(ctx, attemptTimeout, i, fn)
+		if err == nil {
+			h.Promote(active, i)
+			return res, nil
+		}
+		if ctx.Err() != nil || !retriable(err) {
+			return zero, err
+		}
+		lastErr = err
+		h.MarkUnhealthy(i, err)
+	}
+	return zero, lastErr
+}
+
+func callOnce[T any](ctx context.Context, attemptTimeout time.Duration, i int, fn func(context.Context, int) (T, error)) (T, error) {
+	attemptCtx, cancel := WithAttemptTimeout(ctx, attemptTimeout)
+	defer cancel()
+	return fn(attemptCtx, i)
+}
+
+// WithAttemptTimeout derives a per-attempt context bounding a single endpoint
+// attempt to timeout. It is a child of parent, so caller cancellation
+// propagates immediately to the in-flight attempt and the attempt never
+// outlives the caller's overall budget. Failover relies on that budget
+// exceeding a single attemptTimeout — ContractCaller sizes it via
+// GetBorChainCallTimeout (per-attempt timeout times the endpoint count) — so a
+// cascade has the room to reach a fallback within the same call.
+func WithAttemptTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
+}

--- a/x/bor/failover/health.go
+++ b/x/bor/failover/health.go
@@ -174,8 +174,12 @@ func (h *Health) MarkSuccess(i int) {
 }
 
 func (h *Health) markSuccessLocked(i int) {
-	h.health[i].consecutiveSuccess++
 	h.health[i].lastErr = nil
+	// Saturate at the threshold: only the crossing matters, and an unbounded
+	// counter would eventually overflow on a long-lived hot endpoint.
+	if h.health[i].consecutiveSuccess < h.consecutiveThreshold {
+		h.health[i].consecutiveSuccess++
+	}
 	if !h.health[i].healthy && h.health[i].consecutiveSuccess >= h.consecutiveThreshold {
 		h.health[i].healthy = true
 		h.health[i].healthySince = time.Now()

--- a/x/bor/failover/health.go
+++ b/x/bor/failover/health.go
@@ -100,6 +100,9 @@ type Health struct {
 // endpoint i. The primary (index 0) is trusted at boot; a fallback only becomes
 // healthy — and thus a failover candidate — after an identity-validating probe.
 func New(n int, probe func(i int) error, m Metrics, logger log.Logger) *Health {
+	if n < 1 {
+		panic("bor failover: endpoint count must be positive")
+	}
 	hs := make([]endpointHealth, n)
 	hs[0] = endpointHealth{healthy: true}
 	return &Health{

--- a/x/bor/failover/health.go
+++ b/x/bor/failover/health.go
@@ -234,12 +234,22 @@ func (h *Health) Candidates(failed int) []int {
 }
 
 // Promote records a successful in-call failover switch from one endpoint to
-// another, updating active, health, the switch metric, and the log.
-func (h *Health) Promote(from, to int) {
-	h.SetActive(to)
-	h.MarkSuccess(to)
-	h.metric.onSwitch()
-	h.logger.Info("bor failover: switched active endpoint", "from", from, "to", to)
+// another, updating active, health, the switch metric, and the log. It refuses
+// stale candidates that a concurrent Reclaim demoted after Candidates returned.
+func (h *Health) Promote(from, to int) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.health[to].healthy {
+		return false
+	}
+	prev := h.active
+	h.setActiveLocked(to)
+	h.markSuccessLocked(to)
+	if prev != to {
+		h.metric.onSwitch()
+		h.logger.Info("bor failover: switched active endpoint", "from", from, "to", to)
+	}
+	return true
 }
 
 // Call executes fn against the active endpoint. On a retriable error it marks
@@ -261,13 +271,26 @@ func Call[T any](h *Health, ctx context.Context, attemptTimeout time.Duration, f
 	}
 
 	h.MarkUnhealthy(active, err)
-	lastErr := err
+	return callCandidates(h, ctx, attemptTimeout, active, err, fn, retriable)
+}
+
+func callCandidates[T any](
+	h *Health,
+	ctx context.Context,
+	attemptTimeout time.Duration,
+	failed int,
+	lastErr error,
+	fn func(context.Context, int) (T, error),
+	retriable func(error) bool,
+) (T, error) {
 	var zero T
-	for _, i := range h.Candidates(active) {
+	for _, i := range h.Candidates(failed) {
 		res, err := callOnce(ctx, attemptTimeout, i, fn)
 		if err == nil {
-			h.Promote(active, i)
-			return res, nil
+			if h.Promote(failed, i) {
+				return res, nil
+			}
+			continue
 		}
 		if ctx.Err() != nil || !retriable(err) {
 			return zero, err

--- a/x/bor/failover/health_test.go
+++ b/x/bor/failover/health_test.go
@@ -41,6 +41,12 @@ func TestNew_PrimaryValidatedFallbacksNot(t *testing.T) {
 	require.Empty(t, h.Candidates(0))
 }
 
+func TestNew_RejectsZeroEndpoints(t *testing.T) {
+	require.PanicsWithValue(t, "bor failover: endpoint count must be positive", func() {
+		New(0, nopProbe, Metrics{}, log.NewNopLogger())
+	})
+}
+
 func TestCall_PassthroughWhenActiveHealthy(t *testing.T) {
 	h := newTestHealth(t, 2)
 	var calls int

--- a/x/bor/failover/health_test.go
+++ b/x/bor/failover/health_test.go
@@ -86,6 +86,23 @@ func TestCall_CascadesToValidatedFallback(t *testing.T) {
 	require.Equal(t, 1, h.Active())
 }
 
+func TestCall_SkipsCandidateDemotedBeforePromotion(t *testing.T) {
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		if i == 0 {
+			return 0, errBoom
+		}
+		h.Reclaim(0) // simulates the prober reclaiming while this attempt is in flight
+		return okFn(i)
+	}, always)
+
+	require.ErrorIs(t, err, errBoom)
+	require.Equal(t, 0, h.Active())
+	require.Empty(t, h.Candidates(0))
+}
+
 func TestCall_DoesNotCascadeToUnvalidatedFallback(t *testing.T) {
 	h := newTestHealth(t, 2) // secondary never validated (e.g., wrong network)
 	var tried []int

--- a/x/bor/failover/health_test.go
+++ b/x/bor/failover/health_test.go
@@ -1,0 +1,277 @@
+package failover
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+)
+
+var errBoom = errors.New("boom")
+
+func always(error) bool { return true }
+
+func nopProbe(int) error { return nil }
+
+func newTestHealth(t *testing.T, n int) *Health {
+	t.Helper()
+	h := New(n, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(5*time.Millisecond, 1, 10*time.Millisecond, 50*time.Millisecond)
+	return h
+}
+
+// validate marks endpoints validated+healthy, as a successful identity probe
+// would. With the test threshold of 1, a single applied probe suffices.
+func validate(h *Health, idxs ...int) {
+	for _, i := range idxs {
+		h.applyProbe(i, nil)
+	}
+}
+
+func okFn(i int) (int, error) { return i, nil }
+
+func TestNew_PrimaryValidatedFallbacksNot(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	require.Equal(t, 0, h.Active())
+	// Only the primary is trusted at boot, so no fallback is a candidate yet.
+	require.Empty(t, h.Candidates(0))
+}
+
+func TestCall_PassthroughWhenActiveHealthy(t *testing.T) {
+	h := newTestHealth(t, 2)
+	var calls int
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		calls++
+		return okFn(i)
+	}, always)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls) // only the primary is called
+	require.Equal(t, 0, h.Active())
+}
+
+func TestCall_CascadesToValidatedFallback(t *testing.T) {
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	res, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		if i == 0 {
+			return 0, errBoom
+		}
+		return okFn(i)
+	}, always)
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
+	require.Equal(t, 1, h.Active())
+}
+
+func TestCall_DoesNotCascadeToUnvalidatedFallback(t *testing.T) {
+	h := newTestHealth(t, 2) // secondary never validated (e.g., wrong network)
+	var tried []int
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		tried = append(tried, i)
+		return 0, errBoom
+	}, always)
+	require.ErrorIs(t, err, errBoom)
+	require.Equal(t, []int{0}, tried) // unvalidated secondary is never used
+}
+
+func TestCall_NoCascadeOnNonRetriableError(t *testing.T) {
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	var tried []int
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		tried = append(tried, i)
+		return 0, errBoom
+	}, func(error) bool { return false })
+	require.ErrorIs(t, err, errBoom)
+	require.Equal(t, []int{0}, tried)
+	require.Equal(t, 0, h.Active())
+}
+
+func TestCall_StopsOnNonRetriableMidCascade(t *testing.T) {
+	errRetry := errors.New("retry")
+	errStop := errors.New("stop")
+	pred := func(e error) bool { return errors.Is(e, errRetry) }
+
+	h := newTestHealth(t, 3)
+	validate(h, 1, 2)
+	var tried []int
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		tried = append(tried, i)
+		switch i {
+		case 0:
+			return 0, errRetry // retriable → cascade
+		case 1:
+			return 0, errStop // non-retriable → stop here
+		default:
+			return i, nil
+		}
+	}, pred)
+	require.ErrorIs(t, err, errStop)
+	require.Equal(t, []int{0, 1}, tried) // the third endpoint is never reached
+}
+
+func TestCall_AllDownReturnsLastError(t *testing.T) {
+	h := newTestHealth(t, 3)
+	validate(h, 1, 2)
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, _ int) (int, error) {
+		return 0, errBoom
+	}, always)
+	require.ErrorIs(t, err, errBoom)
+}
+
+func TestCall_PerAttemptTimeoutCascades(t *testing.T) {
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	res, err := Call(h, context.Background(), 20*time.Millisecond,
+		func(ctx context.Context, i int) (int, error) {
+			if i == 0 {
+				<-ctx.Done() // primary hangs until the per-attempt timeout fires
+				return 0, ctx.Err()
+			}
+			return okFn(i)
+		},
+		func(e error) bool { return errors.Is(e, context.DeadlineExceeded) })
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
+	require.Equal(t, 1, h.Active())
+}
+
+func TestCall_CascadesWhenParentBudgetExceedsAttempt(t *testing.T) {
+	// Production shape: the caller budgets attemptTimeout per endpoint, so a hung
+	// primary times out at one attempt budget while the parent context (sized for
+	// the whole cascade) is still alive to reach a fallback.
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	attempt := 30 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 3*attempt)
+	defer cancel()
+
+	res, err := Call(h, ctx, attempt, func(actx context.Context, i int) (int, error) {
+		if i == 0 {
+			<-actx.Done() // primary hangs for its whole attempt budget
+			return 0, actx.Err()
+		}
+		return okFn(i)
+	}, func(e error) bool { return errors.Is(e, context.DeadlineExceeded) })
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
+	require.Equal(t, 1, h.Active())
+}
+
+func TestCall_NoCascadeWhenBudgetIsSingleAttempt(t *testing.T) {
+	// If the caller budgets only one attemptTimeout, a hung primary consumes the
+	// whole budget and there is no room to try a fallback — the call fails
+	// deterministically (the background prober routes subsequent calls instead).
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	d := 30 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+
+	_, err := Call(h, ctx, d, func(actx context.Context, i int) (int, error) {
+		if i == 0 {
+			<-actx.Done()
+			return 0, actx.Err()
+		}
+		return okFn(i)
+	}, func(e error) bool { return errors.Is(e, context.DeadlineExceeded) })
+	require.Error(t, err)
+	require.Equal(t, 0, h.Active())
+}
+
+func TestCall_CancellationPropagatesToInFlightAttempt(t *testing.T) {
+	// An in-flight attempt must abort promptly when the caller cancels, well
+	// before the (here, very long) per-attempt timeout would fire.
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := Call(h, ctx, time.Hour, func(actx context.Context, _ int) (int, error) {
+		<-actx.Done() // would block for an hour if cancellation did not propagate
+		return 0, actx.Err()
+	}, func(e error) bool { return errors.Is(e, context.Canceled) })
+	require.Error(t, err)
+	require.Less(t, time.Since(start), time.Second) // returned promptly on cancel, not after an hour
+}
+
+func TestCall_StopsCascadeWhenParentCancelled(t *testing.T) {
+	h := newTestHealth(t, 2)
+	validate(h, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	var tried []int
+	_, err := Call(h, ctx, time.Second, func(_ context.Context, i int) (int, error) {
+		tried = append(tried, i)
+		cancel() // caller abandons the whole call during the first attempt
+		return 0, errBoom
+	}, always)
+	require.Error(t, err)
+	require.Equal(t, []int{0}, tried) // cancellation stops the cascade
+}
+
+func TestCandidates_OnlyHealthyInPriorityOrder(t *testing.T) {
+	h := New(4, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	validate(h, 1, 3) // index 1 and 3 validated+healthy; index 2 never probed
+	require.Equal(t, []int{1, 3}, h.Candidates(0))
+
+	h.MarkUnhealthy(1, errBoom)
+	require.Equal(t, []int{3}, h.Candidates(0)) // a down endpoint drops out
+}
+
+func TestCandidates_CooledBeforeUncooled(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 20*time.Millisecond, time.Second)
+	h.applyProbe(2, nil)              // index 2 healthy now
+	time.Sleep(30 * time.Millisecond) // index 2 becomes cooled
+	h.applyProbe(1, nil)              // index 1 healthy now (uncooled)
+	require.Equal(t, []int{2, 1}, h.Candidates(0))
+}
+
+func TestSetActive_NoOpWhenSameIndex(t *testing.T) {
+	var active int
+	m := Metrics{ActiveIndex: func(int) { active++ }}
+	h := New(2, nopProbe, m, log.NewNopLogger())
+	h.SetActive(0)
+	require.Zero(t, active)
+	h.SetActive(1)
+	require.Equal(t, 1, active)
+}
+
+func TestCall_ConcurrentWithProber(t *testing.T) {
+	h := newTestHealth(t, 3) // nopProbe validates all endpoints over time
+	h.Start()
+	defer h.Stop()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_, _ = Call(h, context.Background(), 50*time.Millisecond, func(_ context.Context, idx int) (int, error) {
+					if idx == 0 {
+						return 0, errBoom
+					}
+					return okFn(idx)
+				}, always)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDefaults(t *testing.T) {
+	require.Equal(t, 10*time.Second, DefaultCheckInterval)
+	require.Equal(t, 3, DefaultConsecutiveThreshold)
+	require.Equal(t, 60*time.Second, DefaultPromotionCooldown)
+	require.Equal(t, 3*time.Second, DefaultProbeTimeout)
+}

--- a/x/bor/failover/health_test.go
+++ b/x/bor/failover/health_test.go
@@ -59,6 +59,19 @@ func TestCall_PassthroughWhenActiveHealthy(t *testing.T) {
 	require.Equal(t, 0, h.Active())
 }
 
+func TestCall_MarksActiveSuccess(t *testing.T) {
+	h := newTestHealth(t, 2)
+	h.MarkUnhealthy(0, errBoom)
+
+	res, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		return okFn(i)
+	}, always)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, res)
+	require.Equal(t, []int{0}, h.Candidates(1))
+}
+
 func TestCall_CascadesToValidatedFallback(t *testing.T) {
 	h := newTestHealth(t, 2)
 	validate(h, 1)

--- a/x/bor/failover/prober.go
+++ b/x/bor/failover/prober.go
@@ -1,0 +1,157 @@
+package failover
+
+import (
+	"sync"
+	"time"
+)
+
+// Start launches the background prober. It is a no-op for single-endpoint
+// setups (nothing to fail over to) and starts at most once.
+func (h *Health) Start() {
+	if h.n <= 1 {
+		return
+	}
+	h.startOnce.Do(func() { go h.run() })
+}
+
+// Stop terminates the background prober and waits for it to exit. Safe to call
+// even if Start was never run.
+func (h *Health) Stop() {
+	if h.n <= 1 {
+		return
+	}
+	// If Start never ran, close done here so the wait below doesn't block (and
+	// consume startOnce so a later Start can't spawn run()).
+	h.startOnce.Do(func() { close(h.done) })
+	h.stopOnce.Do(func() { close(h.quit) })
+	<-h.done
+}
+
+// run probes every endpoint on a ticker, reverting to a recovered
+// higher-priority endpoint and switching away from an unhealthy active one.
+func (h *Health) run() {
+	defer close(h.done)
+
+	h.cycle() // immediate cycle so a primary that is down at boot is caught quickly
+
+	ticker := time.NewTicker(h.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-h.quit:
+			return
+		case <-ticker.C:
+			h.cycle()
+		}
+	}
+}
+
+func (h *Health) cycle() {
+	h.probeAll()
+	h.maybePromote()
+	h.maybeProactiveSwitch()
+}
+
+// probeAll probes every endpoint concurrently and applies each result as it
+// completes, so a request arriving mid-cycle sees fresh data for finished
+// probes rather than stale data for all of them.
+func (h *Health) probeAll() {
+	var wg sync.WaitGroup
+	wg.Add(h.n)
+	for i := 0; i < h.n; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			h.applyProbe(idx, h.probe(idx))
+		}(i)
+	}
+	wg.Wait()
+
+	h.metric.onHealthyCount(h.healthyCount())
+}
+
+func (h *Health) applyProbe(i int, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err != nil {
+		h.health[i].healthy = false
+		h.health[i].consecutiveSuccess = 0
+		h.health[i].lastErr = err
+		return
+	}
+	// A nil probe error means the endpoint answered and matched the expected
+	// chain identity; markSuccessLocked promotes it toward healthy so it becomes
+	// a failover candidate.
+	h.markSuccessLocked(i)
+}
+
+func (h *Health) healthyCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	c := 0
+	for i := 0; i < h.n; i++ {
+		if h.health[i].healthy {
+			c++
+		}
+	}
+	return c
+}
+
+// maybePromote reverts to the highest-priority endpoint above the active one
+// that is healthy and has passed the promotion cooldown.
+func (h *Health) maybePromote() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.active == 0 {
+		return
+	}
+	for i := 0; i < h.active; i++ {
+		if h.health[i].healthy && time.Since(h.health[i].healthySince) >= h.promotionCooldown {
+			h.promoteLocked(i, "revert to higher-priority bor endpoint")
+			return
+		}
+	}
+}
+
+// maybeProactiveSwitch moves off an unhealthy active endpoint to the best
+// healthy alternative before a request has to discover the failure in-call.
+func (h *Health) maybeProactiveSwitch() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.health[h.active].healthy {
+		return
+	}
+	if i, ok := h.bestHealthyLocked(); ok {
+		h.promoteLocked(i, "switch away from unhealthy active bor endpoint")
+	}
+}
+
+// bestHealthyLocked returns the highest-priority healthy endpoint other than
+// the active one, preferring a cooled endpoint but falling back to an uncooled
+// one in an emergency.
+func (h *Health) bestHealthyLocked() (int, bool) {
+	uncooled := -1
+	for i := 0; i < h.n; i++ {
+		if i == h.active || !h.health[i].healthy {
+			continue
+		}
+		if time.Since(h.health[i].healthySince) >= h.promotionCooldown {
+			return i, true
+		}
+		if uncooled == -1 {
+			uncooled = i
+		}
+	}
+	if uncooled != -1 {
+		return uncooled, true
+	}
+	return 0, false
+}
+
+func (h *Health) promoteLocked(i int, msg string) {
+	prev := h.active
+	h.active = i
+	h.metric.onActiveIndex(i)
+	h.metric.onProactiveSwitch()
+	h.logger.Info("bor failover: "+msg, "from", prev, "to", i)
+}

--- a/x/bor/failover/transitions_test.go
+++ b/x/bor/failover/transitions_test.go
@@ -63,6 +63,19 @@ func TestMarkSuccess_ThresholdBoundary(t *testing.T) {
 	require.Equal(t, []int{1, 2}, h.Candidates(0))
 }
 
+func TestMarkSuccess_SaturatesAtThreshold(t *testing.T) {
+	h := New(2, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 2, 0, time.Second) // threshold 2
+
+	for range 5 {
+		h.MarkSuccess(1)
+	}
+
+	require.True(t, h.health[1].healthy)
+	require.Equal(t, h.consecutiveThreshold, h.health[1].consecutiveSuccess,
+		"counter must saturate at the threshold rather than grow unbounded")
+}
+
 func TestMaybePromote_RevertsToHigherPriority(t *testing.T) {
 	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
 	h.SetTuning(time.Second, 1, 0, time.Second)

--- a/x/bor/failover/transitions_test.go
+++ b/x/bor/failover/transitions_test.go
@@ -190,6 +190,20 @@ func TestProber_ContinuesProbingOnTicker(t *testing.T) {
 	}
 }
 
+func TestStart_ProbesOnEveryInterval(t *testing.T) {
+	var probes atomic.Int64
+	h := newTestHealthWithProbe(t, 2, func(int) error {
+		probes.Add(1)
+		return nil
+	})
+	h.Start()
+	defer h.Stop()
+
+	require.Eventually(t, func() bool {
+		return probes.Load() >= int64(2*h.n)
+	}, time.Second, 5*time.Millisecond)
+}
+
 func TestReclaim_AdoptsPrimaryAndDemotesOthers(t *testing.T) {
 	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
 	h.SetTuning(time.Second, 1, 0, time.Second) // threshold 1, cooldown 0

--- a/x/bor/failover/transitions_test.go
+++ b/x/bor/failover/transitions_test.go
@@ -1,0 +1,230 @@
+package failover
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrimaryStartsHealthy(t *testing.T) {
+	h := New(2, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetActive(1)
+	// Primary (0) is validated+healthy with a zero healthySince, so it is cooled
+	// and maybePromote must revert to it.
+	h.maybePromote()
+	require.Equal(t, 0, h.Active())
+}
+
+func TestProbe_WrongNetworkNeverValidated(t *testing.T) {
+	probe := func(i int) error {
+		if i == 1 {
+			return errBoom // wrong network / unreachable
+		}
+		return nil
+	}
+	h := New(2, probe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+
+	h.probeAll()
+	require.Empty(t, h.Candidates(0)) // never validated → never a failover candidate
+}
+
+func TestProbeAll_ValidatesAndCounts(t *testing.T) {
+	var lastHealthy atomic.Int64
+	m := Metrics{HealthyCount: func(c int) { lastHealthy.Store(int64(c)) }}
+	probe := func(i int) error {
+		if i == 1 {
+			return errBoom
+		}
+		return nil
+	}
+	h := New(3, probe, m, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+
+	h.probeAll()
+	require.Equal(t, int64(2), lastHealthy.Load()) // index 0 and 2 up, index 1 down
+	require.Equal(t, []int{2}, h.Candidates(0))    // only validated+up fallback
+}
+
+func TestMarkSuccess_ThresholdBoundary(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 2, 0, time.Second) // threshold 2, cooldown 0
+
+	h.applyProbe(2, nil)
+	h.applyProbe(2, nil) // index 2 healthy+cooled after 2 successes
+	h.applyProbe(1, nil) // index 1 one success → below threshold, not yet healthy
+	require.Equal(t, []int{2}, h.Candidates(0))
+
+	h.applyProbe(1, nil) // index 1 crosses threshold → healthy+cooled
+	require.Equal(t, []int{1, 2}, h.Candidates(0))
+}
+
+func TestMaybePromote_RevertsToHigherPriority(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	h.SetActive(2)
+	h.MarkUnhealthy(0, errBoom) // primary down, so index 1 is the best higher-priority target
+	h.applyProbe(1, nil)        // index 1 validated + healthy
+	h.maybePromote()
+	require.Equal(t, 1, h.Active())
+}
+
+func TestMaybeProactiveSwitch_MovesOffUnhealthyActive(t *testing.T) {
+	h := New(2, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	h.MarkUnhealthy(0, errBoom)
+	h.applyProbe(1, nil) // index 1 validated + healthy
+	h.maybeProactiveSwitch()
+	require.Equal(t, 1, h.Active())
+}
+
+func TestMaybeProactiveSwitch_StaysWhenNoAlternative(t *testing.T) {
+	var prosw atomic.Int64
+	m := Metrics{ProactiveSwitch: func() { prosw.Add(1) }}
+	h := New(2, nopProbe, m, log.NewNopLogger())
+	h.MarkUnhealthy(0, errBoom) // active down; index 1 never validated
+	h.maybeProactiveSwitch()
+	require.Equal(t, 0, h.Active())
+	require.Zero(t, prosw.Load())
+}
+
+func TestMaybeProactiveSwitch_NoSwitchWhenActiveHealthy(t *testing.T) {
+	h := New(2, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	h.applyProbe(1, nil) // a healthy alternative exists, but active (0) is healthy
+	h.maybeProactiveSwitch()
+	require.Equal(t, 0, h.Active())
+}
+
+func TestBestHealthy_PrefersCooled(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 20*time.Millisecond, time.Second)
+	h.MarkUnhealthy(0, errBoom)       // active down
+	h.applyProbe(2, nil)              // index 2 healthy now
+	time.Sleep(30 * time.Millisecond) // index 2 becomes cooled
+	h.applyProbe(1, nil)              // index 1 healthy now (uncooled)
+	h.maybeProactiveSwitch()
+	require.Equal(t, 2, h.Active()) // prefers the cooled endpoint over the uncooled one
+}
+
+func TestMaybeProactiveSwitch_UncooledEmergencyFallback(t *testing.T) {
+	h := New(2, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, time.Minute, time.Second) // long cooldown → stays uncooled
+	h.MarkUnhealthy(0, errBoom)
+	h.applyProbe(1, nil) // validated + healthy but not cooled
+	h.maybeProactiveSwitch()
+	require.Equal(t, 1, h.Active()) // still switches in the emergency (uncooled) pass
+}
+
+func TestMetricsHooksFire(t *testing.T) {
+	var sw, prosw, active, healthy atomic.Int64
+	m := Metrics{
+		Switch:          func() { sw.Add(1) },
+		ProactiveSwitch: func() { prosw.Add(1) },
+		ActiveIndex:     func(int) { active.Add(1) },
+		HealthyCount:    func(int) { healthy.Add(1) },
+	}
+	h := New(2, nopProbe, m, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	validate(h, 1)
+
+	_, err := Call(h, context.Background(), time.Second, func(_ context.Context, i int) (int, error) {
+		if i == 0 {
+			return 0, errBoom
+		}
+		return okFn(i)
+	}, always)
+	require.NoError(t, err)
+	require.Positive(t, sw.Load())
+	require.Positive(t, active.Load())
+
+	h.probeAll()
+	require.Positive(t, healthy.Load())
+
+	h.maybePromote()
+	require.Positive(t, prosw.Load())
+	require.Equal(t, 0, h.Active())
+}
+
+func TestProber_ProactiveSwitchThenRevert(t *testing.T) {
+	var primaryUp atomic.Bool
+	probe := func(i int) error {
+		if i == 0 && !primaryUp.Load() {
+			return errBoom
+		}
+		return nil
+	}
+	h := newTestHealthWithProbe(t, 2, probe)
+	h.Start()
+	defer h.Stop()
+
+	require.Eventually(t, func() bool { return h.Active() == 1 }, 2*time.Second, 5*time.Millisecond,
+		"should proactively switch off the down primary")
+
+	primaryUp.Store(true)
+	require.Eventually(t, func() bool { return h.Active() == 0 }, 2*time.Second, 5*time.Millisecond,
+		"should revert to the recovered primary after cooldown")
+}
+
+func TestProber_ContinuesProbingOnTicker(t *testing.T) {
+	probed := make(chan int, 8)
+	h := newTestHealthWithProbe(t, 2, func(i int) error {
+		probed <- i
+		return nil
+	})
+	go h.run()
+	defer func() {
+		close(h.quit)
+		<-h.done
+	}()
+
+	for range h.n {
+		requireProbe(t, probed)
+	}
+	for range h.n {
+		requireProbe(t, probed)
+	}
+}
+
+func TestReclaim_AdoptsPrimaryAndDemotesOthers(t *testing.T) {
+	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second) // threshold 1, cooldown 0
+	h.MarkUnhealthy(0, errBoom)                 // primary was down during the outage
+	h.applyProbe(1, nil)                        // a fallback validated (against a provisional identity) and is healthy
+	h.SetActive(1)
+	require.Equal(t, []int{1}, h.Candidates(0)) // the stale fallback is an eligible in-call candidate
+
+	h.Reclaim(0)
+	require.Equal(t, 0, h.Active())   // primary adopted as active at once, without the threshold
+	require.Empty(t, h.Candidates(0)) // every other endpoint demoted → must re-validate before reuse
+}
+
+func TestStart_NoOpForSingleEndpoint(t *testing.T) {
+	var probed atomic.Int64
+	h := New(1, func(int) error { probed.Add(1); return nil }, Metrics{}, log.NewNopLogger())
+	h.Start()
+	time.Sleep(50 * time.Millisecond) // a (wrongly) spawned prober would probe within this window
+	got := probed.Load()
+	h.Stop()
+	require.Zero(t, got)
+}
+
+func newTestHealthWithProbe(t *testing.T, n int, probe func(int) error) *Health {
+	t.Helper()
+	h := New(n, probe, Metrics{}, log.NewNopLogger())
+	h.SetTuning(5*time.Millisecond, 1, 10*time.Millisecond, 50*time.Millisecond)
+	return h
+}
+
+func requireProbe(t *testing.T, probed <-chan int) {
+	t.Helper()
+	select {
+	case <-probed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for probe")
+	}
+}

--- a/x/bor/failover/transitions_test.go
+++ b/x/bor/failover/transitions_test.go
@@ -205,7 +205,8 @@ func TestStart_ProbesOnEveryInterval(t *testing.T) {
 }
 
 func TestReclaim_AdoptsPrimaryAndDemotesOthers(t *testing.T) {
-	h := New(3, nopProbe, Metrics{}, log.NewNopLogger())
+	var prosw atomic.Int64
+	h := New(3, nopProbe, Metrics{ProactiveSwitch: func() { prosw.Add(1) }}, log.NewNopLogger())
 	h.SetTuning(time.Second, 1, 0, time.Second) // threshold 1, cooldown 0
 	h.MarkUnhealthy(0, errBoom)                 // primary was down during the outage
 	h.applyProbe(1, nil)                        // a fallback validated (against a provisional identity) and is healthy
@@ -213,8 +214,12 @@ func TestReclaim_AdoptsPrimaryAndDemotesOthers(t *testing.T) {
 	require.Equal(t, []int{1}, h.Candidates(0)) // the stale fallback is an eligible in-call candidate
 
 	h.Reclaim(0)
-	require.Equal(t, 0, h.Active())   // primary adopted as active at once, without the threshold
+	require.Equal(t, 0, h.Active()) // primary adopted as active at once, without the threshold
+	require.Equal(t, int64(1), prosw.Load())
 	require.Empty(t, h.Candidates(0)) // every other endpoint demoted → must re-validate before reuse
+
+	h.Reclaim(0)
+	require.Equal(t, int64(1), prosw.Load()) // no duplicate switch metric when already active
 }
 
 func TestStart_NoOpForSingleEndpoint(t *testing.T) {

--- a/x/bor/failover/transitions_test.go
+++ b/x/bor/failover/transitions_test.go
@@ -222,6 +222,22 @@ func TestReclaim_AdoptsPrimaryAndDemotesOthers(t *testing.T) {
 	require.Equal(t, int64(1), prosw.Load()) // no duplicate switch metric when already active
 }
 
+func TestPromote_RefusesDemotedCandidate(t *testing.T) {
+	var sw atomic.Int64
+	h := New(2, nopProbe, Metrics{Switch: func() { sw.Add(1) }}, log.NewNopLogger())
+	h.SetTuning(time.Second, 1, 0, time.Second)
+	h.applyProbe(1, nil)
+
+	require.True(t, h.Promote(0, 1))
+	require.Equal(t, 1, h.Active())
+	require.Equal(t, int64(1), sw.Load())
+
+	h.Reclaim(0)
+	require.False(t, h.Promote(0, 1))
+	require.Equal(t, 0, h.Active())
+	require.Equal(t, int64(1), sw.Load())
+}
+
 func TestStart_NoOpForSingleEndpoint(t *testing.T) {
 	var probed atomic.Int64
 	h := New(1, func(int) error { probed.Add(1); return nil }, Metrics{}, log.NewNopLogger())

--- a/x/bor/grpc/failover.go
+++ b/x/bor/grpc/failover.go
@@ -44,6 +44,16 @@ type Client interface {
 	Close(logger log.Logger)
 }
 
+// EndpointHeaderFetcher is the per-endpoint header API used by validation
+// hooks. *BorGRPCClient satisfies it; tests can inject small stubs.
+type EndpointHeaderFetcher interface {
+	HeaderByNumber(ctx context.Context, blockID int64) (*ethTypes.Header, error)
+}
+
+// EndpointValidator is an optional probe-time validation hook. Returning an
+// error keeps the endpoint out of the healthy candidate set.
+type EndpointValidator func(context.Context, int, EndpointHeaderFetcher) error
+
 var (
 	_ Client = (*BorGRPCClient)(nil)
 	_ Client = (*MultiBorGRPCClient)(nil)
@@ -60,15 +70,16 @@ type MultiBorGRPCClient struct {
 	expectedGenesis      atomic.Pointer[common.Hash]
 	expectedByPrimary    atomic.Bool
 	primaryProbeFailures atomic.Int32
+	validators           []EndpointValidator
 }
 
 // NewMultiBorGRPCClient wraps already-dialed, priority-ordered clients with
 // failover and starts the background prober.
-func NewMultiBorGRPCClient(clients []*BorGRPCClient, logger log.Logger, m failover.Metrics, attemptTimeout time.Duration) *MultiBorGRPCClient {
+func NewMultiBorGRPCClient(clients []*BorGRPCClient, logger log.Logger, m failover.Metrics, attemptTimeout time.Duration, validators ...EndpointValidator) *MultiBorGRPCClient {
 	if len(clients) < 1 {
 		panic("bor failover: endpoint count must be positive")
 	}
-	mc := &MultiBorGRPCClient{clients: clients, attemptTimeout: attemptTimeout}
+	mc := &MultiBorGRPCClient{clients: clients, attemptTimeout: attemptTimeout, validators: validators}
 	mc.captureExpectedGenesis()
 	mc.health = failover.New(len(clients), mc.probe, m, logger)
 	mc.health.Start()
@@ -88,19 +99,19 @@ func (mc *MultiBorGRPCClient) probe(i int) error {
 		err = fmt.Errorf("bor gRPC endpoint %d returned nil genesis header", i)
 	}
 	if err != nil {
-		if i == primaryGRPCEndpoint {
-			mc.primaryProbeFailures.Add(1)
-		}
+		mc.recordProbeFailure(i)
 		return err
-	}
-	if i == primaryGRPCEndpoint {
-		mc.primaryProbeFailures.Store(0)
 	}
 
 	reclaiming := i == primaryGRPCEndpoint && !mc.expectedByPrimary.Load()
 	if err := mc.checkGenesis(i, h.Hash()); err != nil {
 		return err
 	}
+	if err := mc.validateEndpoint(ctx, i); err != nil {
+		mc.recordProbeFailure(i)
+		return err
+	}
+	mc.recordProbeSuccess(i)
 	if reclaiming {
 		// The authoritative primary just (re)established the identity; if a stale
 		// fallback was the active endpoint during the outage it may be serving
@@ -111,6 +122,30 @@ func (mc *MultiBorGRPCClient) probe(i int) error {
 		mc.health.Reclaim(primaryGRPCEndpoint)
 	}
 
+	return nil
+}
+
+func (mc *MultiBorGRPCClient) recordProbeFailure(i int) {
+	if i == primaryGRPCEndpoint {
+		mc.primaryProbeFailures.Add(1)
+	}
+}
+
+func (mc *MultiBorGRPCClient) recordProbeSuccess(i int) {
+	if i == primaryGRPCEndpoint {
+		mc.primaryProbeFailures.Store(0)
+	}
+}
+
+func (mc *MultiBorGRPCClient) validateEndpoint(ctx context.Context, i int) error {
+	for _, validate := range mc.validators {
+		if validate == nil {
+			continue
+		}
+		if err := validate(ctx, i, mc.clients[i]); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/x/bor/grpc/failover.go
+++ b/x/bor/grpc/failover.go
@@ -1,0 +1,268 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+const (
+	primaryGRPCEndpoint = 0
+	genesisBlock        = int64(0)
+
+	// primaryAnchorFailureThreshold mirrors the HTTP transport: a fallback may
+	// provisionally establish the expected genesis only after the primary has
+	// failed this many consecutive probes. The primary stays authoritative and
+	// reclaims the expectation once reachable (see checkGenesis), so this only
+	// lets failover engage during a window where the primary is unreachable.
+	primaryAnchorFailureThreshold = 2
+)
+
+// Client is the behavior shared by the single-endpoint *BorGRPCClient and the
+// failover *MultiBorGRPCClient, so helper code can hold either transparently.
+type Client interface {
+	GetRootHash(ctx context.Context, startBlock, endBlock uint64) (string, error)
+	GetVoteOnHash(ctx context.Context, startBlock, endBlock uint64, rootHash, milestoneId string) (bool, error)
+	HeaderByNumber(ctx context.Context, blockID int64) (*ethTypes.Header, error)
+	BlockByNumber(ctx context.Context, blockID int64) (*ethTypes.Block, error)
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error)
+	BorBlockReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error)
+	GetAuthor(ctx context.Context, blockNum *big.Int) (*common.Address, error)
+	GetTdByHash(ctx context.Context, hash common.Hash) (uint64, error)
+	GetTdByNumber(ctx context.Context, blockNum *big.Int) (uint64, error)
+	GetBlockInfoInBatch(ctx context.Context, start, end int64) ([]*ethTypes.Header, []uint64, []common.Address, error)
+	Close(logger log.Logger)
+}
+
+var (
+	_ Client = (*BorGRPCClient)(nil)
+	_ Client = (*MultiBorGRPCClient)(nil)
+)
+
+// MultiBorGRPCClient wraps N priority-ordered Bor gRPC clients (index 0 =
+// primary) and fails over to the next validated one on a transport error or a
+// per-attempt timeout. A background prober reverts to a higher-priority
+// endpoint once it recovers. It shares the failover core with the HTTP path.
+type MultiBorGRPCClient struct {
+	clients              []*BorGRPCClient
+	health               *failover.Health
+	attemptTimeout       time.Duration
+	expectedGenesis      atomic.Pointer[common.Hash]
+	expectedByPrimary    atomic.Bool
+	primaryProbeFailures atomic.Int32
+}
+
+// NewMultiBorGRPCClient wraps already-dialed, priority-ordered clients with
+// failover and starts the background prober.
+func NewMultiBorGRPCClient(clients []*BorGRPCClient, logger log.Logger, m failover.Metrics, attemptTimeout time.Duration) *MultiBorGRPCClient {
+	mc := &MultiBorGRPCClient{clients: clients, attemptTimeout: attemptTimeout}
+	mc.captureExpectedGenesis()
+	mc.health = failover.New(len(clients), mc.probe, m, logger)
+	mc.health.Start()
+	return mc
+}
+
+// probe validates endpoint i for the background prober: it must return the
+// genesis header whose hash matches the expected one before it is treated as a
+// healthy fallback. The gRPC API has no chain-id call, so the genesis hash is
+// the chain-identity anchor.
+func (mc *MultiBorGRPCClient) probe(i int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), mc.health.ProbeTimeout())
+	defer cancel()
+
+	h, err := mc.clients[i].HeaderByNumber(ctx, genesisBlock)
+	if err == nil && h == nil {
+		err = fmt.Errorf("bor gRPC endpoint %d returned nil genesis header", i)
+	}
+	if err != nil {
+		if i == primaryGRPCEndpoint {
+			mc.primaryProbeFailures.Add(1)
+		}
+		return err
+	}
+	if i == primaryGRPCEndpoint {
+		mc.primaryProbeFailures.Store(0)
+	}
+
+	reclaiming := i == primaryGRPCEndpoint && !mc.expectedByPrimary.Load()
+	if err := mc.checkGenesis(i, h.Hash()); err != nil {
+		return err
+	}
+	if reclaiming {
+		// The authoritative primary just (re)established the identity; if a stale
+		// fallback was the active endpoint during the outage it may be serving
+		// wrong-network data, so move traffic back to the primary at once instead
+		// of waiting out the promotion threshold. Reclaim also demotes the other
+		// endpoints so a fallback validated against the provisional identity can't
+		// remain an in-call candidate until re-validated.
+		mc.health.Reclaim(primaryGRPCEndpoint)
+	}
+
+	return nil
+}
+
+// checkGenesis compares endpoint i's genesis hash against the expected one. The
+// primary is authoritative: whenever it answers it (re)establishes the
+// expectation, reclaiming a provisional one a fallback set while the primary was
+// unreachable — so the real primary is never rejected. A fallback may
+// provisionally anchor only after the primary has been unreachable for
+// primaryAnchorFailureThreshold probes (see canAnchor); every endpoint that does
+// not anchor must match the current expectation.
+func (mc *MultiBorGRPCClient) checkGenesis(i int, got common.Hash) error {
+	if i == primaryGRPCEndpoint && !mc.expectedByPrimary.Load() {
+		mc.expectedGenesis.Store(&got)
+		mc.expectedByPrimary.Store(true)
+		return nil
+	}
+
+	expected := mc.expectedGenesis.Load()
+	if expected == nil {
+		if !mc.canAnchor(i) {
+			return fmt.Errorf("bor gRPC endpoint %d: expected genesis not yet known", i)
+		}
+		if mc.expectedGenesis.CompareAndSwap(nil, &got) {
+			return nil
+		}
+		expected = mc.expectedGenesis.Load() // lost the race; compare against the winner
+	}
+
+	if *expected != got {
+		return fmt.Errorf("bor gRPC endpoint %d genesis %s != expected %s", i, got.Hex(), expected.Hex())
+	}
+
+	return nil
+}
+
+// canAnchor reports whether a fallback may provisionally establish the expected
+// genesis: only after the primary has failed primaryAnchorFailureThreshold
+// consecutive probes, so failover still engages when the primary is never
+// reachable at boot. The primary itself anchors via checkGenesis's reclaim path.
+func (mc *MultiBorGRPCClient) canAnchor(i int) bool {
+	return i == primaryGRPCEndpoint || mc.primaryProbeFailures.Load() >= primaryAnchorFailureThreshold
+}
+
+// captureExpectedGenesis best-effort records the primary's genesis hash at
+// startup so fallbacks can be validated before the first request.
+func (mc *MultiBorGRPCClient) captureExpectedGenesis() {
+	ctx, cancel := context.WithTimeout(context.Background(), mc.attemptTimeout)
+	defer cancel()
+
+	h, err := mc.clients[primaryGRPCEndpoint].HeaderByNumber(ctx, genesisBlock)
+	if err == nil && h != nil {
+		got := h.Hash()
+		if mc.expectedGenesis.CompareAndSwap(nil, &got) {
+			mc.expectedByPrimary.Store(true)
+		}
+	}
+}
+
+// retriable reports whether err warrants failover: transport-level gRPC codes
+// (including a per-attempt deadline) only. Logical conditions surface as
+// ethereum.NotFound or validation errors (code Unknown) and are not retried.
+func retriable(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mc *MultiBorGRPCClient) GetRootHash(ctx context.Context, startBlock, endBlock uint64) (string, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (string, error) {
+			return mc.clients[i].GetRootHash(ctx, startBlock, endBlock)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) GetVoteOnHash(ctx context.Context, startBlock, endBlock uint64, rootHash, milestoneId string) (bool, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (bool, error) {
+			return mc.clients[i].GetVoteOnHash(ctx, startBlock, endBlock, rootHash, milestoneId)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) HeaderByNumber(ctx context.Context, blockID int64) (*ethTypes.Header, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (*ethTypes.Header, error) {
+			return mc.clients[i].HeaderByNumber(ctx, blockID)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) BlockByNumber(ctx context.Context, blockID int64) (*ethTypes.Block, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (*ethTypes.Block, error) {
+			return mc.clients[i].BlockByNumber(ctx, blockID)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (*ethTypes.Receipt, error) {
+			return mc.clients[i].TransactionReceipt(ctx, txHash)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) BorBlockReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (*ethTypes.Receipt, error) {
+			return mc.clients[i].BorBlockReceipt(ctx, txHash)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) GetAuthor(ctx context.Context, blockNum *big.Int) (*common.Address, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (*common.Address, error) {
+			return mc.clients[i].GetAuthor(ctx, blockNum)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) GetTdByHash(ctx context.Context, hash common.Hash) (uint64, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (uint64, error) {
+			return mc.clients[i].GetTdByHash(ctx, hash)
+		}, retriable)
+}
+
+func (mc *MultiBorGRPCClient) GetTdByNumber(ctx context.Context, blockNum *big.Int) (uint64, error) {
+	return failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (uint64, error) {
+			return mc.clients[i].GetTdByNumber(ctx, blockNum)
+		}, retriable)
+}
+
+// batchResult bundles GetBlockInfoInBatch's three result slices so the generic
+// failover.Call (single value + error) can carry them.
+type batchResult struct {
+	headers []*ethTypes.Header
+	tds     []uint64
+	authors []common.Address
+}
+
+func (mc *MultiBorGRPCClient) GetBlockInfoInBatch(ctx context.Context, start, end int64) ([]*ethTypes.Header, []uint64, []common.Address, error) {
+	res, err := failover.Call(mc.health, ctx, mc.attemptTimeout,
+		func(ctx context.Context, i int) (batchResult, error) {
+			h, td, a, e := mc.clients[i].GetBlockInfoInBatch(ctx, start, end)
+			return batchResult{headers: h, tds: td, authors: a}, e
+		}, retriable)
+
+	return res.headers, res.tds, res.authors, err
+}
+
+// Close stops the prober and closes every underlying client.
+func (mc *MultiBorGRPCClient) Close(logger log.Logger) {
+	mc.health.Stop()
+	for _, c := range mc.clients {
+		c.Close(logger)
+	}
+}

--- a/x/bor/grpc/failover.go
+++ b/x/bor/grpc/failover.go
@@ -65,6 +65,9 @@ type MultiBorGRPCClient struct {
 // NewMultiBorGRPCClient wraps already-dialed, priority-ordered clients with
 // failover and starts the background prober.
 func NewMultiBorGRPCClient(clients []*BorGRPCClient, logger log.Logger, m failover.Metrics, attemptTimeout time.Duration) *MultiBorGRPCClient {
+	if len(clients) < 1 {
+		panic("bor failover: endpoint count must be positive")
+	}
 	mc := &MultiBorGRPCClient{clients: clients, attemptTimeout: attemptTimeout}
 	mc.captureExpectedGenesis()
 	mc.health = failover.New(len(clients), mc.probe, m, logger)

--- a/x/bor/grpc/failover_test.go
+++ b/x/bor/grpc/failover_test.go
@@ -1,0 +1,234 @@
+package grpc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	proto "github.com/0xPolygon/polyproto/bor"
+
+	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
+)
+
+// newTestMulti builds a MultiBorGRPCClient over mock API clients without
+// starting the prober, so tests drive failover deterministically.
+func newTestMulti(clients ...*MockBorApiClient) *MultiBorGRPCClient {
+	bcs := make([]*BorGRPCClient, len(clients))
+	for i, c := range clients {
+		bcs[i] = &BorGRPCClient{client: c}
+	}
+	mc := &MultiBorGRPCClient{clients: bcs, attemptTimeout: time.Second}
+	mc.health = failover.New(len(bcs), mc.probe, failover.Metrics{}, log.NewNopLogger())
+	mc.health.SetTuning(5*time.Millisecond, 1, 0, 50*time.Millisecond)
+	return mc
+}
+
+func genesisResp(extra string) *proto.GetHeaderByNumberResponse {
+	return &proto.GetHeaderByNumberResponse{Header: &proto.Header{Number: 0, ExtraData: []byte(extra)}}
+}
+
+func TestMultiGRPC_CascadesOnUnavailable(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("GetRootHash", mock.Anything, mock.Anything).
+		Return((*proto.GetRootHashResponse)(nil), status.Error(codes.Unavailable, "down"))
+	m1 := new(MockBorApiClient)
+	m1.On("GetRootHash", mock.Anything, mock.Anything).
+		Return(&proto.GetRootHashResponse{RootHash: "0xabc"}, nil)
+
+	mc := newTestMulti(m0, m1)
+	mc.health.MarkSuccess(1) // secondary is a validated candidate
+
+	got, err := mc.GetRootHash(context.Background(), 1, 2)
+	require.NoError(t, err)
+	require.Equal(t, "0xabc", got)
+	require.Equal(t, 1, mc.health.Active())
+}
+
+func TestMultiGRPC_NoCascadeOnLogicalError(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("GetRootHash", mock.Anything, mock.Anything).
+		Return((*proto.GetRootHashResponse)(nil), status.Error(codes.InvalidArgument, "bad range"))
+	m1 := new(MockBorApiClient)
+
+	mc := newTestMulti(m0, m1)
+	mc.health.MarkSuccess(1)
+
+	_, err := mc.GetRootHash(context.Background(), 1, 2)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Equal(t, 0, mc.health.Active())
+	m1.AssertNotCalled(t, "GetRootHash", mock.Anything, mock.Anything)
+}
+
+func TestMultiGRPC_NoCascadeOnCallerCancel(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("GetRootHash", mock.Anything, mock.Anything).
+		Return((*proto.GetRootHashResponse)(nil), status.Error(codes.Unavailable, "down"))
+	m1 := new(MockBorApiClient)
+
+	mc := newTestMulti(m0, m1)
+	mc.health.MarkSuccess(1) // a candidate exists, yet cancellation must still stop the cascade
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := mc.GetRootHash(ctx, 1, 2)
+	require.Error(t, err)
+	require.Equal(t, 0, mc.health.Active())
+	m1.AssertNotCalled(t, "GetRootHash", mock.Anything, mock.Anything)
+}
+
+func TestMultiGRPC_PerAttemptTimeoutCascades(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("GetRootHash", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-args.Get(0).(context.Context).Done() // primary hangs until the attempt times out
+		}).
+		Return((*proto.GetRootHashResponse)(nil), status.Error(codes.DeadlineExceeded, "timeout"))
+	m1 := new(MockBorApiClient)
+	m1.On("GetRootHash", mock.Anything, mock.Anything).
+		Return(&proto.GetRootHashResponse{RootHash: "0xabc"}, nil)
+
+	mc := newTestMulti(m0, m1)
+	mc.attemptTimeout = 30 * time.Millisecond
+	mc.health.MarkSuccess(1)
+
+	got, err := mc.GetRootHash(context.Background(), 1, 2)
+	require.NoError(t, err)
+	require.Equal(t, "0xabc", got)
+	require.Equal(t, 1, mc.health.Active())
+}
+
+func TestMultiGRPC_BatchCascades(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("GetBlockInfoInBatch", mock.Anything, mock.Anything).
+		Return((*proto.GetBlockInfoInBatchResponse)(nil), status.Error(codes.Unavailable, "down"))
+	m1 := new(MockBorApiClient)
+	m1.On("GetBlockInfoInBatch", mock.Anything, mock.Anything).
+		Return(&proto.GetBlockInfoInBatchResponse{Blocks: nil}, nil)
+
+	mc := newTestMulti(m0, m1)
+	mc.health.MarkSuccess(1)
+
+	headers, tds, authors, err := mc.GetBlockInfoInBatch(context.Background(), 0, 0)
+	require.NoError(t, err)
+	require.Empty(t, headers)
+	require.Empty(t, tds)
+	require.Empty(t, authors)
+	require.Equal(t, 1, mc.health.Active())
+}
+
+func TestMultiGRPC_ProbeValidatesGenesis(t *testing.T) {
+	primary := new(MockBorApiClient)
+	primary.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("genesis-a"), nil)
+	match := new(MockBorApiClient)
+	match.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("genesis-a"), nil)
+	wrong := new(MockBorApiClient)
+	wrong.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("genesis-b"), nil)
+
+	mc := newTestMulti(primary, match, wrong)
+	require.NoError(t, mc.probe(0)) // primary establishes the expected genesis
+	require.NoError(t, mc.probe(1)) // same genesis → ok
+	require.Error(t, mc.probe(2))   // different genesis → rejected
+}
+
+func TestCheckGenesis(t *testing.T) {
+	mc := &MultiBorGRPCClient{}
+	a := common.HexToHash("0x0a")
+	b := common.HexToHash("0x0b")
+
+	require.Error(t, mc.checkGenesis(1, a))   // expected unknown + fallback → rejected
+	require.NoError(t, mc.checkGenesis(0, a)) // primary establishes the expectation
+	require.NoError(t, mc.checkGenesis(1, a)) // matches
+	require.Error(t, mc.checkGenesis(2, b))   // mismatch
+}
+
+func TestCheckGenesis_FallbackAnchorsWhenPrimaryUnreachable(t *testing.T) {
+	mc := &MultiBorGRPCClient{}
+	mc.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+	a := common.HexToHash("0x0a")
+	b := common.HexToHash("0x0b")
+
+	require.NoError(t, mc.checkGenesis(1, a)) // fallback provisionally establishes the expectation
+	require.NoError(t, mc.checkGenesis(2, a)) // another fallback on the same chain matches
+	require.Error(t, mc.checkGenesis(2, b))   // a mismatched endpoint is still rejected
+}
+
+func TestMultiGRPC_PrimaryReclaimAdoptsActive(t *testing.T) {
+	m0 := new(MockBorApiClient)
+	m0.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("primary"), nil)
+	m1 := new(MockBorApiClient)
+	m1.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("fallback"), nil)
+
+	mc := newTestMulti(m0, m1)
+	// Boot window: the primary was unreachable, so the fallback provisionally
+	// anchored its own genesis and became the active endpoint.
+	mc.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+	require.NoError(t, mc.probe(1))
+	mc.health.SetActive(1)
+	require.Equal(t, 1, mc.health.Active())
+
+	// The primary recovers: its probe reclaims identity and moves traffic back at once.
+	require.NoError(t, mc.probe(0))
+	require.Equal(t, 0, mc.health.Active())
+}
+
+func TestCheckGenesis_PrimaryReclaimsProvisionalAnchor(t *testing.T) {
+	mc := &MultiBorGRPCClient{}
+	mc.primaryProbeFailures.Store(primaryAnchorFailureThreshold)
+	a := common.HexToHash("0x0a")
+	b := common.HexToHash("0x0b")
+
+	require.NoError(t, mc.checkGenesis(1, a)) // fallback provisionally anchors a
+	require.NoError(t, mc.checkGenesis(0, b)) // primary reclaims with its own genesis, never rejected
+	require.Equal(t, b, *mc.expectedGenesis.Load())
+	require.Error(t, mc.checkGenesis(1, a)) // the stale provisional fallback now mismatches the primary
+}
+
+func TestCaptureExpectedGenesis(t *testing.T) {
+	up := new(MockBorApiClient)
+	up.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("g"), nil)
+	mc := &MultiBorGRPCClient{clients: []*BorGRPCClient{{client: up}}, attemptTimeout: time.Second}
+	mc.captureExpectedGenesis()
+	require.NotNil(t, mc.expectedGenesis.Load())
+
+	down := new(MockBorApiClient)
+	down.On("HeaderByNumber", mock.Anything, mock.Anything).
+		Return((*proto.GetHeaderByNumberResponse)(nil), status.Error(codes.Unavailable, "down"))
+	mc2 := &MultiBorGRPCClient{clients: []*BorGRPCClient{{client: down}}, attemptTimeout: time.Second}
+	mc2.captureExpectedGenesis()
+	require.Nil(t, mc2.expectedGenesis.Load()) // unreachable primary → nothing captured
+}
+
+func TestMultiGRPC_ProbeRejectsUnreachable(t *testing.T) {
+	down := new(MockBorApiClient)
+	down.On("HeaderByNumber", mock.Anything, mock.Anything).
+		Return((*proto.GetHeaderByNumberResponse)(nil), status.Error(codes.Unavailable, "down"))
+
+	mc := newTestMulti(down)
+	require.Error(t, mc.probe(0))
+}
+
+func TestNewMultiBorGRPCClient_StartsProberAndCloses(t *testing.T) {
+	var probed atomic.Int64
+	m0 := new(MockBorApiClient)
+	m0.On("HeaderByNumber", mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { probed.Add(1) }).Return(genesisResp("g"), nil)
+	m1 := new(MockBorApiClient)
+	m1.On("HeaderByNumber", mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { probed.Add(1) }).Return(genesisResp("g"), nil)
+
+	mc := NewMultiBorGRPCClient([]*BorGRPCClient{{client: m0}, {client: m1}}, log.NewNopLogger(), failover.Metrics{}, time.Second)
+	require.NotNil(t, mc)
+
+	require.Eventually(t, func() bool { return probed.Load() > 0 }, time.Second, 5*time.Millisecond)
+	require.NotPanics(t, func() { mc.Close(log.NewNopLogger()) })
+}

--- a/x/bor/grpc/failover_test.go
+++ b/x/bor/grpc/failover_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"math/big"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	proto "github.com/0xPolygon/polyproto/bor"
+	protoutil "github.com/0xPolygon/polyproto/utils"
 
 	"github.com/0xPolygon/heimdall-v2/x/bor/failover"
 )
@@ -124,6 +126,148 @@ func TestMultiGRPC_BatchCascades(t *testing.T) {
 	require.Empty(t, tds)
 	require.Empty(t, authors)
 	require.Equal(t, 1, mc.health.Active())
+}
+
+func TestMultiGRPC_WrapperMethodsCascade(t *testing.T) {
+	t.Run("GetVoteOnHash", func(t *testing.T) {
+		m0 := new(MockBorApiClient)
+		m0.On("GetVoteOnHash", mock.Anything, mock.Anything).
+			Return((*proto.GetVoteOnHashResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("GetVoteOnHash", mock.Anything, mock.Anything).
+			Return(&proto.GetVoteOnHashResponse{Response: true}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.GetVoteOnHash(context.Background(), 1, 2, "0xabc", "mid")
+		require.NoError(t, err)
+		require.True(t, got)
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("HeaderByNumber", func(t *testing.T) {
+		m0 := new(MockBorApiClient)
+		m0.On("HeaderByNumber", mock.Anything, mock.Anything).
+			Return((*proto.GetHeaderByNumberResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("HeaderByNumber", mock.Anything, mock.Anything).
+			Return(&proto.GetHeaderByNumberResponse{Header: &proto.Header{Number: 11}}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.HeaderByNumber(context.Background(), 11)
+		require.NoError(t, err)
+		require.Equal(t, int64(11), got.Number.Int64())
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("BlockByNumber", func(t *testing.T) {
+		m0 := new(MockBorApiClient)
+		m0.On("BlockByNumber", mock.Anything, mock.Anything).
+			Return((*proto.GetBlockByNumberResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("BlockByNumber", mock.Anything, mock.Anything).
+			Return(&proto.GetBlockByNumberResponse{Block: &proto.Block{Header: &proto.Header{Number: 12}}}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.BlockByNumber(context.Background(), 12)
+		require.NoError(t, err)
+		require.Equal(t, uint64(12), got.NumberU64())
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("TransactionReceipt", func(t *testing.T) {
+		txHash := common.HexToHash("0x1234")
+		m0 := new(MockBorApiClient)
+		m0.On("TransactionReceipt", mock.Anything, mock.Anything).
+			Return((*proto.ReceiptResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("TransactionReceipt", mock.Anything, mock.Anything).
+			Return(&proto.ReceiptResponse{Receipt: &proto.Receipt{TxHash: protoutil.ConvertHashToH256(txHash)}}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.TransactionReceipt(context.Background(), txHash)
+		require.NoError(t, err)
+		require.Equal(t, txHash, got.TxHash)
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("BorBlockReceipt", func(t *testing.T) {
+		txHash := common.HexToHash("0x5678")
+		m0 := new(MockBorApiClient)
+		m0.On("BorBlockReceipt", mock.Anything, mock.Anything).
+			Return((*proto.ReceiptResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("BorBlockReceipt", mock.Anything, mock.Anything).
+			Return(&proto.ReceiptResponse{Receipt: &proto.Receipt{TxHash: protoutil.ConvertHashToH256(txHash)}}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.BorBlockReceipt(context.Background(), txHash)
+		require.NoError(t, err)
+		require.Equal(t, txHash, got.TxHash)
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("GetAuthor", func(t *testing.T) {
+		author := common.HexToAddress("0x1111111111111111111111111111111111111111")
+		m0 := new(MockBorApiClient)
+		m0.On("GetAuthor", mock.Anything, mock.Anything).
+			Return((*proto.GetAuthorResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("GetAuthor", mock.Anything, mock.Anything).
+			Return(&proto.GetAuthorResponse{Author: protoutil.ConvertAddressToH160(author)}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.GetAuthor(context.Background(), big.NewInt(13))
+		require.NoError(t, err)
+		require.Equal(t, author, *got)
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("GetTdByHash", func(t *testing.T) {
+		hash := common.HexToHash("0xabcd")
+		m0 := new(MockBorApiClient)
+		m0.On("GetTdByHash", mock.Anything, mock.Anything).
+			Return((*proto.GetTdResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("GetTdByHash", mock.Anything, mock.Anything).
+			Return(&proto.GetTdResponse{TotalDifficulty: 33}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.GetTdByHash(context.Background(), hash)
+		require.NoError(t, err)
+		require.Equal(t, uint64(33), got)
+		require.Equal(t, 1, mc.health.Active())
+	})
+
+	t.Run("GetTdByNumber", func(t *testing.T) {
+		m0 := new(MockBorApiClient)
+		m0.On("GetTdByNumber", mock.Anything, mock.Anything).
+			Return((*proto.GetTdResponse)(nil), status.Error(codes.Unavailable, "down"))
+		m1 := new(MockBorApiClient)
+		m1.On("GetTdByNumber", mock.Anything, mock.Anything).
+			Return(&proto.GetTdResponse{TotalDifficulty: 44}, nil)
+
+		mc := newTestMulti(m0, m1)
+		mc.health.MarkSuccess(1)
+
+		got, err := mc.GetTdByNumber(context.Background(), big.NewInt(14))
+		require.NoError(t, err)
+		require.Equal(t, uint64(44), got)
+		require.Equal(t, 1, mc.health.Active())
+	})
 }
 
 func TestMultiGRPC_ProbeValidatesGenesis(t *testing.T) {

--- a/x/bor/grpc/failover_test.go
+++ b/x/bor/grpc/failover_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"sync/atomic"
 	"testing"
@@ -288,6 +289,28 @@ func TestMultiGRPC_ProbeValidatesGenesis(t *testing.T) {
 	require.NoError(t, mc.probe(0)) // primary establishes the expected genesis
 	require.NoError(t, mc.probe(1)) // same genesis → ok
 	require.Error(t, mc.probe(2))   // different genesis → rejected
+}
+
+func TestMultiGRPC_ProbeRunsEndpointValidators(t *testing.T) {
+	primary := new(MockBorApiClient)
+	primary.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("genesis-a"), nil)
+	fallback := new(MockBorApiClient)
+	fallback.On("HeaderByNumber", mock.Anything, mock.Anything).Return(genesisResp("genesis-a"), nil)
+
+	errParity := errors.New("parity mismatch")
+	mc := newTestMulti(primary, fallback)
+	mc.validators = []EndpointValidator{
+		func(_ context.Context, i int, _ EndpointHeaderFetcher) error {
+			if i == 1 {
+				return errParity
+			}
+			return nil
+		},
+	}
+
+	require.NoError(t, mc.probe(0))
+	require.ErrorIs(t, mc.probe(1), errParity)
+	require.Empty(t, mc.health.Candidates(0))
 }
 
 func TestCheckGenesis(t *testing.T) {

--- a/x/bor/grpc/failover_test.go
+++ b/x/bor/grpc/failover_test.go
@@ -54,6 +54,12 @@ func TestMultiGRPC_CascadesOnUnavailable(t *testing.T) {
 	require.Equal(t, 1, mc.health.Active())
 }
 
+func TestNewMultiBorGRPCClient_RejectsZeroClients(t *testing.T) {
+	require.PanicsWithValue(t, "bor failover: endpoint count must be positive", func() {
+		NewMultiBorGRPCClient(nil, log.NewNopLogger(), failover.Metrics{}, time.Second)
+	})
+}
+
 func TestMultiGRPC_NoCascadeOnLogicalError(t *testing.T) {
 	m0 := new(MockBorApiClient)
 	m0.On("GetRootHash", mock.Anything, mock.Anything).


### PR DESCRIPTION
## Summary
Add Bor endpoint failover for Heimdall's Bor HTTP JSON-RPC and optional gRPC clients. Operators can configure comma-separated, priority-ordered `bor_rpc_url` and `bor_grpc_url` values; a single endpoint keeps the existing plain dial behavior.

The feature adds a shared failover state machine under `x/bor/failover`, an HTTP RoundTripper cascade, and a gRPC `MultiBorGRPCClient`. The active endpoint is tried first, retriable failures cascade through currently healthy validated candidates, and the first successful candidate becomes active for subsequent calls.

Identity safety is built into the prober before fallback candidacy: HTTP validates Bor chain ID, and gRPC validates the genesis block hash. The primary remains authoritative, can reclaim a provisional fallback identity, and demotes other endpoints on reclaim so stale or wrong-network fallbacks cannot remain candidates after the primary returns.

The call budget is time-based rather than an attempt counter: `min(bor_rpc_timeout, MaxBorRPCTimeout) * clamp(bor_grpc_flag ? max(httpCount, grpcCount) : httpCount, 1, maxBudgetedEndpoints)`, where `MaxBorRPCTimeout = 3s` and `maxBudgetedEndpoints = 3`, so a single Bor call is bounded at 9s even if the configured `bor_rpc_timeout` is higher. Per-attempt contexts still propagate caller cancellation immediately. HTTP cascades on transport errors, per-attempt timeout, and 5xx while preserving the final real 5xx response if all endpoints fail; gRPC cascades only on transport-style status codes (`Unavailable`, `DeadlineExceeded`, `ResourceExhausted`).

Additional wiring:
- Bridge `SendTransaction` now uses the HTTP failover client; re-broadcasting the same signed transaction is idempotent by tx hash.
- Bridge shutdown now closes Bor failover probers / gRPC clients.
- Prometheus metrics expose failover switches, proactive switches, active index, and healthy endpoint count by transport.
- Config templates and `docs/bor-failover.md` document operator behavior, timings, identity validation, and credential handling.

## Executed tests
- `go test ./...`
- `go test -race ./helper ./bridge/broadcaster ./bridge/service ./x/bor/failover ./x/bor/grpc ./metrics`
- `go vet ./helper ./bridge/broadcaster ./bridge/service ./x/bor/failover ./x/bor/grpc ./metrics`
- diffguard (mutation testing): `100.0% (83/83 killed, 0 survived)`. Non-failing warnings remained for pre-existing dependency-stability / churn-weighted-complexity surfaces.

### Live devnet failover validation (kurtosis-pos)

Two-validator devnet running this branch's Heimdall image. gRPC is disabled by default, so this exercises the HTTP path; metrics below are `heimdallv2_bor_failover_*{transport="http"}`. Driven by a local-only kurtosis-pos tweak that sets a comma-separated `bor_rpc_url` (not part of this PR).

Provisional anchor / graceful degradation — every Heimdall booted with an unreachable primary Bor (`bor_rpc_url = "http://127.0.0.1:1,<own-el>"`):
- both validators started with no startup fatal; `active_index → 1`, `healthy_endpoints = 1`, `proactive_switches_total = 1`
- consensus stayed live through the fallback: Bor blocks advancing, Heimdall synced (`catching_up=false`), checkpoint number 4 produced with a `root_hash` computed from Bor `GetRootHash` (`bor_chain_id 4927`) — confirming the fallback served consensus-critical Bor reads

Live failover + cooldown switchback — two live same-chain ELs (`bor_rpc_url = "<own-el>,<el-2>"`); primary stopped then restarted on validator 1:
- `kurtosis service stop` of the primary → `active_index → 1`, `switches_total = 1` (in-call reactive cascade), `healthy_endpoints = 1`; Heimdall height and the Bor chain kept advancing via the fallback
- `kurtosis service start` → primary re-validated to healthy within ~20s (`healthy_endpoints = 2`) but traffic stayed on the fallback through the promotion cooldown, then reverted: `active_index → 0` at ~100s with `proactive_switches_total = 1` — the cooldown-gated switchback ("fail fast, switch back slow")

### Worst-case / failure-mode validation (kurtosis-pos)

Follow-up pass beyond the primary-down/fallback-up case above, exercising the failure cells unit tests can't cover convincingly. Same two-validator + two-RPC devnet on this branch's image; HTTP path; signals are `heimdallv2_bor_failover_*{transport="http"}`. Driven by the same local-only kurtosis-pos `bor_rpc_url` tweak (not part of this PR).

All endpoints down, from a failed-over state — primary = own bor, fallback = an RPC-node bor (same chain):
- stop primary → reactive cascade (`active_index → 1`, `switches_total = 1`, `healthy_endpoints = 1`); stop the fallback too → `healthy_endpoints = 0` with **no additional switches** (empty candidate set, so no thrash or call pile-up), Heimdall height kept advancing and the validator never panicked — the same failure surface as a single-endpoint node with a dead Bor (side-tx Bor reads degrade to NO/UNSPECIFIED, never a fabricated success). Restore → recovered to `active_index = 0`.

Flapping primary — primary = own bor, fallback = RPC-node bor; two stop/start cycles:
- switch-away was immediate (**~1s**, reactive); switchback was cooldown-gated (**~90–100s**: ~3 successful probes to clear the threshold + the 60s promotion cooldown) — the intended "fail fast, switch back slow" asymmetry. Counters incremented by exactly 1 per transition (`switches_total` and `proactive_switches_total` each reached 3 across the run), no double-count and no metric churn.

Wrong-network fallback, primary healthy — primary = bor (chain 4927), fallback = L1 geth (chain 3151908):
- the wrong-chain fallback never became a candidate (`healthy_endpoints = 1`; chain-id mismatch rejected by the prober). Killing the primary did **not** fail over onto it (`active_index` stayed 0, `healthy_endpoints → 0`): the node degrades to "no Bor" (→ NO votes), never "wrong Bor". Heimdall kept advancing.

Wrong-network fallback, primary never reachable at boot — primary = dead address, fallback = L1 geth:
- after the primary-probe-failure threshold the fallback provisionally anchored identity (`active_index = 1`, `healthy_endpoints = 1`, `proactive_switches_total = 1`) — the documented provisional-anchor window. Even within it, Bor consensus reads against the wrong chain were rejected: spans never advanced past 0, i.e. the node makes **no progress** rather than wrong progress. The primary reclaim/demote that closes the window is covered by unit tests (`TestCheckChainID_PrimaryReclaimsProvisionalAnchor`, `TestCheckGenesis_PrimaryReclaimsProvisionalAnchor`, `TestReclaim_AdoptsPrimaryAndDemotesOthers`).

## Rollout notes
This is operator-facing but backward compatible: nodes with a single Bor HTTP/gRPC endpoint keep the old plain client behavior. Failover only activates when multiple endpoints are configured. To enable it, set comma-separated, priority-ordered `bor_rpc_url` / `bor_grpc_url` (first = primary); remote gRPC fallbacks need an explicit `http(s)://` scheme (a bare `host:port` is accepted only for localhost). See `docs/bor-failover.md`.

Fallback identity validation is conservative. A fallback can only serve after probe validation; if the primary was never reachable, a reachable fallback can provisionally anchor identity after the primary probe failure threshold, and the primary reclaims/demotes all fallbacks once it returns.

No coordinated network upgrade or hardfork is required. The consensus effect is per-node side-handler read routing: a bad or lagging same-chain fallback affects that node's local YES/NO/UNSPECIFIED opinion, not deterministic consensus state.

That per-node isolation holds only while failures are uncorrelated. Operators should prefer diverse fallback assignment across the fleet (e.g. each validator falling back to a different peer's Bor) rather than pointing every node at one shared fallback — a single shared fallback is a correlated failure point (thundering-herd load when many nodes fail over at once, or fleet-wide reliance on one possibly-lagging endpoint).



---

## Block-producer guard

### Summary
Restrict Bor endpoint failover for block producers. Under VEBLOP, a validator's milestone-vote participation gates its producer eligibility (`supportingValidatorIDs` → `FilterByActiveProducerSet`), so a producer whose own Bor is down could keep voting via a fallback, stay producer-eligible, be elected, and then fail to produce when its turn comes. To prevent this, the node **fails closed** when the local signer maps to a validator in the protected producer set **and** Bor endpoint failover is configured. The guard runs at two points: at startup in `newStartApp` (synced nodes, whose validator state is already loaded) and in `InitChainer` after `InitGenesis` (a fresh-DB / genesis producer, whose validator record doesn't exist until genesis state is written). A startup hit aborts `heimdalld start`; an `InitChainer` hit fails `InitChain`.

The protected producer set is the union of: the configured/default producer votes (e.g. `DefaultMainnetProducers = "91,92,93,94"`), the current span's `SelectedProducers`, and the calculated VEBLOP candidate set (`CalculateProducerSet`, fallback to default producer votes when empty). The risk is confined to that small set (`GetProducerSetLimit` = 3, or 4 post-`setProducerDowntimeHeight`) — a validator outside it can never be elected regardless of how it votes. Non-producing validators, sentries/RPC/archive nodes, and Heimdall-without-Bor topologies are unaffected and keep failover. The guard is node-local and read-only: it does not write app state or change proto/wire format. The InitChainer hook only aborts a locally misconfigured node during startup; it does not change deterministic consensus state for correctly configured nodes.

### Executed tests
- `make test` (full suite) — pass; `make lint` (golangci-lint v2.11.4) — 0 issues; `go vet` / `gofmt` — clean.
- New unit tests: `TestValidateBorFailoverBPGuard`, `TestBorFailoverProtectedProducerIDsDoesNotIncludeEveryValidator`, `TestBorFailoverConfigured`, `TestApplyBorFailoverBPGuard`, `TestMustApplyBorFailoverBPGuard`, `TestInitChainFailsClosedForGenesisBorFailoverProducer` — covering configured/selected/calculated producers (blocked), inactive and jailed configured producers (blocked), non-producer / non-validator signers (allowed), the fail-closed panic contract, and the fresh-DB/genesis path where `InitChain` fails for a genesis producer.
- diffguard (mutation, guard surface): the guard decision logic, the `applyBorFailoverBPGuard` close/log/return logic, and the fail-closed `mustApplyBorFailoverBPGuard` panic are all fully killed; the only residual mutants are the irreducible `newStartApp` AppCreator wiring (the guard call and `return hApp`), which require a full app build to exercise.

### Rollout notes
Block-producer nodes must point Heimdall at a single local Bor endpoint; a multi-endpoint `bor_rpc_url` / `bor_grpc_url` on a producer aborts startup with an actionable message. Backward compatible for every non-producer and every single-endpoint config. See the "Not for block producers" section in `docs/bor-failover.md`.



### Kurtosis e2e (live devnet) validation

Ran on a kurtosis-pos devnet built from this branch's Heimdall image, with the BP guard and failover exercised end-to-end. Failover endpoints were injected via a local-only kurtosis-pos template tweak (comma-separated `bor_rpc_url` / `bor_grpc_url` per node role); not part of this PR.

BP guard (both enforcement layers):
- **Fresh-genesis BP + multi `bor_rpc_url`** → startup guard correctly allows pre-genesis (no validator record yet), then `InitChainer` re-check fails `InitChain`: `bor endpoint failover is not allowed for block producer validators … validator ID 1`. Validates `09211c3d`.
- **Synced BP + multi `bor_rpc_url`, restart** → `newStartApp` startup guard panics before any `InitChain` (validator record already committed at height 732). Node fails closed.
- **BP + `bor_grpc_flag=true` + multi `bor_grpc_url`** (single `bor_rpc_url`) → rejected by the same guard, confirming the gRPC transport is covered.

Failover behavior (non-validator RPC node, where failover is allowed):
- **Primary down, healthy fallback** → `active_index → 1`, `proactive_switches_total = 1`, reads continue via fallback.
- **Primary returns** → traffic stays on fallback through the promotion cooldown (~90–100s), then reverts to primary (`active_index → 0`) — "fail fast, switch back slow".
- **Fallback down, primary healthy** → no switch (`active_index` stays `0`, `healthy_endpoints → 1`).
- **All endpoints down** → `healthy_endpoints → 0`, no panic, no switch-thrash; node keeps following the chain via peers; recovers to `healthy_endpoints = 1` when an endpoint returns.
- **Wrong-chain fallback (L1 geth)** → never validated as a candidate (chain-id mismatch); killing the primary degrades to "no Bor" (`healthy_endpoints → 0`), never adopts the wrong chain, no panic.

Shutdown cleanup (`#10`/`#11`) is covered by unit tests; span-rotation end-to-end (`#13`) and a full gRPC failover cascade were out of scope (the latter needs a Bor whose gRPC `Header` proto matches HTTP — the devnet Bor `2.7.2` instead triggered the gRPC parity-fatal safety check, itself a valid behavior).