### PR TITLE
bor: validate veblop span producer against current validator set

### DIFF
--- a/app/veblop_producer_fallback_test.go
+++ b/app/veblop_producer_fallback_test.go
@@ -175,6 +175,64 @@ func TestVeBlopEmptyElectedSetPostIthacaFallsBack(t *testing.T) {
 	require.True(t, ok, "new producer %d should be one of the milestone supporters", newProducer)
 }
 
+// A supporter drawn from the penultimate set may have exited by the time the future span is
+// frozen: its record survives with zero power and it is absent from the current validator set.
+// The fallback must not select it, otherwise the span's sole producer has zero power, which Bor
+// reads as a validator deletion and cannot build a producer snapshot from (chain halt). The
+// selected producer must instead be a positive-power member of the frozen validator set.
+func TestVeBlopFallbackSkipsExitedSupporter(t *testing.T) {
+	s := stageSingletonProducer(t)
+
+	oldIthaca := helper.GetIthacaHeight()
+	helper.SetIthacaHeight(s.height)
+	t.Cleanup(func() { helper.SetIthacaHeight(oldIthaca) })
+
+	// Deactivate the lowest-ID supporter — the one the deterministic (ascending) fallback would
+	// otherwise pick first — reproducing an approved MsgValidatorExit at this transition.
+	removed := s.validators[1]
+	for _, validator := range s.validators[2:] {
+		if validator.ValId < removed.ValId {
+			removed = validator
+		}
+	}
+	deactivated := removed.Copy()
+	deactivated.EndEpoch = 1
+	deactivated.VotingPower = 0
+	require.NoError(t, s.app.StakeKeeper.AddValidator(s.ctx, *deactivated))
+
+	// The real EndBlock update keeps the older snapshot used for vote-extension tallying and
+	// removes the validator from the current set used to freeze the new span.
+	updates, err := s.app.StakeKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Zero(t, updates[0].Power)
+
+	_, err = s.app.PreBlocker(s.ctx, &abci.RequestFinalizeBlock{
+		Height:          s.height,
+		Txs:             [][]byte{s.extCommitBytes},
+		ProposerAddress: common.FromHex(s.validators[1].Signer),
+	})
+	require.NoError(t, err)
+
+	span, err := s.app.BorKeeper.GetLastSpan(s.ctx)
+	require.NoError(t, err)
+	require.Equal(t, s.lastSpan.Id+1, span.Id)
+	require.Len(t, span.SelectedProducers, 1)
+
+	producer := span.SelectedProducers[0]
+	require.NotEqual(t, removed.ValId, producer.ValId, "exited validator must not be selected as producer")
+	require.Positive(t, producer.VotingPower)
+
+	inFrozenSet := false
+	for _, validator := range span.ValidatorSet.Validators {
+		if validator.ValId == producer.ValId {
+			inFrozenSet = true
+		}
+		require.NotEqual(t, removed.ValId, validator.ValId, "exited validator must be absent from the frozen set")
+	}
+	require.True(t, inFrozenSet, "selected producer must be a member of the frozen validator set")
+}
+
 func milestoneExtendedCommit(t *testing.T, chainID string, height int64, validators []*stakeTypes.Validator, validatorPrivKeys []cmtsecp256k1.PrivKey, currentProducerID uint64, milestone *milestoneTypes.MilestoneProposition) []byte {
 	t.Helper()
 	require.Len(t, validatorPrivKeys, len(validators))

--- a/x/bor/keeper/veblop.go
+++ b/x/bor/keeper/veblop.go
@@ -39,6 +39,16 @@ func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, start
 		return err
 	}
 
