### PR TITLE
x/clerk: fix archive sync around ss

### DIFF
--- a/x/clerk/keeper/grpc_query.go
+++ b/x/clerk/keeper/grpc_query.go
@@ -189,7 +189,10 @@ func (q queryServer) recordListWithTimeDeterministic(ctx context.Context, reques
 	latestIndexedTime, err := q.k.GetLatestIndexedBlockTime(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNoBlockFound) {
-			return &types.RecordListWithTimeResponse{EventRecords: []types.EventRecord{}}, nil
+			// Block-time index is empty (no committed block past the HF height has
+			// been indexed yet): the cutoff can only be pre-HF, so answer with
+			// legacy record_time semantics rather than dropping events.
+			return q.recordListWithTimeLegacy(ctx, request)
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -200,7 +203,11 @@ func (q queryServer) recordListWithTimeDeterministic(ctx context.Context, reques
 	height, err := q.k.GetBlockHeightByTime(ctx, cutoffUnix)
 	if err != nil {
 		if errors.Is(err, ErrNoBlockFound) {
-			return &types.RecordListWithTimeResponse{EventRecords: []types.EventRecord{}}, nil
+			// Cutoff falls before the first indexed (post-HF) block: this is a pre-HF
+			// window with no height to pin. Fall back to the legacy record_time query
+			// so a node replaying pre-HF blocks derives the same state-sync set
+			// producers committed.
+			return q.recordListWithTimeLegacy(ctx, request)
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/clerk/keeper/grpc_query_test.go
+++ b/x/clerk/keeper/grpc_query_test.go
@@ -335,8 +335,10 @@ func (s *KeeperTestSuite) TestGetRecordListWithTime_Deterministic_NoEvents() {
 
 // TestGetRecordListWithTime_Deterministic_HeightResolutionFails verifies that
 // when only blocks AFTER the cutoff exist (stability gate passes, but
-// GetBlockHeightByTime returns ErrNoBlockFound) the handler returns empty
-// rather than erroring.
+// GetBlockHeightByTime returns ErrNoBlockFound) the handler falls back to the
+// legacy record_time path without erroring. With no events in the store the
+// legacy result is also empty; the with-events case is covered by
+// TestGetRecordListWithTime_Deterministic_PreHFCutoffFallsBackToLegacy.
 func (s *KeeperTestSuite) TestGetRecordListWithTime_Deterministic_HeightResolutionFails() {
 	ctx, ck := s.ctx, s.keeper
 	require := s.Require()
@@ -361,9 +363,49 @@ func (s *KeeperTestSuite) TestGetRecordListWithTime_Deterministic_HeightResoluti
 		ToTime:     cutoff,
 		Pagination: query.PageRequest{Limit: 10, Key: []byte{0x00}},
 	})
-	require.NoError(err, "height resolution failure should return empty, not error")
+	require.NoError(err, "height resolution failure should fall back to legacy, not error")
 	require.NotNil(resp)
-	require.Empty(resp.EventRecords)
+	require.Empty(resp.EventRecords, "no events in store: legacy fallback is also empty")
+}
+
+func (s *KeeperTestSuite) TestGetRecordListWithTime_Deterministic_PreHFCutoffFallsBackToLegacy() {
+	ctx, ck := s.ctx, s.keeper
+	require := s.Require()
+	defer enableVisibilityTimeForTest(s, 1)()
+
+	baseTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	cutoff := baseTime
+
+	// Pre-HF events (no visibility_height, not pending): record_time before the cutoff.
+	for i := uint64(1); i <= 3; i++ {
+		rec := types.NewEventRecord(TxHash1, i, i, Address1, make([]byte, 1), "1",
+			baseTime.Add(-time.Duration(i)*time.Minute))
+		rec.RecordTime = rec.RecordTime.UTC()
+		require.NoError(ck.SetEventRecord(ctx, rec))
+	}
+
+	// Index only covers a post-cutoff block, mirroring a node whose block-time
+	// index starts at the visibility-height activation height.
+	ctx = ctx.WithBlockHeight(300).WithBlockHeader(cmtproto.Header{
+		Time:   baseTime.Add(2 * time.Minute),
+		Height: 300,
+	})
+	require.NoError(ck.StoreBlockTime(ctx))
+
+	// Query from a height well past activation: takes the deterministic branch.
+	ctx = ctx.WithBlockHeight(10000).WithBlockHeader(cmtproto.Header{
+		Time:   cutoff.Add(3 * time.Minute),
+		Height: 10000,
+	})
+
+	resp, err := clerkKeeper.NewQueryServer(&ck).GetRecordListWithTime(ctx, &types.RecordListWithTimeRequest{
+		FromId:     1,
+		ToTime:     cutoff,
+		Pagination: query.PageRequest{Limit: 10, Key: []byte{0x00}},
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Len(resp.EventRecords, 3, "pre-HF cutoff must fall back to legacy and return the producer's set, not empty")
 }
 
 // TestGetRecordListWithTime_OffsetExceedsMax verifies the offset upper bound


### PR DESCRIPTION
## Summary

Fixes a regression in the Zurich deterministic state-sync querying that makes a node replaying pre-Zurich blocks compute a divergent state root (bad block) when its own height is already past the Zurich activation.

`GetRecordListWithTime` chooses between the legacy `record_time` path and the deterministic (height-pinned, `visibility_height`) path based on the querying node's current height (`IsZurichHardfork(sdkCtx.BlockHeight())`). The deterministic path resolves the cutoff time to a Heimdall height via the block-time reverse index, which is only populated from the Zurich activation height onward. So when a node that is already post-Zurich answers a query whose cutoff falls in the pre-Zurich window, `GetBlockHeightByTime` returns `ErrNoBlockFound` and the handler returned an empty result instead of the events.

Bor consumes a contiguous state-sync prefix, so an empty answer makes the replaying node commit fewer state syncs than the original producer did for that block (hence the different `IntermediateRoot` and `invalid merkle root`). The canonical trigger is a fresh archive replaying history long after production: the original producer (pre-Zurich) used the legacy path and returned the events, while the archive (post-Zurich tip) took the deterministic path and returned nothing.

### Fix

When the deterministic path cannot pin the cutoff to an indexed height (`ErrNoBlockFound` — i.e. the cutoff predates the index, which only covers the post-Zurich window), fall back to the legacy `record_time` query — the exact path that produced those blocks. Pre-Zurich events have no `visibility_height` and were always served by `record_time`, so producer and replayer now agree. Post-Zurich cutoffs are unchanged and keep the deterministic path. Wire format is unchanged; bor/erigon clients are agnostic.

## Executed tests

- **Unit:** new regression test `TestGetRecordListWithTime_Deterministic_PreHFCutoffFallsBackToLegacy` (pre-Zurich cutoff with events present + index only covering post-Zurich) — fails before the change (0 records), passes after (returns the producer's set). Updated the stale `..._HeightResolutionFails` test that documented the old empty-return as intended. Full `./x/clerk/...` suite green; `go build ./...` clean; diffguard (with mutation testing) exits 0, no surviving mutants in the change.
- **Local Kurtosis devnet** (bor `2.8.3` + heimdall `v0.9.0-beta` + this fix, Zurich activated mid-chain to create a pre/post window): baseline health green — block production, cross-validator hash agreement, milestones, checkpoints, spans, state-syncs.
- **Archive-sync repro:** a full-re-execution archive (`syncmode=full, gcmode=archive`) replayed from genesis across the pre-Zurich state-sync block, reached the same `lastStateID` as the validators, with **0 bad blocks**, and caught up to tip. Same scenario bad-blocks at the pre-Zurich sprint boundary without the fix.)
- **Fault injection:** killed a validator (correct BFT halt at n=3), restarted it and had clean resync, 0 bad blocks, full hash + state-sync agreement across all nodes.

## Rollout notes

- Backwards-compatible: query-layer only, no stored-state / app-hash change, no migration, no coordinated hardfork. Wire format unchanged.
- Consensus-relevant in that it changes which state-sync set a replaying node derives for pre-fork blocks — but it restores parity with what producers committed, so it removes divergence rather than introducing it.
- Should land in v0.9.0 before Zurich activation. Relevant for mainnet: after Zurich activates, a fresh from-genesis archive replaying pre-Zurich history would otherwise hit this bad block; nodes serving clerk queries should run the fix before archive sync across the boundary is relied upon.