### PR TITLE
bor: fall back to eligible producers when veblop candidate set is empty

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -1069,7 +1069,7 @@ func (app *HeimdallApp) checkAndRotateCurrentSpan(ctx sdk.Context) error {
 
 		delete(latestActiveProducer, currentProducer)
 
-		err = app.BorKeeper.AddNewVeBlopSpan(addSpanCtx, currentProducer, lastMilestone.EndBlock+1, endBlock, lastMilestone.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, nil)
+		err = app.BorKeeper.AddNewVeBlopSpan(addSpanCtx, currentProducer, lastMilestone.EndBlock+1, endBlock, lastMilestone.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, nil, false)
 		if err != nil {
 			logger.Warn("Error occurred while adding new veblop span", "error", err)
 		} else {

--- a/app/abci.go
+++ b/app/abci.go
@@ -961,7 +961,7 @@ func (app *HeimdallApp) checkAndAddFutureSpan(ctx sdk.Context, majorityMilestone
 			return err
 		}
 
-		err = app.BorKeeper.AddNewVeBlopSpan(ctx, currentProducer, lastSpan.EndBlock+1, endBlock, lastSpan.BorChainId, supportingValidatorIDs, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, nil)
+		err = app.BorKeeper.AddNewVeBlopSpan(ctx, currentProducer, lastSpan.EndBlock+1, endBlock, lastSpan.BorChainId, supportingValidatorIDs, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, nil, true)
 		if err != nil {
 			logger.Error("Error occurred while adding new veblop span", "error", err)
 			return err

--- a/app/pending_stall.go
+++ b/app/pending_stall.go
@@ -202,7 +202,7 @@ func (app *HeimdallApp) rotateSpanFromPendingHead(ctx sdk.Context, pendingHead u
 		return err
 	}
 
-	if err := app.BorKeeper.AddNewVeBlopSpan(addSpanCtx, currentProducer, pendingHead+1, endBlock, lastSpan.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, excludedProducers); err != nil {
+	if err := app.BorKeeper.AddNewVeBlopSpan(addSpanCtx, currentProducer, pendingHead+1, endBlock, lastSpan.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), borTypes.RoundRobinDefault, excludedProducers, false); err != nil {
 		// Don't halt consensus if no producer can be selected this block; retry next block.
 		logger.Warn("Error occurred while adding new veblop span on pending stall", "error", err)
 		return nil

--- a/app/veblop_producer_fallback_test.go
+++ b/app/veblop_producer_fallback_test.go
@@ -1,0 +1,217 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtsecp256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
+	"github.com/0xPolygon/heimdall-v2/sidetxs"
+	borKeeper "github.com/0xPolygon/heimdall-v2/x/bor/keeper"
+	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
+	milestoneTypes "github.com/0xPolygon/heimdall-v2/x/milestone/types"
+	stakeTypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
+)
+
+// singletonScenario holds the staged degenerate VEBLOP state: the elected producer set
+// has collapsed to the single current producer, and a >2/3 milestone is finalized by the
+// other validators while the current producer withholds its milestone vote (so it is
+// excluded from the supporting set). Future-span creation in PreBlocker then asks
+// SelectNextSpanProducer for a replacement and the candidate set (singleton minus the
+// current producer) is empty.
+type singletonScenario struct {
+	app               *HeimdallApp
+	ctx               sdk.Context
+	height            int64
+	lastSpan          borTypes.Span
+	currentProducerID uint64
+	validators        []*stakeTypes.Validator
+	extCommitBytes    []byte
+}
+
+func stageSingletonProducer(t *testing.T) *singletonScenario {
+	t.Helper()
+	_, app, ctx, validatorPrivKeys := SetupAppWithABCICtxAndValidators(t, 4)
+
+	oldRio := helper.GetRioHeight()
+	helper.SetRioHeight(100)
+	t.Cleanup(func() { helper.SetRioHeight(oldRio) })
+
+	height := app.LastBlockHeight() + 1
+	ctx = ctx.WithBlockHeight(height)
+
+	validators := app.StakeKeeper.GetAllValidators(ctx)
+	require.Len(t, validators, 4)
+
+	currentProducerID := validators[0].ValId
+	lastSpan := borTypes.Span{
+		Id:                1,
+		StartBlock:        100,
+		EndBlock:          199,
+		BorChainId:        "1",
+		ValidatorSet:      stakeTypes.ValidatorSet{Validators: validators, Proposer: validators[0]},
+		SelectedProducers: []stakeTypes.Validator{*validators[0]},
+	}
+	require.NoError(t, app.BorKeeper.AddNewSpan(ctx, &lastSpan))
+
+	// Every validator casts a one-entry ballot for the current producer, collapsing
+	// CalculateProducerSet to the singleton [currentProducer].
+	msgServer := borKeeper.NewMsgServerImpl(app.BorKeeper)
+	for _, validator := range validators {
+		_, err := msgServer.VoteProducers(ctx, &borTypes.MsgVoteProducers{
+			Voter:   validator.Signer,
+			VoterId: validator.ValId,
+			Votes:   borTypes.ProducerVotes{Votes: []uint64{currentProducerID}},
+		})
+		require.NoError(t, err)
+	}
+	candidates, err := app.BorKeeper.CalculateProducerSet(ctx, helper.GetProducerSetLimit(ctx))
+	require.NoError(t, err)
+	require.Equal(t, []uint64{currentProducerID}, candidates)
+
+	previousMilestoneHash := common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
+	require.NoError(t, app.MilestoneKeeper.AddMilestone(ctx, milestoneTypes.Milestone{
+		Proposer:        validators[1].Signer,
+		Hash:            previousMilestoneHash,
+		StartBlock:      1,
+		EndBlock:        lastSpan.StartBlock - 1,
+		BorChainId:      "1",
+		MilestoneId:     "previous",
+		Timestamp:       1,
+		TotalDifficulty: 1,
+	}))
+
+	winningMilestone := &milestoneTypes.MilestoneProposition{
+		StartBlockNumber: lastSpan.StartBlock,
+		ParentHash:       previousMilestoneHash,
+		BlockHashes:      [][]byte{common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Bytes()},
+		BlockTds:         []uint64{2},
+	}
+
+	// Validators 1, 2 and 3 (75% of voting power) finalize the milestone; the current
+	// producer (validator 0) withholds, so it is absent from supportingValidatorIDs.
+	extCommitBytes := milestoneExtendedCommit(t, app.ChainID(), height, validators, validatorPrivKeys, currentProducerID, winningMilestone)
+
+	return &singletonScenario{
+		app:               app,
+		ctx:               ctx,
+		height:            height,
+		lastSpan:          lastSpan,
+		currentProducerID: currentProducerID,
+		validators:        validators,
+		extCommitBytes:    extCommitBytes,
+	}
+}
+
+// Pre-Ithaca the fallback is gated off, so the singleton-minus-current empty set still
+// errors out of PreBlocker. This pins the gate boundary: the fix changes nothing before
+// the fork activates.
+func TestVeBlopEmptyElectedSetPreIthacaErrors(t *testing.T) {
+	s := stageSingletonProducer(t)
+
+	oldIthaca := helper.GetIthacaHeight()
+	helper.SetIthacaHeight(0) // disabled: IsIthaca is always false
+	t.Cleanup(func() { helper.SetIthacaHeight(oldIthaca) })
+
+	_, err := s.app.PreBlocker(s.ctx, &abci.RequestFinalizeBlock{
+		Height:          s.height,
+		Txs:             [][]byte{s.extCommitBytes},
+		ProposerAddress: common.FromHex(s.validators[1].Signer),
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "no candidates found"), err.Error())
+
+	// Nothing committed: the failing height replays identically.
+	milestoneCount, err := s.app.MilestoneKeeper.GetMilestoneCount(s.ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), milestoneCount)
+	span, err := s.app.BorKeeper.GetLastSpan(s.ctx)
+	require.NoError(t, err)
+	require.Equal(t, s.lastSpan.Id, span.Id)
+}
+
+// Post-Ithaca the fallback supplies a deterministic non-empty candidate set drawn from
+// the milestone supporters, so future-span creation succeeds, the milestone/span commit,
+// and the new producer is a supporting validator rather than the excluded incumbent.
+func TestVeBlopEmptyElectedSetPostIthacaFallsBack(t *testing.T) {
+	s := stageSingletonProducer(t)
+
+	oldIthaca := helper.GetIthacaHeight()
+	helper.SetIthacaHeight(s.height)
+	t.Cleanup(func() { helper.SetIthacaHeight(oldIthaca) })
+
+	_, err := s.app.PreBlocker(s.ctx, &abci.RequestFinalizeBlock{
+		Height:          s.height,
+		Txs:             [][]byte{s.extCommitBytes},
+		ProposerAddress: common.FromHex(s.validators[1].Signer),
+	})
+	require.NoError(t, err)
+
+	// The milestone committed and a new span was frozen.
+	milestoneCount, err := s.app.MilestoneKeeper.GetMilestoneCount(s.ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), milestoneCount)
+
+	span, err := s.app.BorKeeper.GetLastSpan(s.ctx)
+	require.NoError(t, err)
+	require.Equal(t, s.lastSpan.Id+1, span.Id)
+	require.Len(t, span.SelectedProducers, 1)
+
+	// The replacement must be a supporting validator, never the excluded incumbent.
+	newProducer := span.SelectedProducers[0].ValId
+	require.NotEqual(t, s.currentProducerID, newProducer)
+	supporters := map[uint64]struct{}{
+		s.validators[1].ValId: {},
+		s.validators[2].ValId: {},
+		s.validators[3].ValId: {},
+	}
+	_, ok := supporters[newProducer]
+	require.True(t, ok, "new producer %d should be one of the milestone supporters", newProducer)
+}
+
+func milestoneExtendedCommit(t *testing.T, chainID string, height int64, validators []*stakeTypes.Validator, validatorPrivKeys []cmtsecp256k1.PrivKey, currentProducerID uint64, milestone *milestoneTypes.MilestoneProposition) []byte {
+	t.Helper()
+	require.Len(t, validatorPrivKeys, len(validators))
+
+	dummyNonRpExt, err := GetDummyNonRpVoteExtension(height-1, chainID)
+	require.NoError(t, err)
+
+	extCommit := &abci.ExtendedCommitInfo{Round: 0, Votes: make([]abci.ExtendedVoteInfo, 0, len(validators))}
+	for i, validator := range validators {
+		var prop *milestoneTypes.MilestoneProposition
+		if validator.ValId != currentProducerID {
+			prop = milestone
+		}
+
+		voteExt := sidetxs.VoteExtension{
+			BlockHash:            []byte("repro-previous-block"),
+			Height:               height - 1,
+			MilestoneProposition: prop,
+			SideTxResponses:      []sidetxs.SideTxResponse{},
+		}
+		voteExtBytes, err := voteExt.Marshal()
+		require.NoError(t, err)
+
+		voteInfo := abci.ExtendedVoteInfo{
+			Validator: abci.Validator{
+				Address: common.FromHex(validator.Signer),
+				Power:   validator.VotingPower,
+			},
+			VoteExtension:      voteExtBytes,
+			NonRpVoteExtension: dummyNonRpExt,
+			BlockIdFlag:        cmtproto.BlockIDFlagCommit,
+		}
+		createSignatureForVoteExtension(t, height-1, validatorPrivKeys[i], voteExtBytes, dummyNonRpExt, &voteInfo)
+		extCommit.Votes = append(extCommit.Votes, voteInfo)
+	}
+
+	bz, err := extCommit.Marshal()
+	require.NoError(t, err)
+	return bz
+}

--- a/x/bor/keeper/side_msg_server.go
+++ b/x/bor/keeper/side_msg_server.go
@@ -700,7 +700,7 @@ func (srv sideMsgServer) PostHandleSetProducerDowntime(ctx sdk.Context, msgI sdk
 		spanEndBlock = msg.DowntimeRange.StartBlock + params.SpanDuration
 	}
 
-	if err := srv.k.AddNewVeBlopSpan(ctx, validatorId, msg.DowntimeRange.StartBlock, spanEndBlock, lastSpan.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), msg.TargetProducerId, nil); err != nil {
+	if err := srv.k.AddNewVeBlopSpan(ctx, validatorId, msg.DowntimeRange.StartBlock, spanEndBlock, lastSpan.BorChainId, latestActiveProducer, uint64(ctx.BlockHeight()), msg.TargetProducerId, nil, false); err != nil {
 		logger.Error("Error occurred while adding new veBlop span", "error", err)
 		return err
 	}

--- a/x/bor/keeper/veblop.go
+++ b/x/bor/keeper/veblop.go
@@ -18,13 +18,13 @@ import (
 //
 // fallbackToActiveSet opts the caller into the post-Ithaca empty-candidate recovery in
 // SelectNextSpanProducer. Only the future-span PreBlocker path passes true: there an empty
-// candidate set is a fatal chain halt. The rotation / pending-stall / side-message callers omit
-// it (default false) and keep their existing skip-and-retry behavior on an empty selection.
-func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, startBlock uint64, endBlock uint64, borChainID string, activeValidatorIDs map[uint64]struct{}, heimdallBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet ...bool) error {
+// candidate set is a fatal chain halt. The rotation / pending-stall / side-message callers pass
+// false and keep their existing skip-and-retry behavior on an empty selection.
+func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, startBlock uint64, endBlock uint64, borChainID string, activeValidatorIDs map[uint64]struct{}, heimdallBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet bool) error {
 	logger := k.Logger(ctx)
 
 	// select next producers
-	newProducerId, err := k.SelectNextSpanProducer(ctx, currentProducer, activeValidatorIDs, helper.GetProducerSetLimit(ctx), startBlock, endBlock, targetProducerID, excludedProducerIDs, fallbackToActiveSet...)
+	newProducerId, err := k.SelectNextSpanProducer(ctx, currentProducer, activeValidatorIDs, helper.GetProducerSetLimit(ctx), startBlock, endBlock, targetProducerID, excludedProducerIDs, fallbackToActiveSet)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (k *Keeper) ClearLatestFailedProducer(ctx context.Context) error {
 
 // SelectNextSpanProducer selects the next producer for a new span.
 // It calculates the candidate set, filters by active producers, and selects one.
-func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64, activeValidatorIDs map[uint64]struct{}, producerSetLimit, startBlock, endBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet ...bool) (uint64, error) {
+func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64, activeValidatorIDs map[uint64]struct{}, producerSetLimit, startBlock, endBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet bool) (uint64, error) {
 	candidates, err := k.CalculateProducerSet(ctx, producerSetLimit)
 	if err != nil {
 		return 0, fmt.Errorf("failed to calculate producer set: %w", err)
@@ -274,7 +274,7 @@ func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64,
 	}
 
 	// Post-Ithaca, recover a candidate so the future-span path (the only opt-in via fallbackToActiveSet) can't hand SelectProducer an empty set (see eligibleProducerFallback).
-	if len(activeCandidates) == 0 && len(fallbackToActiveSet) > 0 && fallbackToActiveSet[0] && helper.IsIthaca(ctx.BlockHeight()) {
+	if len(activeCandidates) == 0 && fallbackToActiveSet && helper.IsIthaca(ctx.BlockHeight()) {
 		activeCandidates = k.eligibleProducerFallback(ctx, currentProducer, activeValidatorIDs, excludedProducerIDs)
 	}
 	// If the declaring producer requested a specific replacement, try to honor it.

--- a/x/bor/keeper/veblop.go
+++ b/x/bor/keeper/veblop.go
@@ -14,12 +14,17 @@ import (
 	staketypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
-// AddNewVeBlopSpan adds a new veBlop (Validator-elected block producer) span
-func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, startBlock uint64, endBlock uint64, borChainID string, activeValidatorIDs map[uint64]struct{}, heimdallBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}) error {
+// AddNewVeBlopSpan adds a new veBlop (Validator-elected block producer) span.
+//
+// fallbackToActiveSet opts the caller into the post-Ithaca empty-candidate recovery in
+// SelectNextSpanProducer. Only the future-span PreBlocker path passes true: there an empty
+// candidate set is a fatal chain halt. The rotation / pending-stall / side-message callers omit
+// it (default false) and keep their existing skip-and-retry behavior on an empty selection.
+func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, startBlock uint64, endBlock uint64, borChainID string, activeValidatorIDs map[uint64]struct{}, heimdallBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet ...bool) error {
 	logger := k.Logger(ctx)
 
 	// select next producers
-	newProducerId, err := k.SelectNextSpanProducer(ctx, currentProducer, activeValidatorIDs, helper.GetProducerSetLimit(ctx), startBlock, endBlock, targetProducerID, excludedProducerIDs)
+	newProducerId, err := k.SelectNextSpanProducer(ctx, currentProducer, activeValidatorIDs, helper.GetProducerSetLimit(ctx), startBlock, endBlock, targetProducerID, excludedProducerIDs, fallbackToActiveSet...)
 	if err != nil {
 		return err
 	}
@@ -237,7 +242,7 @@ func (k *Keeper) ClearLatestFailedProducer(ctx context.Context) error {
 
 // SelectNextSpanProducer selects the next producer for a new span.
 // It calculates the candidate set, filters by active producers, and selects one.
-func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64, activeValidatorIDs map[uint64]struct{}, producerSetLimit, startBlock, endBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}) (uint64, error) {
+func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64, activeValidatorIDs map[uint64]struct{}, producerSetLimit, startBlock, endBlock uint64, targetProducerID uint64, excludedProducerIDs map[uint64]struct{}, fallbackToActiveSet ...bool) (uint64, error) {
 	candidates, err := k.CalculateProducerSet(ctx, producerSetLimit)
 	if err != nil {
 		return 0, fmt.Errorf("failed to calculate producer set: %w", err)
@@ -268,8 +273,8 @@ func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64,
 		activeCandidates = filterExcludedProducers(newCandidates, excludedProducerIDs)
 	}
 
-	// Post-Ithaca, recover a candidate so the future-span path can't hand SelectProducer an empty set (see eligibleProducerFallback).
-	if len(activeCandidates) == 0 && helper.IsIthaca(ctx.BlockHeight()) {
+	// Post-Ithaca, recover a candidate so the future-span path (the only opt-in via fallbackToActiveSet) can't hand SelectProducer an empty set (see eligibleProducerFallback).
+	if len(activeCandidates) == 0 && len(fallbackToActiveSet) > 0 && fallbackToActiveSet[0] && helper.IsIthaca(ctx.BlockHeight()) {
 		activeCandidates = k.eligibleProducerFallback(ctx, currentProducer, activeValidatorIDs, excludedProducerIDs)
 	}
 	// If the declaring producer requested a specific replacement, try to honor it.

--- a/x/bor/keeper/veblop.go
+++ b/x/bor/keeper/veblop.go
@@ -268,6 +268,10 @@ func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64,
 		activeCandidates = filterExcludedProducers(newCandidates, excludedProducerIDs)
 	}
 
+	// Post-Ithaca, recover a candidate so the future-span path can't hand SelectProducer an empty set (see eligibleProducerFallback).
+	if len(activeCandidates) == 0 && helper.IsIthaca(ctx.BlockHeight()) {
+		activeCandidates = k.eligibleProducerFallback(ctx, currentProducer, activeValidatorIDs, excludedProducerIDs)
+	}
 	// If the declaring producer requested a specific replacement, try to honor it.
 	// The target must still be an active candidate and not down for the range.
 	// If any check fails, we fall through to round-robin rather than blocking span creation.

--- a/x/bor/keeper/veblop_producer_fallback.go
+++ b/x/bor/keeper/veblop_producer_fallback.go
@@ -1,0 +1,57 @@
+package keeper
+
+import (
+	"slices"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// eligibleProducerFallback returns a deterministic candidate set for the degenerate case
+// where producer election leaves no selectable candidate other than the current producer
+// (the elected set has collapsed to the lone incumbent, or every alternative was filtered
+// out). It draws from the caller's active set (milestone supporters in the future-span
+// path, latest active producers in the rotation paths) first, then the full validator set,
+// each sorted ascending with the current and excluded producers removed.
+//
+// In the future-span (milestone) path this is always non-empty: a >2/3 milestone that
+// excludes the current producer leaves a non-empty supporting set, so SelectProducer never
+// receives an empty slice there and the PreBlocker halt cannot occur. In the non-fatal
+// rotation / pending-stall paths it may legitimately return empty (e.g. every producer is
+// failed/excluded); those callers already treat an empty selection as "skip this rotation
+// and retry", so the result is intentionally not forced non-empty — reinstalling an
+// excluded producer would defeat the rotation those paths exist to perform.
+func (k *Keeper) eligibleProducerFallback(ctx sdk.Context, currentProducer uint64, activeValidatorIDs, excludedProducerIDs map[uint64]struct{}) []uint64 {
+	if c := sortedEligibleProducers(activeValidatorIDs, currentProducer, excludedProducerIDs); len(c) > 0 {
+		return c
+	}
+
+	valSet, err := k.sk.GetValidatorSet(ctx)
+	if err != nil {
+		k.Logger(ctx).Error("Failed to get validator set for producer fallback", "error", err)
+		return nil
+	}
+
+	valIDs := make(map[uint64]struct{}, len(valSet.Validators))
+	for _, v := range valSet.Validators {
+		valIDs[v.ValId] = struct{}{}
+	}
+	return sortedEligibleProducers(valIDs, currentProducer, excludedProducerIDs)
+}
+
+// sortedEligibleProducers returns the ids in set, ascending, omitting the current producer
+// and any excluded producer. Sorting makes the result deterministic across validators (Go
+// map iteration order is not).
+func sortedEligibleProducers(set map[uint64]struct{}, currentProducer uint64, excluded map[uint64]struct{}) []uint64 {
+	ids := make([]uint64, 0, len(set))
+	for id := range set {
+		if id == currentProducer {
+			continue
+		}
+		if _, isExcluded := excluded[id]; isExcluded {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/x/bor/keeper/veblop_producer_fallback.go
+++ b/x/bor/keeper/veblop_producer_fallback.go
@@ -9,17 +9,15 @@ import (
 // eligibleProducerFallback returns a deterministic candidate set for the degenerate case
 // where producer election leaves no selectable candidate other than the current producer
 // (the elected set has collapsed to the lone incumbent, or every alternative was filtered
-// out). It draws from the caller's active set (milestone supporters in the future-span
-// path, latest active producers in the rotation paths) first, then the full validator set,
-// each sorted ascending with the current and excluded producers removed.
+// out). It draws from the caller's active set (the milestone supporters) first, then the
+// full validator set, each sorted ascending with the current and excluded producers removed.
 //
-// In the future-span (milestone) path this is always non-empty: a >2/3 milestone that
-// excludes the current producer leaves a non-empty supporting set, so SelectProducer never
-// receives an empty slice there and the PreBlocker halt cannot occur. In the non-fatal
-// rotation / pending-stall paths it may legitimately return empty (e.g. every producer is
-// failed/excluded); those callers already treat an empty selection as "skip this rotation
-// and retry", so the result is intentionally not forced non-empty — reinstalling an
-// excluded producer would defeat the rotation those paths exist to perform.
+// Only the future-span PreBlocker path reaches this, where an empty candidate set is a fatal
+// chain halt. There it is always non-empty: a >2/3 milestone that excludes the current
+// producer leaves a non-empty supporting set, so SelectProducer never receives an empty slice
+// and the halt cannot occur. The validator-set step is defense-in-depth for that guarantee;
+// the non-fatal rotation paths do not opt into this fallback and keep their skip-and-retry
+// behavior.
 func (k *Keeper) eligibleProducerFallback(ctx sdk.Context, currentProducer uint64, activeValidatorIDs, excludedProducerIDs map[uint64]struct{}) []uint64 {
 	if c := sortedEligibleProducers(activeValidatorIDs, currentProducer, excludedProducerIDs); len(c) > 0 {
 		return c

--- a/x/bor/keeper/veblop_producer_fallback_test.go
+++ b/x/bor/keeper/veblop_producer_fallback_test.go
@@ -1,0 +1,181 @@
+package keeper
+
+import (
+	"errors"
+	"testing"
+
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/helper"
+	bortestutil "github.com/0xPolygon/heimdall-v2/x/bor/testutil"
+	"github.com/0xPolygon/heimdall-v2/x/bor/types"
+	staketypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
+)
+
+func newFallbackKeeper(t *testing.T) (Keeper, sdk.Context, *bortestutil.MockStakeKeeper) {
+	t.Helper()
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: cmttime.Now()})
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+
+	ctrl := gomock.NewController(t)
+	sk := bortestutil.NewMockStakeKeeper(ctrl)
+	k := NewKeeper(
+		encCfg.Codec,
+		runtime.NewKVStoreService(key),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		bortestutil.NewMockChainManagerKeeper(ctrl),
+		sk,
+		bortestutil.NewMockMilestoneKeeper(ctrl),
+		nil,
+	)
+	require.NoError(t, k.SetParams(ctx, types.DefaultParams()))
+	return k, ctx, sk
+}
+
+func valSetOf(ids ...uint64) staketypes.ValidatorSet {
+	vals := make([]*staketypes.Validator, 0, len(ids))
+	for _, id := range ids {
+		vals = append(vals, &staketypes.Validator{ValId: id, VotingPower: 10})
+	}
+	return staketypes.ValidatorSet{Validators: vals}
+}
+
+func TestEligibleProducerFallback(t *testing.T) {
+	t.Run("prefers the active set and never reads the validator set", func(t *testing.T) {
+		k, ctx, _ := newFallbackKeeper(t) // GetValidatorSet must not be called
+		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, nil)
+		require.Equal(t, []uint64{2, 3}, got)
+	})
+
+	t.Run("falls back to the validator set when the active set is empty", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3, 4), nil)
+		got := k.eligibleProducerFallback(ctx, 2, map[uint64]struct{}{}, nil)
+		require.Equal(t, []uint64{1, 3, 4}, got)
+	})
+
+	t.Run("honors the excluded set in the validator-set fallback", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3, 4), nil)
+		got := k.eligibleProducerFallback(ctx, 2, map[uint64]struct{}{}, map[uint64]struct{}{3: {}})
+		require.Equal(t, []uint64{1, 4}, got)
+	})
+
+	t.Run("returns nil when the validator set cannot be read", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(staketypes.ValidatorSet{}, errors.New("boom"))
+		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{}, nil)
+		require.Nil(t, got)
+	})
+}
+
+// SelectNextSpanProducer must not hand SelectProducer an empty slice once the elected set
+// has collapsed to the current producer: pre-Ithaca it still errors (gate off), post-Ithaca
+// the fallback supplies a replacement from the active set.
+func TestSelectNextSpanProducerEmptyCandidateFallback(t *testing.T) {
+	k, ctx, sk := newFallbackKeeper(t)
+
+	oldZurich, oldIthaca := helper.GetZurichHardforkHeight(), helper.GetIthacaHeight()
+	t.Cleanup(func() {
+		helper.SetZurichHardforkHeight(oldZurich)
+		helper.SetIthacaHeight(oldIthaca)
+	})
+	helper.SetZurichHardforkHeight(1)
+
+	vals := valSetOf(1, 2, 3, 4)
+	sk.EXPECT().GetValidatorSet(gomock.Any()).Return(vals, nil).AnyTimes()
+	// Every validator ranks only producer 1, so CalculateProducerSet collapses to [1].
+	for _, v := range vals.Validators {
+		require.NoError(t, k.SetProducerVotes(ctx, v.ValId, types.ProducerVotes{Votes: []uint64{1}}))
+	}
+	ctx = ctx.WithBlockHeight(10)
+	limit := helper.GetProducerSetLimit(ctx)
+
+	candidates, err := k.CalculateProducerSet(ctx, limit)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, candidates)
+
+	// Current producer (1) is excluded from the active set, emptying the candidate list.
+	active := map[uint64]struct{}{2: {}, 3: {}, 4: {}}
+
+	helper.SetIthacaHeight(0) // gate off -> still errors
+	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
+	require.Error(t, err)
+
+	helper.SetIthacaHeight(1) // gate on -> fallback selects a non-current producer
+	got, err := k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, uint64(1), got)
+	require.Contains(t, []uint64{2, 3, 4}, got)
+}
+
+func TestSortedEligibleProducers(t *testing.T) {
+	set := func(ids ...uint64) map[uint64]struct{} {
+		m := make(map[uint64]struct{}, len(ids))
+		for _, id := range ids {
+			m[id] = struct{}{}
+		}
+		return m
+	}
+
+	tests := []struct {
+		name            string
+		in              map[uint64]struct{}
+		currentProducer uint64
+		excluded        map[uint64]struct{}
+		want            []uint64
+	}{
+		{
+			name:            "sorts ascending and drops current",
+			in:              set(5, 2, 4, 3),
+			currentProducer: 4,
+			want:            []uint64{2, 3, 5},
+		},
+		{
+			name:            "drops excluded",
+			in:              set(1, 2, 3, 4),
+			currentProducer: 1,
+			excluded:        set(3),
+			want:            []uint64{2, 4},
+		},
+		{
+			name:            "current and excluded combined empty the set",
+			in:              set(1, 2),
+			currentProducer: 1,
+			excluded:        set(2),
+			want:            []uint64{},
+		},
+		{
+			name:            "empty input",
+			in:              set(),
+			currentProducer: 1,
+			want:            []uint64{},
+		},
+		{
+			name:            "nil excluded is a no-op",
+			in:              set(9, 7, 8),
+			currentProducer: 7,
+			excluded:        nil,
+			want:            []uint64{8, 9},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sortedEligibleProducers(tc.in, tc.currentProducer, tc.excluded)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/x/bor/keeper/veblop_producer_fallback_test.go
+++ b/x/bor/keeper/veblop_producer_fallback_test.go
@@ -82,8 +82,10 @@ func TestEligibleProducerFallback(t *testing.T) {
 }
 
 // SelectNextSpanProducer must not hand SelectProducer an empty slice once the elected set
-// has collapsed to the current producer: pre-Ithaca it still errors (gate off), post-Ithaca
-// the fallback supplies a replacement from the active set.
+// has collapsed to the current producer, but only when the caller opts in (the future-span
+// path). Pre-Ithaca it still errors (gate off); post-Ithaca without opt-in it still errors
+// (non-fatal paths keep skip-and-retry); post-Ithaca with opt-in the fallback supplies a
+// replacement from the active set.
 func TestSelectNextSpanProducerEmptyCandidateFallback(t *testing.T) {
 	k, ctx, sk := newFallbackKeeper(t)
 
@@ -110,12 +112,20 @@ func TestSelectNextSpanProducerEmptyCandidateFallback(t *testing.T) {
 	// Current producer (1) is excluded from the active set, emptying the candidate list.
 	active := map[uint64]struct{}{2: {}, 3: {}, 4: {}}
 
-	helper.SetIthacaHeight(0) // gate off -> still errors
-	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
+	helper.SetIthacaHeight(0) // gate off -> still errors even with opt-in
+	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil, true)
 	require.Error(t, err)
 
-	helper.SetIthacaHeight(1) // gate on -> fallback selects a non-current producer
-	got, err := k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
+	helper.SetIthacaHeight(1)
+	// Without opt-in the non-fatal paths keep their skip-and-retry behavior: still errors,
+	// whether the flag is omitted entirely or passed explicitly false.
+	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
+	require.Error(t, err)
+	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil, false)
+	require.Error(t, err)
+
+	// With opt-in (the future-span path) the fallback selects a non-current producer.
+	got, err := k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil, true)
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(1), got)
 	require.Contains(t, []uint64{2, 3, 4}, got)

--- a/x/bor/keeper/veblop_producer_fallback_test.go
+++ b/x/bor/keeper/veblop_producer_fallback_test.go
@@ -117,10 +117,8 @@ func TestSelectNextSpanProducerEmptyCandidateFallback(t *testing.T) {
 	require.Error(t, err)
 
 	helper.SetIthacaHeight(1)
-	// Without opt-in the non-fatal paths keep their skip-and-retry behavior: still errors,
-	// whether the flag is omitted entirely or passed explicitly false.
-	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil)
-	require.Error(t, err)
+	// Without opt-in the non-fatal paths keep their skip-and-retry behavior: still errors
+	// when fallbackToActiveSet is false.
 	_, err = k.SelectNextSpanProducer(ctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil, false)
 	require.Error(t, err)
 

--- a/x/bor/keeper/veblop_test.go
+++ b/x/bor/keeper/veblop_test.go
@@ -534,7 +534,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducer() {
 			startBlock := lastSpan.EndBlock + 1
 			endBlock := lastSpan.EndBlock + params.SpanDuration
 
-			result, err := borKeeper.SelectNextSpanProducer(ctx, 1, tc.activeValidatorIDs, tc.producerSetLimit, startBlock, endBlock, types.RoundRobinDefault, tc.excludedProducerIDs)
+			result, err := borKeeper.SelectNextSpanProducer(ctx, 1, tc.activeValidatorIDs, tc.producerSetLimit, startBlock, endBlock, types.RoundRobinDefault, tc.excludedProducerIDs, false)
 
 			if tc.expectedError {
 				require.Error(err)
@@ -623,7 +623,7 @@ func (s *KeeperTestSuite) TestAddNewVeBlopSpan() {
 	borChainID := "137"
 	heimdallBlock := uint64(5000)
 
-	err := borKeeper.AddNewVeBlopSpan(ctx, 1, startBlock, endBlock, borChainID, active, heimdallBlock, types.RoundRobinDefault, nil)
+	err := borKeeper.AddNewVeBlopSpan(ctx, 1, startBlock, endBlock, borChainID, active, heimdallBlock, types.RoundRobinDefault, nil, false)
 	require.NoError(err)
 
 	span, err := borKeeper.GetSpan(ctx, 1)
@@ -692,7 +692,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		setupMocks()
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(3), result)
 	})
@@ -705,7 +705,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		require.NoError(borKeeper.ProducerPlannedDowntime.Set(ctx, 3, types.BlockRange{StartBlock: 1000, EndBlock: 2500}))
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(2), result)
 