+	// Post-Ithaca, the producer serialized into the span must have positive voting power. Check the
+	// resolved record itself, not the validator-set snapshot by id: an approved exit earlier in the
+	// same block zeroes the individual validator record while the current-set snapshot is not
+	// refreshed until the stake module's PreBlock, so a by-id snapshot check can read stale positive
+	// power for an already-exited validator. Bor reads a zero-power producer as a validator deletion
+	// and panics snapshot construction, so fail closed rather than commit it.
+	if helper.IsIthaca(ctx.BlockHeight()) && newProducer.VotingPower <= 0 {
+		return fmt.Errorf("selected producer %d has non-positive voting power", newProducerId)
+	}
+
 	lastSpan, err := k.GetLastSpan(ctx)
 	if err != nil {
 		return err
@@ -62,6 +72,32 @@ func (k *Keeper) AddNewVeBlopSpan(ctx sdk.Context, currentProducer uint64, start
 	}
 
 	return k.SetLastSpanBlock(ctx, heimdallBlock)
+}
+
+// filterToCurrentValidators drops any id that is not a positive-power member of the current
+// validator set, preserving order. An exited validator's record survives with zero power and is
+// absent from the current set; keeping it out prevents freezing it as a span producer.
+func (k *Keeper) filterToCurrentValidators(ctx sdk.Context, ids []uint64) ([]uint64, error) {
+	if len(ids) == 0 {
+		return ids, nil
+	}
+	valSet, err := k.sk.GetValidatorSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	eligible := make(map[uint64]struct{}, len(valSet.Validators))
+	for _, v := range valSet.Validators {
+		if v.VotingPower > 0 {
+			eligible[v.ValId] = struct{}{}
+		}
+	}
+	filtered := make([]uint64, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := eligible[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	return filtered, nil
 }
 
 func (k *Keeper) FindCurrentProducerID(ctx context.Context, blockNum uint64) (uint64, error) {
@@ -261,6 +297,18 @@ func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64,
 	// active set still triggers the fallback below instead of handing an empty slice to SelectProducer.
 	activeCandidates = filterExcludedProducers(activeCandidates, excludedProducerIDs)
 
+	// Post-Ithaca, drop any candidate that is not a positive-power member of the current validator
+	// set. Candidates come from producer votes and the milestone supporter set, both of which can
+	// still name a validator that has since exited (its record survives with zero power, absent from
+	// the current set). Freezing such a producer yields a span Bor cannot build a snapshot from.
+	// Filtering before the empty check routes a fully-exited set into the fallback below.
+	ithaca := helper.IsIthaca(ctx.BlockHeight())
+	if ithaca {
+		if activeCandidates, err = k.filterToCurrentValidators(ctx, activeCandidates); err != nil {
+			return 0, err
+		}
+	}
+
 	// If no candidate is available after threshold filtering,
 	// rotate the original candidate list to the next producer EVEN IF the producer is not active.
 	if len(activeCandidates) == 0 {
@@ -271,10 +319,15 @@ func (k *Keeper) SelectNextSpanProducer(ctx sdk.Context, currentProducer uint64,
 			}
 		}
 		activeCandidates = filterExcludedProducers(newCandidates, excludedProducerIDs)
+		if ithaca {
+			if activeCandidates, err = k.filterToCurrentValidators(ctx, activeCandidates); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	// Post-Ithaca, recover a candidate so the future-span path (the only opt-in via fallbackToActiveSet) can't hand SelectProducer an empty set (see eligibleProducerFallback).
-	if len(activeCandidates) == 0 && fallbackToActiveSet && helper.IsIthaca(ctx.BlockHeight()) {
+	if len(activeCandidates) == 0 && fallbackToActiveSet && ithaca {
 		activeCandidates = k.eligibleProducerFallback(ctx, currentProducer, activeValidatorIDs, excludedProducerIDs)
 	}
 	// If the declaring producer requested a specific replacement, try to honor it.

--- a/x/bor/keeper/veblop_producer_fallback.go
+++ b/x/bor/keeper/veblop_producer_fallback.go
@@ -12,28 +12,44 @@ import (
 // out). It draws from the caller's active set (the milestone supporters) first, then the
 // full validator set, each sorted ascending with the current and excluded producers removed.
 //
+// Every candidate is restricted to a positive-power member of the current validator set.
+// The active set carries milestone supporter IDs resolved against the penultimate validator
+// set, which can name a validator that has since exited: its record survives with zero power
+// and it is absent from the current set. Selecting such a validator freezes a span whose sole
+// producer has zero power, which Bor reads as a validator deletion and cannot build a producer
+// snapshot from. Intersecting with the current positive-power set keeps that producer out.
+//
 // Only the future-span PreBlocker path reaches this, where an empty candidate set is a fatal
-// chain halt. There it is always non-empty: a >2/3 milestone that excludes the current
-// producer leaves a non-empty supporting set, so SelectProducer never receives an empty slice
-// and the halt cannot occur. The validator-set step is defense-in-depth for that guarantee;
-// the non-fatal rotation paths do not opt into this fallback and keep their skip-and-retry
-// behavior.
+// chain halt. The current-validator-set step makes the result deterministically non-empty
+// whenever the set holds a positive-power validator other than the current and excluded
+// producers, so selection does not depend on how many supporters remain eligible. The non-fatal
+// rotation paths do not opt into this fallback and keep their skip-and-retry behavior.
 func (k *Keeper) eligibleProducerFallback(ctx sdk.Context, currentProducer uint64, activeValidatorIDs, excludedProducerIDs map[uint64]struct{}) []uint64 {
-	if c := sortedEligibleProducers(activeValidatorIDs, currentProducer, excludedProducerIDs); len(c) > 0 {
-		return c
-	}
-
 	valSet, err := k.sk.GetValidatorSet(ctx)
 	if err != nil {
 		k.Logger(ctx).Error("Failed to get validator set for producer fallback", "error", err)
 		return nil
 	}
 
-	valIDs := make(map[uint64]struct{}, len(valSet.Validators))
+	eligible := make(map[uint64]struct{}, len(valSet.Validators))
 	for _, v := range valSet.Validators {
-		valIDs[v.ValId] = struct{}{}
+		if v.VotingPower > 0 {
+			eligible[v.ValId] = struct{}{}
+		}
 	}
-	return sortedEligibleProducers(valIDs, currentProducer, excludedProducerIDs)
+
+	// Prefer the milestone supporters, restricted to currently-eligible validators.
+	supporters := make(map[uint64]struct{}, len(activeValidatorIDs))
+	for id := range activeValidatorIDs {
+		if _, ok := eligible[id]; ok {
+			supporters[id] = struct{}{}
+		}
+	}
+	if c := sortedEligibleProducers(supporters, currentProducer, excludedProducerIDs); len(c) > 0 {
+		return c
+	}
+
+	return sortedEligibleProducers(eligible, currentProducer, excludedProducerIDs)
 }
 
 // sortedEligibleProducers returns the ids in set, ascending, omitting the current producer

--- a/x/bor/keeper/veblop_producer_fallback_test.go
+++ b/x/bor/keeper/veblop_producer_fallback_test.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	storetypes "cosmossdk.io/store/types"
@@ -52,14 +53,44 @@ func valSetOf(ids ...uint64) staketypes.ValidatorSet {
 	return staketypes.ValidatorSet{Validators: vals}
 }
 
+func valSetOfPowers(powers map[uint64]int64) staketypes.ValidatorSet {
+	ids := make([]uint64, 0, len(powers))
+	for id := range powers {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	vals := make([]*staketypes.Validator, 0, len(ids))
+	for _, id := range ids {
+		vals = append(vals, &staketypes.Validator{ValId: id, VotingPower: powers[id]})
+	}
+	return staketypes.ValidatorSet{Validators: vals}
+}
+
 func TestEligibleProducerFallback(t *testing.T) {
-	t.Run("prefers the active set and never reads the validator set", func(t *testing.T) {
-		k, ctx, _ := newFallbackKeeper(t) // GetValidatorSet must not be called
+	t.Run("prefers supporters that are current positive-power validators", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3), nil)
 		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, nil)
 		require.Equal(t, []uint64{2, 3}, got)
 	})
 
-	t.Run("falls back to the validator set when the active set is empty", func(t *testing.T) {
+	t.Run("drops supporters absent from the current validator set", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		// Supporter 7 exited and is gone from the current set; it must not be selected.
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3), nil)
+		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{2: {}, 7: {}}, nil)
+		require.Equal(t, []uint64{2}, got)
+	})
+
+	t.Run("drops supporters with zero voting power", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		// Supporter 3 is still present but exited (power 0); it must not be selected.
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOfPowers(map[uint64]int64{1: 10, 2: 10, 3: 0}), nil)
+		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{2: {}, 3: {}}, nil)
+		require.Equal(t, []uint64{2}, got)
+	})
+
+	t.Run("falls back to the validator set when no supporter is eligible", func(t *testing.T) {
 		k, ctx, sk := newFallbackKeeper(t)
 		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3, 4), nil)
 		got := k.eligibleProducerFallback(ctx, 2, map[uint64]struct{}{}, nil)
@@ -71,6 +102,13 @@ func TestEligibleProducerFallback(t *testing.T) {
 		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOf(1, 2, 3, 4), nil)
 		got := k.eligibleProducerFallback(ctx, 2, map[uint64]struct{}{}, map[uint64]struct{}{3: {}})
 		require.Equal(t, []uint64{1, 4}, got)
+	})
+
+	t.Run("excludes zero-power validators from the validator-set fallback", func(t *testing.T) {
+		k, ctx, sk := newFallbackKeeper(t)
+		sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOfPowers(map[uint64]int64{1: 10, 2: 0, 3: 10}), nil)
+		got := k.eligibleProducerFallback(ctx, 1, map[uint64]struct{}{}, nil)
+		require.Equal(t, []uint64{3}, got)
 	})
 
 	t.Run("returns nil when the validator set cannot be read", func(t *testing.T) {
@@ -127,6 +165,153 @@ func TestSelectNextSpanProducerEmptyCandidateFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(1), got)
 	require.Contains(t, []uint64{2, 3, 4}, got)
+}
+
+// An exited validator can remain in the elected candidate set (voters still rank it) and in the
+// supporter set, without the candidate set ever collapsing to the fallback. Post-Ithaca the
+// selection pipeline must drop it (zero power, absent from the current set) and pick a real
+// producer, keeping the chain live rather than freezing a span Bor cannot build a snapshot from.
+// Exercised across the exact activation boundary (F-1, F, F+1) at a configured Ithaca height: the
+// gate flips behavior only from block F onward.
+func TestSelectNextSpanProducerSkipsExitedElectedCandidate(t *testing.T) {
+	k, ctx, sk := newFallbackKeeper(t)
+
+	oldZurich, oldIthaca := helper.GetZurichHardforkHeight(), helper.GetIthacaHeight()
+	t.Cleanup(func() {
+		helper.SetZurichHardforkHeight(oldZurich)
+		helper.SetIthacaHeight(oldIthaca)
+	})
+	helper.SetZurichHardforkHeight(1)
+
+	const forkHeight int64 = 100
+	helper.SetIthacaHeight(forkHeight)
+
+	// Validator 2 has exited: still present in the set but with zero power. 1 and 3 are active.
+	sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOfPowers(map[uint64]int64{1: 10, 2: 0, 3: 10}), nil).AnyTimes()
+
+	// Active voters 1 and 3 rank the exited validator 2 first, then 3, so the elected set is [2, 3].
+	require.NoError(t, k.SetProducerVotes(ctx, 1, types.ProducerVotes{Votes: []uint64{2, 3}}))
+	require.NoError(t, k.SetProducerVotes(ctx, 3, types.ProducerVotes{Votes: []uint64{2, 3}}))
+
+	active := map[uint64]struct{}{2: {}, 3: {}}
+
+	tests := []struct {
+		name   string
+		height int64
+		want   uint64
+	}{
+		// F-1: gate off, the exited validator is elected, active, and selected — the latent bug.
+		{name: "one block before Ithaca selects the exited validator", height: forkHeight - 1, want: 2},
+		// F and F+1: gate on, the exited validator is filtered out and a positive-power validator wins.
+		{name: "at Ithaca skips the exited validator", height: forkHeight, want: 3},
+		{name: "after Ithaca skips the exited validator", height: forkHeight + 1, want: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cctx := ctx.WithBlockHeight(tc.height)
+			limit := helper.GetProducerSetLimit(cctx)
+
+			candidates, err := k.CalculateProducerSet(cctx, limit)
+			require.NoError(t, err)
+			require.Equal(t, []uint64{2, 3}, candidates)
+
+			got, err := k.SelectNextSpanProducer(cctx, 1, active, limit, 240, 383, types.RoundRobinDefault, nil, false)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// Within a single block an approved exit zeroes a validator's individual record while the
+// current-set snapshot (GetValidatorSet) is not refreshed until the stake module's PreBlock. A
+// later span-creating post-handler then sees a stale-positive snapshot but a zero-power resolved
+// record. AddNewVeBlopSpan must validate the resolved record it actually serializes, not the
+// snapshot by id, so it refuses to freeze the zero-power producer that would crash Bor.
+func TestAddNewVeBlopSpanRejectsStaleZeroPowerProducer(t *testing.T) {
+	k, ctx, sk := newFallbackKeeper(t)
+
+	oldZurich, oldIthaca := helper.GetZurichHardforkHeight(), helper.GetIthacaHeight()
+	t.Cleanup(func() {
+		helper.SetZurichHardforkHeight(oldZurich)
+		helper.SetIthacaHeight(oldIthaca)
+	})
+	helper.SetZurichHardforkHeight(1)
+	helper.SetIthacaHeight(1)
+	ctx = ctx.WithBlockHeight(10)
+
+	require.NoError(t, k.AddNewSpan(ctx, &types.Span{
+		Id: 1, StartBlock: 100, EndBlock: 199, BorChainId: "1",
+		SelectedProducers: []staketypes.Validator{{ValId: 1, VotingPower: 10}},
+	}))
+
+	// Snapshot still lists validator 2 with positive power (exit not yet applied to the set), but the
+	// resolved individual record already reports zero power.
+	sk.EXPECT().GetValidatorSet(gomock.Any()).Return(valSetOfPowers(map[uint64]int64{1: 10, 2: 10}), nil).AnyTimes()
+	sk.EXPECT().GetValidatorFromValID(gomock.Any(), uint64(2)).Return(staketypes.Validator{ValId: 2, VotingPower: 0}, nil).AnyTimes()
+
+	// Votes elect [2]; current producer 1 with active {2} selects 2.
+	require.NoError(t, k.SetProducerVotes(ctx, 1, types.ProducerVotes{Votes: []uint64{2}}))
+	require.NoError(t, k.SetProducerVotes(ctx, 2, types.ProducerVotes{Votes: []uint64{2}}))
+
+	active := map[uint64]struct{}{2: {}}
+	err := k.AddNewVeBlopSpan(ctx, 1, 200, 300, "1", active, 5000, types.RoundRobinDefault, nil, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-positive voting power")
+
+	// No span with the stale zero-power producer was frozen.
+	last, err := k.GetLastSpan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), last.Id)
+}
+
+// A signer change maps a validator id to a new, positive-power signer while the current-set
+// snapshot may still carry the old signer. Bor's VEBLOP snapshot consumes only SelectedProducers,
+// so the new signer is the correct one to seal with; span creation must succeed and freeze the new
+// signer. This pins that the guard checks the resolved record's power, not signer equality against
+// the (possibly stale) snapshot — a signer-equality check would wrongly reject this valid case.
+func TestAddNewVeBlopSpanAcceptsSignerChangedProducer(t *testing.T) {
+	k, ctx, sk := newFallbackKeeper(t)
+
+	oldZurich, oldIthaca := helper.GetZurichHardforkHeight(), helper.GetIthacaHeight()
+	t.Cleanup(func() {
+		helper.SetZurichHardforkHeight(oldZurich)
+		helper.SetIthacaHeight(oldIthaca)
+	})
+	helper.SetZurichHardforkHeight(1)
+	helper.SetIthacaHeight(1)
+	ctx = ctx.WithBlockHeight(10)
+
+	const oldSigner = "0x0000000000000000000000000000000000000aa1"
+	const newSigner = "0x0000000000000000000000000000000000000bb2"
+
+	require.NoError(t, k.AddNewSpan(ctx, &types.Span{
+		Id: 1, StartBlock: 100, EndBlock: 199, BorChainId: "1",
+		SelectedProducers: []staketypes.Validator{{ValId: 1, VotingPower: 10}},
+	}))
+
+	// Snapshot still lists validator 2 under its OLD signer; the resolved individual record maps the
+	// same id to a NEW, positive-power signer.
+	snapshot := staketypes.ValidatorSet{Validators: []*staketypes.Validator{
+		{ValId: 1, VotingPower: 10},
+		{ValId: 2, VotingPower: 10, Signer: oldSigner},
+	}}
+	sk.EXPECT().GetValidatorSet(gomock.Any()).Return(snapshot, nil).AnyTimes()
+	sk.EXPECT().GetValidatorFromValID(gomock.Any(), uint64(2)).Return(staketypes.Validator{ValId: 2, VotingPower: 10, Signer: newSigner}, nil).AnyTimes()
+
+	require.NoError(t, k.SetProducerVotes(ctx, 1, types.ProducerVotes{Votes: []uint64{2}}))
+	require.NoError(t, k.SetProducerVotes(ctx, 2, types.ProducerVotes{Votes: []uint64{2}}))
+
+	active := map[uint64]struct{}{2: {}}
+	require.NoError(t, k.AddNewVeBlopSpan(ctx, 1, 200, 300, "1", active, 5000, types.RoundRobinDefault, nil, false))
+
+	last, err := k.GetLastSpan(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), last.Id)
+	require.Len(t, last.SelectedProducers, 1)
+	require.Equal(t, uint64(2), last.SelectedProducers[0].ValId)
+	require.Equal(t, newSigner, last.SelectedProducers[0].Signer)
+	require.Positive(t, last.SelectedProducers[0].VotingPower)
 }
 
 func TestSortedEligibleProducers(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens veBlop span producer selection so a span's selected producer is always a positive-power member of the current validator set.

Producer candidates are drawn from producer votes and the milestone supporter set, both of which can reference a validator that is no longer active in the current set (its record can linger with zero power). Selecting such a validator freezes a span whose producer is inconsistent with the validator set frozen into the same span. This PR enforces the invariant in two places:

- candidate selection filters to positive-power members of the current validator set, so a valid producer is chosen; and
- span creation performs a fail-closed check on the resolved producer record it serializes, so an inconsistent producer is never committed.

The new behavior is gated on the Ithaca fork, so pre-fork span creation is unchanged.

## Executed tests

- `go test ./x/bor/keeper/... ./app/...` — green.
- New keeper/app tests covering: the fork activation boundary (F-1 / F / F+1), a stale current-set snapshot versus a zero-power resolved record, and a signer-change producer.
- Existing veblop producer-selection and span suites unchanged.

## Rollout notes

- Consensus-relevant (producer selection); gated on Ithaca, so no pre-fork behavior change. Targets the v0.10.0 beta line.
- Backport to `develop` to follow after merge.
