### PR TITLE
app: cap messages per tx in CheckTx

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -103,6 +103,12 @@ const (
 	// HTTP header constants
 	headerContentType       = "Content-Type"
 	mimeTypeApplicationJSON = "application/json"
+
+	// maxMsgsPerTx bounds how many messages a single tx may carry through CheckTx.
+	// Capping here avoids mempool amplification where one oversized tx packs thousands of messages,
+	// forcing decode and validation on every gossip hop before rejection.
+	// Enforced in CheckTx only, so block validity and consensus are unaffected.
+	maxMsgsPerTx = 16
 )
 
 var (
@@ -496,6 +502,12 @@ func (app *HeimdallApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx
 		}
 
 		msgs := tx.GetMsgs()
+		if len(msgs) > maxMsgsPerTx {
+			return &abci.ResponseCheckTx{
+				Code: sdkerrors.ErrTxTooLarge.ABCICode(),
+				Log:  fmt.Sprintf("tx carries %d messages, exceeds per-tx limit of %d", len(msgs), maxMsgsPerTx),
+			}, nil
+		}
 		for _, msg := range msgs {
 			// Check for MsgVoteProducers and apply VEBLOP validation
 			if _, ok := msg.(*borTypes.MsgVoteProducers); ok {

--- a/app/app.go
+++ b/app/app.go
@@ -105,8 +105,10 @@ const (
 	mimeTypeApplicationJSON = "application/json"
 
 	// maxMsgsPerTx bounds how many messages a single tx may carry through CheckTx.
-	// Capping here avoids mempool amplification where one oversized tx packs thousands of messages,
-	// forcing decode and validation on every gossip hop before rejection.
+	// The tx is still decoded once (needed to count its messages), but capping
+	// here skips the per-message veBlop validation loop and the downstream ante
+	// processing in BaseApp.CheckTx that an oversized multi-message tx would
+	// otherwise trigger on every gossip hop.
 	// Enforced in CheckTx only, so block validity and consensus are unaffected.
 	maxMsgsPerTx = 16
 )

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -272,4 +274,70 @@ func TestEndBlockerEmitsTransferEvent(t *testing.T) {
 	require.NotNil(t, amountAttr)
 	require.NotNil(t, amountAttr.Value, "amount attribute value should not be nil")
 	require.Equal(t, feeAmount.String(), amountAttr.Value)
+}
+
+// CheckTx rejects txs carrying more than maxMsgsPerTx messages before the
+// per-message validation loop, neutralizing the oversized-tx mempool flood.
+func TestCheckTx_RejectsTxExceedingMsgCap(t *testing.T) {
+	priv, app, ctx, _ := SetupAppWithABCICtxAndValidators(t, 1)
+
+	signer := sdk.AccAddress(priv.PubKey().Address()).String()
+	makeMsgs := func(n int) []sdk.Msg {
+		msgs := make([]sdk.Msg, n)
+		for i := range msgs {
+			msgs[i] = &banktypes.MsgSend{
+				FromAddress: signer,
+				ToAddress:   signer,
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin("pol", 1)),
+			}
+		}
+		return msgs
+	}
+
+	cases := []struct {
+		name       string
+		count      int
+		wantCapHit bool
+	}{
+		{name: "single message passes the cap", count: 1, wantCapHit: false},
+		{name: "at cap passes", count: maxMsgsPerTx, wantCapHit: false},
+		{name: "one over cap is rejected", count: maxMsgsPerTx + 1, wantCapHit: true},
+		{name: "far over cap is rejected", count: maxMsgsPerTx * 100, wantCapHit: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			txBytes, err := buildSignedMultiMsgTx(makeMsgs(tc.count), ctx, priv, app)
+			require.NoError(t, err)
+
+			resp, err := app.CheckTx(&abci.RequestCheckTx{Tx: txBytes, Type: abci.CheckTxType_New})
+			require.NoError(t, err)
+
+			if tc.wantCapHit {
+				require.Equal(t, sdkerrors.ErrTxTooLarge.ABCICode(), resp.Code)
+				require.Contains(t, resp.Log, "exceeds per-tx limit")
+			} else {
+				require.NotEqual(t, sdkerrors.ErrTxTooLarge.ABCICode(), resp.Code,
+					"under-cap tx must not be rejected by the message cap; log=%s", resp.Log)
+			}
+		})
+	}
+}
+
+// The cap guard only applies to fresh CheckTx, not recheck, matching the
+// veBlop guards it sits alongside.
+func TestCheckTx_MsgCapSkippedOnRecheck(t *testing.T) {
+	priv, app, ctx, _ := SetupAppWithABCICtxAndValidators(t, 1)
+
+	signer := sdk.AccAddress(priv.PubKey().Address()).String()
+	msgs := make([]sdk.Msg, maxMsgsPerTx+1)
+	for i := range msgs {
+		msgs[i] = &banktypes.MsgSend{FromAddress: signer, ToAddress: signer, Amount: sdk.NewCoins(sdk.NewInt64Coin("pol", 1))}
+	}
+	txBytes, err := buildSignedMultiMsgTx(msgs, ctx, priv, app)
+	require.NoError(t, err)
+
+	resp, err := app.CheckTx(&abci.RequestCheckTx{Tx: txBytes, Type: abci.CheckTxType_Recheck})
+	require.NoError(t, err)
+	require.NotEqual(t, sdkerrors.ErrTxTooLarge.ABCICode(), resp.Code)
 }


### PR DESCRIPTION
## Summary

Adds a per-transaction message-count bound enforced at `CheckTx` (mempool admission). A single transaction may now carry at most `maxMsgsPerTx = 16` top-level messages; a transaction exceeding that is rejected with
`ErrTxTooLarge` before the per-message decode/validation loop runs.

In normal operation every Heimdall transaction carries exactly **one** top-level message — all submission paths (bridge broadcaster and CLI) build single-message txs, and there is no batching anywhere, including the
clerk/state-sync path. The cap of 16 is therefore 16× the real maximum and cannot reject legitimate traffic; it matches the existing `maxMultiSendOutputs = 16` bound already used in the ante stack.

Without this bound, a single large multi-message transaction forces every node to do O(number-of-messages) decode and validation work on each gossip hop before the transaction is ultimately rejected downstream. Capping the
message count at admission removes that amplification cheaply.

Note: the existing `SideTxDecorator` only bounds the number of *side* messages per tx (≤1), not the total message count — so this guard is additive and is the right place to bound `len(tx.GetMsgs())` directly.

## Executed tests

- Unit test (`app/app_test.go`): drives real encoded txs through `CheckTx` with counts 1 / 16 / 17 / 1600 (+ a recheck-path case), asserting the boundary: `>16` → `ErrTxTooLarge`, `≤16` → passes the cap into the ante chain.
- Diffguard (with mutation): mutation 100% (3/3), cognitive-complexity / dependency / dead-code all clean. The only flag is `CheckTx` function length (57 lines vs the 50 threshold) — pre-existing (base was already 51; this change adds 6). Left as-is to avoid churning the consensus-adjacent veBlop loop in `CheckTx`; a follow-up can decompose that function.
- Kurtosis small devnet (built from this branch), confirmed end-to-end:
  - A 2000-message and a 17-message tx are rejected at `CheckTx` with `ErrTxTooLarge` ("exceeds per-tx limit of 16"); a 16-message tx passes the cap and proceeds to the ante chain (fails later at signature check, not the cap). Boundary is exact and fires before decode.
  - Regression: state syncs (clerk `MsgEventRecord`), checkpoints, and spans all commit normally with the cap in place — no legitimate flow is affected.
  - Under a burst of oversized txs, heimdall CPU stayed flat and the chain kept producing blocks (rejected pre-decode → no processing cost).

## Rollout notes

- **Not consensus-affecting, no hardfork required.** The bound is enforced only in the overridden `CheckTx` (mempool admission + gossip), not in `DeliverTx` / `ProcessProposal` / block execution. Block validity and the app hash are unchanged, so no coordinated upgrade is needed.
- **Backwards-compatible.** No proto, state, or API changes; legitimate single-message traffic is unaffected.
- Beneficial to prioritise on sentries / RPC nodes (they front the public API and gossip mempool traffic), but it can roll out incrementally.
- Follow-ups tracked separately (optional): rejection observability (a Prometheus counter and/or a rate-limited log) and a hardfork-gated `ValidateBasic` for the affected message type.