@@ -718,7 +718,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		setupMocks()
 
 		active := map[uint64]struct{}{2: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(2), result)
 	})
@@ -729,7 +729,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		setupMocks()
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, types.RoundRobinDefault, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, types.RoundRobinDefault, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(2), result)
 	})
@@ -740,7 +740,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		setupMocks()
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 999, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 999, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(2), result)
 	})
@@ -752,7 +752,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		setupMocks()
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 2, active, 2, 1002, 2001, 2, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 2, active, 2, 1002, 2001, 2, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(3), result) // round-robin: next after current=2 in [2,3] is 3
 	})
@@ -766,7 +766,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		require.NoError(borKeeper.ProducerPlannedDowntime.Set(ctx, 3, types.BlockRange{StartBlock: 1500, EndBlock: 2500}))
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(2), result)
 
@@ -782,7 +782,7 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		require.NoError(borKeeper.ProducerPlannedDowntime.Set(ctx, 3, types.BlockRange{StartBlock: 500, EndBlock: 900}))
 
 		active := map[uint64]struct{}{2: {}, 3: {}}
-		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil)
+		result, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 3, nil, false)
 		require.NoError(err)
 		require.Equal(uint64(3), result)
 
@@ -797,14 +797,14 @@ func (s *KeeperTestSuite) TestSelectNextSpanProducerWithTarget() {
 		active := map[uint64]struct{}{2: {}, 3: {}}
 
 		// With invalid target (falls through)
-		resultWithTarget, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 999, nil)
+		resultWithTarget, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 999, nil, false)
 		require.NoError(err)
 
 		require.NoError(borKeeper.ClearProducerVotes(ctx))
 		setupMocks()
 
 		// Without target
