### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -6404,7 +6404,6 @@ func TestExtractTxHashMsgEventRecordValidation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			msg := &clerkTypes.MsgEventRecord{TxHash: tc.txHash}
 			hash, ok := extractTxHash(msg)

--- a/bridge/listener/rootchain_selfheal_test.go
+++ b/bridge/listener/rootchain_selfheal_test.go
@@ -39,7 +39,6 @@ func TestJoinGraphQLErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, joinGraphQLErrors(tt.errs))
@@ -107,7 +106,6 @@ func TestMaxNonceFromResponse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := maxNonceFromResponse(tt.response)
@@ -140,7 +138,6 @@ func TestPickStakeEventHit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := pickStakeEventHit(tt.response)


### PR DESCRIPTION
## Summary


The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore


## Executed tests

## Rollout notes
