### PR TITLE
fix(stake): guard nil amount before IsZero/IsNegative in ValidateBasic

### DIFF
--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -70,6 +70,11 @@ func (msg MsgValidatorJoin) ValidateBasic() error {
 		return ErrInvalidMsg.Wrap("signer public key can't be of zero bytes")
 	}
 
+	// Guard before IsZero/IsNegative: a nil/uninitialized Int (proto field omitted)
+	// panics on those methods, and ValidateBasic runs ahead of signature verification.
+	if msg.Amount.IsNil() {
+		return ErrInvalidMsg.Wrap("amount is required")
+	}
 	if msg.Amount.IsZero() || msg.Amount.IsNegative() {
 		return ErrInvalidMsg.Wrapf("invalid amount %v", msg.Amount)
 	}
@@ -115,6 +120,9 @@ func (msg MsgStakeUpdate) ValidateBasic() error {
 		return ErrInvalidMsg.Wrapf(errInvalidProposer, msg.From)
 	}
 
+	if msg.NewAmount.IsNil() {
+		return ErrInvalidMsg.Wrap("amount is required")
+	}
 	if msg.NewAmount.IsZero() || msg.NewAmount.IsNegative() {
 		return ErrInvalidMsg.Wrapf("invalid amount %v", msg.NewAmount)
 	}

--- a/x/stake/types/msg_test.go
+++ b/x/stake/types/msg_test.go
@@ -123,3 +123,47 @@ func TestMsgDecode(t *testing.T) {
 	require.Equal(t, msgValidatorExit.ValId, msgValidatorExit2.ValId)
 	require.Equal(t, msgValidatorExit.DeactivationEpoch, msgValidatorExit2.DeactivationEpoch)
 }
+
+func TestMsgValidatorJoin_ValidateBasic_NilAmount(t *testing.T) {
+	t.Parallel()
+
+	pk1 := secp256k1.GenPrivKey().PubKey()
+	msg := types.MsgValidatorJoin{
+		From:            pk1.Address().String(),
+		ValId:           1,
+		ActivationEpoch: 1,
+		Amount:          math.Int{},
+		SignerPubKey:    pk1.Bytes(),
+		TxHash:          make([]byte, 32),
+		LogIndex:        1,
+		BlockNumber:     1,
+		Nonce:           1,
+	}
+
+	require.NotPanics(t, func() {
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "amount is required")
+	})
+}
+
+func TestMsgStakeUpdate_ValidateBasic_NilAmount(t *testing.T) {
+	t.Parallel()
+
+	pk1 := secp256k1.GenPrivKey().PubKey()
+	msg := types.MsgStakeUpdate{
+		From:        pk1.Address().String(),
+		ValId:       1,
+		NewAmount:   math.Int{},
+		TxHash:      make([]byte, 32),
+		LogIndex:    1,
+		BlockNumber: 1,
+		Nonce:       1,
+	}
+
+	require.NotPanics(t, func() {
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "amount is required")
+	})
+}


### PR DESCRIPTION
## Summary
- `MsgValidatorJoin` / `MsgStakeUpdate` `ValidateBasic` called `IsZero()` / `IsNegative()` on possibly nil `math.Int` (proto field omitted).
- Nil Int panics on those methods. `ValidateBasic` runs ahead of signature verification in the ante handler, so the panic is reachable unauthenticated.
- Same class as the existing topup `Fee` / `Amount` `IsNil()` guards.

## Test plan
- [x] `go test ./x/stake/types/ -run NilAmount` (no panic; error contains `amount is required`)

Made with [Cursor](https://cursor.com)