-		resultNoTarget, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 0, nil)
+		resultNoTarget, err := borKeeper.SelectNextSpanProducer(ctx, 1, active, 2, 1002, 2001, 0, nil, false)
 		require.NoError(err)
 
 		require.Equal(resultNoTarget, resultWithTarget)
@@ -843,7 +843,7 @@ func (s *KeeperTestSuite) TestAddNewVeBlopSpanWithTarget() {
 	active := map[uint64]struct{}{1: {}, 2: {}, 3: {}}
 
 	// Valid target=3 should be selected over round-robin
-	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, 3, nil)
+	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, 3, nil, false)
 	require.NoError(err)
 
 	span, err := borKeeper.GetSpan(ctx, 1)
@@ -886,7 +886,7 @@ func (s *KeeperTestSuite) TestAddNewVeBlopSpanTargetFallthrough() {
 
 	active := map[uint64]struct{}{1: {}, 2: {}, 3: {}}
 
-	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, 3, nil)
+	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, 3, nil, false)
 	require.NoError(err)
 
 	span, err := borKeeper.GetSpan(ctx, 1)
@@ -915,7 +915,7 @@ func (s *KeeperTestSuite) TestAddNewVeBlopSpanCalculateProducerSetError() {
 
 	active := map[uint64]struct{}{}
 
-	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, types.RoundRobinDefault, nil)
+	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, types.RoundRobinDefault, nil, false)
 	require.Error(err)
 	require.Contains(err.Error(), "validator set error")
 }
