### PR TITLE
ci: bump kurtosis-pos pin and Actions versions in kurtosis workflows

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout bor
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/bor
           ref: develop
@@ -37,7 +37,7 @@ jobs:
         run: docker save bor:local | gzip > bor-image.tar.gz
 
       - name: Upload bor docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bor-image
           path: bor-image.tar.gz
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout heimdall-v2
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Build heimdall-v2 docker image
         run: docker build -t heimdall-v2:local --file Dockerfile .
@@ -57,7 +57,7 @@ jobs:
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
       - name: Upload heimdall-v2 docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz
@@ -77,10 +77,10 @@ jobs:
     steps:
       # Set up kurtosis
       - name: Checkout kurtosis-pos
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.3.4
+          ref: v1.4.1
 
       # This step will free disk space and thus remove any docker images previously built
       - name: Pre kurtosis run
@@ -91,7 +91,7 @@ jobs:
           docker_token: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Checkout pos-workflows
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/pos-workflows
           ref: main
@@ -102,12 +102,12 @@ jobs:
 
       # Load images
       - name: Download bor docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bor-image
 
       - name: Download heimdall-v2 docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: heimdall-v2-image
 
@@ -131,7 +131,7 @@ jobs:
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 'stable'
 

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout bor
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/bor
           ref: develop
@@ -37,7 +37,7 @@ jobs:
         run: docker save bor:local | gzip > bor-image.tar.gz
 
       - name: Upload bor docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bor-image
           path: bor-image.tar.gz
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout heimdall-v2
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Build heimdall-v2 docker image
         run: docker build -t heimdall-v2:local --file Dockerfile .
@@ -57,7 +57,7 @@ jobs:
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
       - name: Upload heimdall-v2 docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz
@@ -77,10 +77,10 @@ jobs:
     steps:
       # Set up kurtosis
       - name: Checkout kurtosis-pos
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.3.4
+          ref: v1.4.1
 
       # This step will free disk space and thus remove any docker images previously built
       - name: Pre kurtosis run
@@ -91,7 +91,7 @@ jobs:
           docker_token: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Checkout pos-workflows
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 0xPolygon/pos-workflows
           ref: main
@@ -102,12 +102,12 @@ jobs:
 
       # Load images
       - name: Download bor docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bor-image
 
       - name: Download heimdall-v2 docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: heimdall-v2-image
 


### PR DESCRIPTION
kurtosis-pos was pinned to v1.3.4 for 10+ weeks; v1.4.0 dropped Erigon support (handled on the pos-workflows side).

- Bump kurtosis-pos pin v1.3.4 -> v1.4.1.
- Bump actions/checkout, upload-artifact, download-artifact, setup-go to current majors.

Depends on 0xPolygon/pos-workflows#49 merging first (this workflow pulls that repo's configs at `ref: main`).