### PR TITLE
ci: bump kurtosis-pos pin to v1.4.2

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.4.1
+          ref: v1.4.2
 
       # This step will free disk space and thus remove any docker images previously built
       - name: Pre kurtosis run

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: 0xPolygon/kurtosis-pos
-          ref: v1.4.1
+          ref: v1.4.2
 
       # This step will free disk space and thus remove any docker images previously built
       - name: Pre kurtosis run


### PR DESCRIPTION
## Summary
Both Kurtosis e2e jobs in this repo (`kurtosis-e2e.yml`, `kurtosis-stateless-e2e.yml`) check out `0xPolygon/kurtosis-pos@v1.4.1` and run its shared `.github/actions/kurtosis/setup` composite action, which pins `foundry-rs/foundry-toolchain@c7450ba` (v1.8.0). That commit is broken against Foundry's current install infrastructure — `foundryup` fails with `cannot execute binary file` on every run, confirmed as a known upstream regression ([foundry-rs/foundry-toolchain#170](https://github.com/foundry-rs/foundry-toolchain/issues/170), filed by an unrelated third party against the same SHA).

The fix (bump to `foundry-toolchain@908c540`, v1.9.1) already landed on `kurtosis-pos` `main` via #702, and reliability just cut `v1.4.2` off current `main` to expose it. This bumps our pin from `v1.4.1` → `v1.4.2` to unblock both Kurtosis e2e jobs.

## Executed tests
N/A — CI-only change, verified by the Kurtosis e2e jobs themselves passing on this PR.

## Rollout notes
Not consensus-affecting. CI-only.