@@ -958,7 +958,7 @@ func (s *KeeperTestSuite) TestAddNewVeBlopSpanGetValidatorSetError() {
 
 	active := map[uint64]struct{}{1: {}, 2: {}}
 
-	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, types.RoundRobinDefault, nil)
+	err := borKeeper.AddNewVeBlopSpan(ctx, 1, 200, 300, "137", active, 5000, types.RoundRobinDefault, nil, false)
 	require.Error(err)
 	require.Contains(err.Error(), "validator set unavailable")
 }


### PR DESCRIPTION
## Summary

veBlop span producer selection (`SelectNextSpanProducer`) could hand `SelectProducer` an empty candidate slice when the elected producer set collapsed to only the current producer and that producer was filtered out of the active/supporting set. In the future-span path the resulting error propagates out of `PreBlocker` before the milestone/span commit, so block finalization cannot make progress — a deterministic halt with no self-heal.

This adds a deterministic, **Ithaca-gated** fallback that fires **only on the future-span path**. `SelectNextSpanProducer` / `AddNewVeBlopSpan` take an opt-in `fallbackToActiveSet` flag, and only `checkAndAddFutureSpan` (the fatal `PreBlocker` path) passes it. When that path's candidate list would otherwise be empty, the fallback draws a replacement from the caller's active set (the milestone supporters), then from the full validator set as defense-in-depth, each sorted ascending and excluding the current and excluded producers. In the future-span path this is always non-empty — a >2/3 milestone that excludes the current producer leaves a non-empty supporting set — so producer selection no longer errors there.

The non-fatal rotation / pending-stall / side-message paths **do not opt in** and are unchanged: post-Ithaca they still hit `SelectProducer([])` → `"no candidates found"` → skip-and-retry, exactly as before. Scoping the fallback to the future-span path (rather than sharing it across all callers) keeps the rotation paths' self-heal contract intact and avoids reinstating a known-failed producer there.

The fallback helpers live in `x/bor/keeper/veblop_producer_fallback.go` (`eligibleProducerFallback`, `sortedEligibleProducers`) to keep `veblop.go` within size/complexity budgets.

## Executed tests

- **Unit (`x/bor/keeper`)**: `eligibleProducerFallback` branch coverage (active-set preference, validator-set fallback, excluded-set handling, validator-set read error → nil), `sortedEligibleProducers`, and `SelectNextSpanProducer`'s empty-candidate path — pre-Ithaca still errors; post-Ithaca **without** opt-in still errors (rotation-path behavior preserved); post-Ithaca **with** opt-in falls back to a non-current producer.
- **App-level regression (`app`)**: `PreBlocker` future-span creation when the elected set has collapsed to the current producer and it withholds its milestone vote — pre-Ithaca still errors (`no candidates found`), post-Ithaca commits the milestone + span with a milestone-supporting validator as the new producer.
- Full `x/bor/...` and `app/...` suites, `go vet`, `gofmt` clean.
- **diffguard** diff-mode incl. mutation testing: passing (Tier-1 logic mutation kill 100%, Tier-2 100%).
- **Kurtosis devnet**: confirmed the fallback fires on a running network — the empty-candidate selection error no longer occurs and spans are created with the fallback producer. Note: a long-running devnet in which every validator votes for a single producer is *intentionally pathological* (a permanent single-elected-producer state oscillates regardless of this change) and is **not required for verification**; the deterministic unit/app tests above cover the behavior.

## Rollout notes

- **Consensus-affecting**: changes deterministic producer selection in the degenerate empty-candidate case, on the future-span path only. **Gated behind the Ithaca hardfork height**, which is unset (`0`) on mainnet, Amoy, and local today, so behavior is unchanged until the coordinated Ithaca activation — it ships with that upgrade alongside the related forced-span-rotation work.
- No state schema, store, migration, proto, or genesis changes. Backwards-compatible until the fork height.
