### PR TITLE
app, helper, metrics: add milestone/vote-extension/bor-RPC observability metrics

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -470,7 +470,9 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 			logger.Warn("extend vote budget exhausted before milestone proposition, skipping",
 				"elapsed", time.Since(startTime))
 		} else {
+			genStart := time.Now()
 			milestoneProp, err = milestoneAbci.GenMilestoneProposition(ctx, &app.BorKeeper, &app.MilestoneKeeper, app.caller, getBlockAuthor)
+			metrics.RecordMilestoneGenerationDuration(genStart)
 		}
 		if err != nil {
 			if errors.Is(err, milestoneAbci.ErrNoNewHeadersFound) {
@@ -740,8 +742,10 @@ func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 		if err := milestoneAbci.ValidateMilestoneProposition(milestoneCtx, &app.MilestoneKeeper, majorityMilestone); err != nil {
 			logger.Warn("Invalid milestone proposition", "error", err, "height", req.Height, "majorityMilestone", majorityMilestone)
 			// We don't want to halt consensus because of an invalid majority milestone proposition
+			metrics.RecordMilestoneMajorityCommitSuppressed("validate_failed")
 		} else if helper.IsRio(majorityMilestone.StartBlockNumber) && ctx.BlockHeight() == int64(lastSpanHeimdallBlock)+1 {
 			logger.Info("Last span was created in the previous block, skipping milestone addition", "lastSpanHeimdallBlock", lastSpanHeimdallBlock, "currentBlock", ctx.BlockHeight())
+			metrics.RecordMilestoneMajorityCommitSuppressed("rio_last_span_same_block")
 		} else {
 			logger.Info("2/3rd majority reached on milestone proposition",
 				"startBlock", majorityMilestone.StartBlockNumber,

--- a/app/abci.go
+++ b/app/abci.go
@@ -393,13 +393,15 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 
 		// decode txs and execute side txs
 		for _, rawTx := range txs {
-			if budgetActive && !time.Now().Before(deadline) {
-				metrics.RecordExtendVoteBudgetExhausted("side_tx_loop")
+			if budgetActive {
 				metrics.RecordExtendVoteElapsed("side_tx_loop", startTime)
-				logger.Warn("extend vote budget exhausted, returning partial response",
-					"processed_side_handlers", len(sideTxRes),
-					"elapsed", time.Since(startTime))
-				break
+				if !time.Now().Before(deadline) {
+					metrics.RecordExtendVoteBudgetExhausted("side_tx_loop")
+					logger.Warn("extend vote budget exhausted, returning partial response",
+						"processed_side_handlers", len(sideTxRes),
+						"elapsed", time.Since(startTime))
+					break
+				}
 			}
 			// create a cache wrapped context for stateless execution
 			ctx, _ = app.cacheTxContext(ctx)
@@ -464,9 +466,11 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		}
 
 		var milestoneProp *milestoneTypes.MilestoneProposition
+		if budgetActive {
+			metrics.RecordExtendVoteElapsed("pre_milestone", startTime)
+		}
 		if budgetActive && !time.Now().Before(deadline) {
 			metrics.RecordExtendVoteBudgetExhausted("pre_milestone")
-			metrics.RecordExtendVoteElapsed("pre_milestone", startTime)
 			logger.Warn("extend vote budget exhausted before milestone proposition, skipping",
 				"elapsed", time.Since(startTime))
 		} else {

--- a/app/abci.go
+++ b/app/abci.go
@@ -395,6 +395,7 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		for _, rawTx := range txs {
 			if budgetActive && !time.Now().Before(deadline) {
 				metrics.RecordExtendVoteBudgetExhausted("side_tx_loop")
+				metrics.RecordExtendVoteElapsed("side_tx_loop", startTime)
 				logger.Warn("extend vote budget exhausted, returning partial response",
 					"processed_side_handlers", len(sideTxRes),
 					"elapsed", time.Since(startTime))
@@ -465,6 +466,7 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		var milestoneProp *milestoneTypes.MilestoneProposition
 		if budgetActive && !time.Now().Before(deadline) {
 			metrics.RecordExtendVoteBudgetExhausted("pre_milestone")
+			metrics.RecordExtendVoteElapsed("pre_milestone", startTime)
 			logger.Warn("extend vote budget exhausted before milestone proposition, skipping",
 				"elapsed", time.Since(startTime))
 		} else {
@@ -472,6 +474,7 @@ func (app *HeimdallApp) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		}
 		if err != nil {
 			if errors.Is(err, milestoneAbci.ErrNoNewHeadersFound) {
+				metrics.RecordMilestoneNoNewHeaders()
 				logger.Debug("No new headers found for generating milestone proposition, continuing without it")
 			} else {
 				logger.Warn("Error occurred while generating milestone proposition", "error", err)
@@ -532,23 +535,27 @@ func (app *HeimdallApp) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHand
 		}
 
 		if err := rejectUnknownVoteExtFields(req.VoteExtension); err != nil {
+			metrics.RecordVoteExtensionRejected("unknown_fields")
 			logger.Error(heimdallTypes.ErrAlertVoteExtensionRejected+" Error while checking unknown fields in VoteExtension", "validator", valAddr, "error", err)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
 
 		var voteExtension sidetxs.VoteExtension
 		if err := proto.Unmarshal(req.VoteExtension, &voteExtension); err != nil {
+			metrics.RecordVoteExtensionRejected("unmarshal_failed")
 			logger.Error(heimdallTypes.ErrAlertVoteExtensionRejected+" Error while unmarshalling VoteExtension", "validator", valAddr, "error", err)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
 
 		// ensure block height and hash match
 		if req.Height != voteExtension.Height {
+			metrics.RecordVoteExtensionRejected("height_mismatch")
 			logger.Error(heimdallTypes.ErrAlertVoteExtensionRejected, "block height", req.Height, "consolidatedSideTxResponse height", voteExtension.Height, "validator", valAddr)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
 
 		if !bytes.Equal(req.Hash, voteExtension.BlockHash) {
+			metrics.RecordVoteExtensionRejected("hash_mismatch")
 			logger.Error(heimdallTypes.ErrAlertVoteExtensionRejected, "block hash", common.Bytes2Hex(req.Hash), "consolidatedSideTxResponse blockHash", common.Bytes2Hex(voteExtension.BlockHash), "validator", valAddr)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
@@ -556,6 +563,7 @@ func (app *HeimdallApp) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHand
 		// check for duplicate votes
 		txHash, err := validateSideTxResponses(voteExtension.SideTxResponses)
 		if err != nil {
+			metrics.RecordVoteExtensionRejected("invalid_side_tx_responses")
 			logger.Error(heimdallTypes.ErrAlertVoteExtensionRejected, "validator", valAddr, "tx hash", common.Bytes2Hex(txHash), "error", err)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
@@ -565,6 +573,7 @@ func (app *HeimdallApp) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHand
 			tolerateBorErr := errors.Is(err, borTypes.ErrFailedToQueryBor) ||
 				(helper.IsZurichHardfork(req.Height) && errors.Is(err, borTypes.ErrBorBlockNotFound))
 			if helper.IsPhuketHardfork(req.Height) && !tolerateBorErr {
+				metrics.RecordVoteExtensionRejected("nonrp_rejected")
 				logger.Error(heimdallTypes.ErrAlertNonRpVoteExtensionRejected, "validator", valAddr, "error", err)
 				return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 			}
@@ -576,6 +585,7 @@ func (app *HeimdallApp) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHand
 		// avoids ambiguity at the activation boundary and for direct handler callers.
 		milestoneCtx := ctx.WithBlockHeight(voteExtension.Height)
 		if err := milestoneAbci.ValidateMilestoneProposition(milestoneCtx, &app.MilestoneKeeper, voteExtension.MilestoneProposition); err != nil {
+			metrics.RecordVoteExtensionRejected("milestone_proposition_rejected")
 			logger.Error(heimdallTypes.ErrAlertMilestonePropositionVoteExtensionRejected, "validator", valAddr, "error", err)
 			return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
 		}
@@ -738,6 +748,7 @@ func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 				"endBlock", majorityMilestone.StartBlockNumber+uint64(len(majorityMilestone.BlockHashes)-1),
 				"blockHashes", strutil.HashesToString(majorityMilestone.BlockHashes),
 			)
+			metrics.RecordMilestoneMajorityFound("two_thirds")
 			isValidMilestone = true
 		}
 	}
@@ -817,8 +828,11 @@ func (app *HeimdallApp) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlo
 			if err := app.checkAndRotateCurrentSpan(ctx); err != nil {
 				return nil, err
 			}
-		} else if err := app.handlePendingMilestone(ctx, pendingMilestone, validatorSet, extVoteInfo, minMajorityVP); err != nil {
-			return nil, err
+		} else {
+			metrics.RecordMilestoneMajorityFound("one_third")
+			if err := app.handlePendingMilestone(ctx, pendingMilestone, validatorSet, extVoteInfo, minMajorityVP); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -825,6 +825,29 @@ func TestVerifyVoteExtensionHandler(t *testing.T) {
 			wantReason: "unknown_fields",
 		},
 		{
+			name: "malformed bytes that pass unknown-fields check but fail proto.Unmarshal",
+			// rejectUnknownVoteExtFields (unknownproto.RejectUnknownFieldsStrict) treats
+			// MilestoneProposition.block_tds (a packed-varint scalar field) as opaque once its
+			// declared length fits the remaining buffer: it never decodes the packed varints
+			// themselves, so a truncated varint sequence sails through. gogoproto's real
+			// Unmarshal, however, must decode each packed varint and fails with
+			// "unexpected EOF" on the same bytes. This exercises the branch at line ~547
+			// (proto.Unmarshal failure) as opposed to the unknown-fields branch above.
+			//
+			// Wire layout: VoteExtension.milestone_proposition (field 4, wiretype 2) wraps
+			// MilestoneProposition.block_tds (field 4, wiretype 2, packed) wraps a single
+			// truncated varint byte (0x80: continuation bit set, no continuation byte).
+			req: abci.RequestVerifyVoteExtension{
+				VoteExtension:      []byte{0x22, 0x03, 0x22, 0x01, 0x80},
+				NonRpVoteExtension: respExtend.NonRpExtension,
+				ValidatorAddress:   voteInfo.Validator.Address,
+				Height:             3,
+				Hash:               []byte("test-hash"),
+			},
+			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			wantReason: "unmarshal_failed",
+		},
+		{
 			name:       "height mismatch",
 			req:        abci.RequestVerifyVoteExtension{VoteExtension: respExtend.VoteExtension, NonRpVoteExtension: respExtend.NonRpExtension, ValidatorAddress: voteInfo.Validator.Address, Height: 4, Hash: []byte("test-hash")},
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
@@ -3711,6 +3734,65 @@ func TestPreBlockerSpanRotationWithMinorityMilestone(t *testing.T) {
 	currentSpan, err := app.BorKeeper.GetLastSpan(ctx)
 	require.NoError(t, err)
 	require.Equal(t, span.Id, currentSpan.Id, "Span should not have been rotated when 1/3+ voting power supports a milestone")
+}
+
+// TestPreBlocker_PendingMilestoneHandlingErrorPropagates tests that PreBlocker propagates a real
+// error from handlePendingMilestone rather than swallowing it. Post-Ithaca, handlePendingMilestone
+// calls app.BorKeeper.GetLastSpan first; with no span ever recorded, that lookup fails, and
+// PreBlocker must surface the resulting error (not silently return a nil error, which is what a
+// branch_removal or return_value mutation of the `if err := app.handlePendingMilestone(...); err
+// != nil { return nil, err }` guard would produce).
+func TestPreBlocker_PendingMilestoneHandlingErrorPropagates(t *testing.T) {
+	_, app, ctx, validatorPrivKeys := SetupAppWithABCICtxAndValidators(t, 10)
+	validators := app.StakeKeeper.GetAllValidators(ctx)
+
+	// Set up consensus params to enable vote extensions
+	params := cmtproto.ConsensusParams{
+		Abci: &cmtproto.ABCIParams{
+			VoteExtensionsEnableHeight: 1,
+		},
+	}
+	ctx = ctx.WithConsensusParams(params)
+
+	// Set up the initial state with a milestone, but deliberately no span.
+	milestone := milestoneTypes.Milestone{
+		MilestoneId: "1",
+		StartBlock:  0,
+		EndBlock:    100,
+		Hash:        common.HexToHash("0x1234").Bytes(),
+	}
+	err := app.MilestoneKeeper.AddMilestone(ctx, milestone)
+	require.NoError(t, err)
+
+	// Activate Ithaca so handlePendingMilestone takes the GetLastSpan/GetMajorityActualHead path
+	// instead of the pre-Ithaca log-and-return-nil path.
+	origIthaca := helper.GetIthacaHeight()
+	helper.SetIthacaHeight(1)
+	t.Cleanup(func() { helper.SetIthacaHeight(origIthaca) })
+
+	blockHeight := int64(milestone.EndBlock) + helper.GetChangeProducerThreshold(ctx) + 1
+	ctx = ctx.WithBlockHeight(blockHeight)
+
+	// Create vote extensions with 40% voting power supporting a new milestone: more than 1/3 but
+	// less than 2/3, so PreBlocker takes the pending-milestone (handlePendingMilestone) branch.
+	voteExtensions := createVoteExtensionsWithPartialSupport(t, validators, validatorPrivKeys, &milestone, 40, blockHeight-1)
+
+	extCommit := &abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: voteExtensions,
+	}
+	extCommitBytes, err := extCommit.Marshal()
+	require.NoError(t, err)
+
+	req := &abci.RequestFinalizeBlock{
+		Height:          ctx.BlockHeight(),
+		Txs:             [][]byte{extCommitBytes, []byte("dummy-tx")},
+		ProposerAddress: common.FromHex(validators[0].Signer),
+	}
+
+	resp, err := app.PreBlocker(ctx, req)
+	require.Error(t, err, "PreBlocker must propagate the error from handlePendingMilestone (no span found) rather than swallowing it")
+	require.Nil(t, resp)
 }
 
 // TestPreBlockerSpanRotationWithoutMinorityMilestone tests that span rotation occurs

--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -34,6 +34,9 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -42,6 +45,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/contracts/statesender"
 	"github.com/0xPolygon/heimdall-v2/helper"
 	helpermocks "github.com/0xPolygon/heimdall-v2/helper/mocks"
+	"github.com/0xPolygon/heimdall-v2/metrics"
 	"github.com/0xPolygon/heimdall-v2/sidetxs"
 	"github.com/0xPolygon/heimdall-v2/x/bor"
 	borKeeper "github.com/0xPolygon/heimdall-v2/x/bor/keeper"
@@ -621,10 +625,23 @@ func TestExtendVoteHandler(t *testing.T) {
 		Hash:   []byte("test-hash"),
 		Height: 3,
 	}
+
+	// The mocked GetBorChainBlockInfoInBatch always returns an empty header batch, so
+	// GenMilestoneProposition always fails with ErrNoNewHeadersFound here, and since no Zurich
+	// budget is active, the milestone-proposition-generation path always runs. Assert both the
+	// no-new-headers counter and the generation-duration histogram move accordingly.
+	noNewHeadersBefore := promtestutil.ToFloat64(metrics.MilestoneNoNewHeadersTotal)
+	genDurationBefore := histogramSampleCount(t, metrics.MilestoneGenerationDuration)
+
 	respExtend, err := app.ExtendVoteHandler()(ctx, &reqExtend)
 	require.NoError(t, err)
 	require.NotNil(t, respExtend.VoteExtension)
 	mockCaller.AssertCalled(t, "GetBorChainBlockInfoInBatch", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64"))
+
+	require.Equal(t, noNewHeadersBefore+1, promtestutil.ToFloat64(metrics.MilestoneNoNewHeadersTotal),
+		"ExtendVoteHandler must record a no-new-headers event when GenMilestoneProposition returns ErrNoNewHeadersFound")
+	require.Equal(t, genDurationBefore+1, histogramSampleCount(t, metrics.MilestoneGenerationDuration),
+		"ExtendVoteHandler must record the milestone-proposition-generation duration")
 
 	terrUnmarshal := "error occurred while decoding ExtendedCommitInfo"
 	terrTxDecode := "error occurred while decoding tx bytes in ExtendVoteHandler"
@@ -791,6 +808,9 @@ func TestVerifyVoteExtensionHandler(t *testing.T) {
 		name       string
 		req        abci.RequestVerifyVoteExtension
 		wantStatus abci.ResponseVerifyVoteExtension_VerifyStatus
+		// wantReason is the metrics.VoteExtensionRejectedTotal label expected to be incremented by
+		// exactly one when wantStatus is REJECT. Empty for the ACCEPT case.
+		wantReason string
 	}{
 		{
 			name:       "valid extension",
@@ -798,42 +818,67 @@ func TestVerifyVoteExtensionHandler(t *testing.T) {
 			wantStatus: abci.ResponseVerifyVoteExtension_ACCEPT,
 		},
 		{
-			name:       "unmarshal fail",
+			name:       "unknown fields / garbage bytes",
 			req:        abci.RequestVerifyVoteExtension{VoteExtension: []byte{0x01, 0x02, 0x03}, NonRpVoteExtension: respExtend.NonRpExtension, ValidatorAddress: voteInfo.Validator.Address, Height: 3, Hash: []byte("test-hash")},
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			// [0x01, 0x02, 0x03] fails the unknown-fields check before it ever reaches proto.Unmarshal.
+			wantReason: "unknown_fields",
 		},
 		{
 			name:       "height mismatch",
 			req:        abci.RequestVerifyVoteExtension{VoteExtension: respExtend.VoteExtension, NonRpVoteExtension: respExtend.NonRpExtension, ValidatorAddress: voteInfo.Validator.Address, Height: 4, Hash: []byte("test-hash")},
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			wantReason: "height_mismatch",
 		},
 		{
 			name:       "hash mismatch",
 			req:        abci.RequestVerifyVoteExtension{VoteExtension: respExtend.VoteExtension, NonRpVoteExtension: respExtend.NonRpExtension, ValidatorAddress: voteInfo.Validator.Address, Height: 3, Hash: []byte("wrong-hash")},
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			wantReason: "hash_mismatch",
 		},
 		{
 			name: "side-tx validation failure",
-			// construct invalid side extension bytes
+			// construct a well-formed extension (correct height/hash so it passes those checks)
+			// with a malformed side-tx response (invalid tx hash length) so it is rejected by
+			// validateSideTxResponses specifically.
 			req: func() abci.RequestVerifyVoteExtension {
-				fake := &sidetxs.VoteExtension{BlockHash: respExtend.VoteExtension, Height: 3, SideTxResponses: nil}
-				bz, _ := gogoproto.Marshal(fake)
+				fake := &sidetxs.VoteExtension{
+					BlockHash: []byte("test-hash"),
+					Height:    3,
+					SideTxResponses: []sidetxs.SideTxResponse{
+						{TxHash: []byte("too-short"), Result: sidetxs.Vote_VOTE_YES},
+					},
+				}
+				bz, err := gogoproto.Marshal(fake)
+				require.NoError(t, err)
 				return abci.RequestVerifyVoteExtension{VoteExtension: bz, NonRpVoteExtension: respExtend.NonRpExtension, ValidatorAddress: voteInfo.Validator.Address, Height: 3, Hash: []byte("test-hash")}
 			}(),
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			wantReason: "invalid_side_tx_responses",
 		},
 		{
 			name:       "non-rp validation error",
 			req:        abci.RequestVerifyVoteExtension{VoteExtension: respExtend.VoteExtension, NonRpVoteExtension: []byte{0x01, 0x02, 0x03, 0xFF}, ValidatorAddress: voteInfo.Validator.Address, Height: 3, Hash: []byte("test-hash")},
 			wantStatus: abci.ResponseVerifyVoteExtension_REJECT,
+			wantReason: "nonrp_rejected",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			var rejectedBefore float64
+			if tc.wantReason != "" {
+				rejectedBefore = promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues(tc.wantReason))
+			}
+
 			resp, err := app.VerifyVoteExtensionHandler()(ctx, &tc.req)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantStatus, resp.Status)
+
+			if tc.wantReason != "" {
+				require.Equal(t, rejectedBefore+1, promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues(tc.wantReason)),
+					"VerifyVoteExtensionHandler must record a rejection for reason=%s", tc.wantReason)
+			}
 		})
 	}
 }
@@ -890,9 +935,12 @@ func TestVerifyVoteExtensionHandlerUsesAuthenticatedHeightForIthaca(t *testing.T
 	require.Equal(t, abci.ResponseVerifyVoteExtension_ACCEPT, res.Status)
 
 	// Conversely, a future-looking ambient context must not make pre-fork fields valid.
+	milestoneRejectedBefore := promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues("milestone_proposition_rejected"))
 	res, err = handler(ctx.WithBlockHeight(100), makeReq(99))
 	require.NoError(t, err)
 	require.Equal(t, abci.ResponseVerifyVoteExtension_REJECT, res.Status)
+	require.Equal(t, milestoneRejectedBefore+1, promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues("milestone_proposition_rejected")),
+		"VerifyVoteExtensionHandler must record a rejection for reason=milestone_proposition_rejected when pre-fork fields are populated")
 }
 
 func TestVerifyVoteExtensionHandler_AcceptsOnBorQueryError(t *testing.T) {
@@ -1033,10 +1081,15 @@ func TestVerifyVoteExtensionHandler_RejectsUnknownFieldsPadding(t *testing.T) {
 		VoteExtension:    paddedVE,
 	}
 
+	unknownFieldsRejectedBefore := promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues("unknown_fields"))
+
 	resp, err := hApp.VerifyVoteExtensionHandler()(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, abci.ResponseVerifyVoteExtension_REJECT, resp.Status)
+
+	require.Equal(t, unknownFieldsRejectedBefore+1, promtestutil.ToFloat64(metrics.VoteExtensionRejectedTotal.WithLabelValues("unknown_fields")),
+		"VerifyVoteExtensionHandler must record a rejection for reason=unknown_fields when protobuf padding is present")
 }
 
 // TestPreBlocker tests the PreBlocker function of the HeimdallApp by creating a MsgProposeSpan message, building a signed transaction, creating an extension commit, and calling the PreBlocker with the transaction and extension commit to ensure it processes without errors.
@@ -3645,9 +3698,14 @@ func TestPreBlockerSpanRotationWithMinorityMilestone(t *testing.T) {
 		ProposerAddress: common.FromHex(validators[0].Signer),
 	}
 
+	oneThirdFoundBefore := promtestutil.ToFloat64(metrics.MilestoneMajorityFoundTotal.WithLabelValues("one_third"))
+
 	// Execute PreBlocker
 	_, err = app.PreBlocker(ctx, req)
 	require.NoError(t, err)
+
+	require.Equal(t, oneThirdFoundBefore+1, promtestutil.ToFloat64(metrics.MilestoneMajorityFoundTotal.WithLabelValues("one_third")),
+		"PreBlocker must record a majority-found event for threshold=one_third when only 1/3+ voting power supports a milestone")
 
 	// Verify that span was not rotated
 	currentSpan, err := app.BorKeeper.GetLastSpan(ctx)
@@ -3803,9 +3861,14 @@ func TestPreBlockerSpanRotationWithMajorityMilestone(t *testing.T) {
 		ProposerAddress: common.FromHex(validators[0].Signer),
 	}
 
+	twoThirdsFoundBefore := promtestutil.ToFloat64(metrics.MilestoneMajorityFoundTotal.WithLabelValues("two_thirds"))
+
 	// Execute PreBlocker
 	_, err = app.PreBlocker(ctx, req)
 	require.NoError(t, err)
+
+	require.Equal(t, twoThirdsFoundBefore+1, promtestutil.ToFloat64(metrics.MilestoneMajorityFoundTotal.WithLabelValues("two_thirds")),
+		"PreBlocker must record a majority-found event for threshold=two_thirds when a 2/3+ majority milestone is committed")
 
 	// When there's a 2/3-majority milestone, it gets processed normally
 	// This can include creating a new span if the milestone warrants it
@@ -3816,6 +3879,201 @@ func TestPreBlockerSpanRotationWithMajorityMilestone(t *testing.T) {
 	latestMilestone, err := app.MilestoneKeeper.GetLastMilestone(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(101), latestMilestone.EndBlock, "New milestone should have been added with correct end block")
+}
+
+// TestPreBlocker_MajorityMilestoneValidateFailedSuppressesCommit tests that a 2/3-majority
+// milestone proposition that fails ValidateMilestoneProposition (here: malformed block hash
+// length) is NOT committed, and that this is recorded as a
+// metrics.MilestoneMajorityCommitSuppressedTotal{reason="validate_failed"} event rather than
+// silently falling through.
+func TestPreBlocker_MajorityMilestoneValidateFailedSuppressesCommit(t *testing.T) {
+	_, app, ctx, validatorPrivKeys := SetupAppWithABCICtxAndValidators(t, 10)
+	validators := app.StakeKeeper.GetAllValidators(ctx)
+
+	params := cmtproto.ConsensusParams{
+		Abci: &cmtproto.ABCIParams{
+			VoteExtensionsEnableHeight: 1,
+		},
+	}
+	ctx = ctx.WithConsensusParams(params)
+
+	milestone := milestoneTypes.Milestone{
+		MilestoneId: "1",
+		StartBlock:  0,
+		EndBlock:    100,
+		Hash:        common.HexToHash("0x1234").Bytes(),
+	}
+	err := app.MilestoneKeeper.AddMilestone(ctx, milestone)
+	require.NoError(t, err)
+	err = app.MilestoneKeeper.SetLastMilestoneBlock(ctx, milestone.EndBlock)
+	require.NoError(t, err)
+
+	span := &borTypes.Span{
+		Id:         1,
+		StartBlock: 1,
+		EndBlock:   200,
+		ValidatorSet: stakeTypes.ValidatorSet{
+			Validators: validators,
+			Proposer:   validators[0],
+		},
+		SelectedProducers: []stakeTypes.Validator{*validators[0]},
+		BorChainId:        "test",
+	}
+	err = app.BorKeeper.AddNewSpan(ctx, span)
+	require.NoError(t, err)
+
+	blockHeight := int64(milestone.EndBlock) + helper.GetChangeProducerThreshold(ctx) + 1
+	ctx = ctx.WithBlockHeight(blockHeight)
+	// Keep the Rio guard out of the way (IsRio false for this proposition's start block) so the
+	// validate-failure branch is unambiguously what suppresses the commit.
+	helper.SetRioHeight(0)
+	t.Cleanup(func() { helper.SetRioHeight(0) })
+
+	// Every validator votes for the same proposition, guaranteeing 100% (>2/3) support, but the
+	// proposition carries a block hash that is not 32 bytes long, which
+	// ValidateMilestoneProposition rejects via validateLatestHead/length checks downstream of
+	// GetMajorityMilestoneProposition's own hash+td round-trip (which does not itself validate
+	// hash length).
+	malformedHash := bytes.Repeat([]byte{0xAB}, 20) // not common.HashLength (32)
+	invalidMilestone := &milestoneTypes.MilestoneProposition{
+		StartBlockNumber: milestone.EndBlock + 1,
+		BlockHashes:      [][]byte{malformedHash},
+		ParentHash:       milestone.Hash,
+		BlockTds:         []uint64{1},
+	}
+
+	dummyNonRpExt, err := GetDummyNonRpVoteExtension(blockHeight-1, "test-chain")
+	require.NoError(t, err)
+
+	voteExtensions := make([]abci.ExtendedVoteInfo, 0, len(validators))
+	for i, validator := range validators {
+		voteExtension := &sidetxs.VoteExtension{
+			BlockHash:            []byte("test-block-hash"),
+			Height:               blockHeight - 1,
+			MilestoneProposition: invalidMilestone,
+			SideTxResponses:      []sidetxs.SideTxResponse{},
+		}
+		encoded, err := gogoproto.Marshal(voteExtension)
+		require.NoError(t, err)
+		voteExtensions = append(voteExtensions, abci.ExtendedVoteInfo{
+			Validator: abci.Validator{
+				Address: validatorPrivKeys[i].PubKey().Address(),
+				Power:   validator.VotingPower,
+			},
+			VoteExtension:           encoded,
+			ExtensionSignature:      []byte("dummy-signature"),
+			NonRpVoteExtension:      dummyNonRpExt,
+			NonRpExtensionSignature: []byte("dummy-non-rp-signature"),
+			BlockIdFlag:             cmtproto.BlockIDFlagCommit,
+		})
+	}
+
+	extCommit := &abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: voteExtensions,
+	}
+	extCommitBytes, err := extCommit.Marshal()
+	require.NoError(t, err)
+
+	req := &abci.RequestFinalizeBlock{
+		Height:          ctx.BlockHeight(),
+		Txs:             [][]byte{extCommitBytes, []byte("dummy-tx")},
+		ProposerAddress: common.FromHex(validators[0].Signer),
+	}
+
+	suppressedBefore := promtestutil.ToFloat64(metrics.MilestoneMajorityCommitSuppressedTotal.WithLabelValues("validate_failed"))
+
+	_, err = app.PreBlocker(ctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, suppressedBefore+1, promtestutil.ToFloat64(metrics.MilestoneMajorityCommitSuppressedTotal.WithLabelValues("validate_failed")),
+		"PreBlocker must record a commit-suppressed event for reason=validate_failed when the majority milestone proposition fails validation")
+
+	// No new milestone should have been committed.
+	latestMilestone, err := app.MilestoneKeeper.GetLastMilestone(ctx)
+	require.NoError(t, err)
+	require.Equal(t, milestone.EndBlock, latestMilestone.EndBlock, "no new milestone should have been committed when validation fails")
+}
+
+// TestPreBlocker_MajorityMilestoneRioLastSpanSuppressesCommit tests that a valid 2/3-majority
+// milestone proposition is NOT committed when the Rio guard trips (the last span was created in
+// the immediately preceding block), and that this is recorded as a
+// metrics.MilestoneMajorityCommitSuppressedTotal{reason="rio_last_span_same_block"} event.
+func TestPreBlocker_MajorityMilestoneRioLastSpanSuppressesCommit(t *testing.T) {
+	_, app, ctx, validatorPrivKeys := SetupAppWithABCICtxAndValidators(t, 10)
+	validators := app.StakeKeeper.GetAllValidators(ctx)
+
+	params := cmtproto.ConsensusParams{
+		Abci: &cmtproto.ABCIParams{
+			VoteExtensionsEnableHeight: 1,
+		},
+	}
+	ctx = ctx.WithConsensusParams(params)
+
+	milestone := milestoneTypes.Milestone{
+		MilestoneId: "1",
+		StartBlock:  0,
+		EndBlock:    100,
+		Hash:        common.HexToHash("0x1234").Bytes(),
+	}
+	err := app.MilestoneKeeper.AddMilestone(ctx, milestone)
+	require.NoError(t, err)
+	err = app.MilestoneKeeper.SetLastMilestoneBlock(ctx, milestone.EndBlock)
+	require.NoError(t, err)
+
+	span := &borTypes.Span{
+		Id:         1,
+		StartBlock: 1,
+		EndBlock:   200,
+		ValidatorSet: stakeTypes.ValidatorSet{
+			Validators: validators,
+			Proposer:   validators[0],
+		},
+		SelectedProducers: []stakeTypes.Validator{*validators[0]},
+		BorChainId:        "test",
+	}
+	err = app.BorKeeper.AddNewSpan(ctx, span)
+	require.NoError(t, err)
+
+	blockHeight := int64(milestone.EndBlock) + helper.GetChangeProducerThreshold(ctx) + 1
+	ctx = ctx.WithBlockHeight(blockHeight)
+	// The proposition's start block (milestone.EndBlock+1) must be >= Rio height for IsRio to be true.
+	helper.SetRioHeight(int64(milestone.EndBlock + 1))
+	t.Cleanup(func() { helper.SetRioHeight(0) })
+
+	// Trip the Rio guard: the last span was recorded as having been created exactly one block
+	// before the current one.
+	require.NoError(t, app.BorKeeper.SetLastSpanBlock(ctx, uint64(blockHeight-1)))
+
+	// Every validator votes for the same, otherwise-valid proposition, guaranteeing 100% (>2/3)
+	// support.
+	voteExtensions := createVoteExtensionsWithPartialSupport(t, validators, validatorPrivKeys, &milestone, 100, blockHeight-1)
+
+	extCommit := &abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: voteExtensions,
+	}
+	extCommitBytes, err := extCommit.Marshal()
+	require.NoError(t, err)
+
+	req := &abci.RequestFinalizeBlock{
+		Height:          ctx.BlockHeight(),
+		Txs:             [][]byte{extCommitBytes, []byte("dummy-tx")},
+		ProposerAddress: common.FromHex(validators[0].Signer),
+	}
+
+	suppressedBefore := promtestutil.ToFloat64(metrics.MilestoneMajorityCommitSuppressedTotal.WithLabelValues("rio_last_span_same_block"))
+
+	_, err = app.PreBlocker(ctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, suppressedBefore+1, promtestutil.ToFloat64(metrics.MilestoneMajorityCommitSuppressedTotal.WithLabelValues("rio_last_span_same_block")),
+		"PreBlocker must record a commit-suppressed event for reason=rio_last_span_same_block when the last span was created in the previous block")
+
+	// No new milestone should have been committed.
+	latestMilestone, err := app.MilestoneKeeper.GetLastMilestone(ctx)
+	require.NoError(t, err)
+	require.Equal(t, milestone.EndBlock, latestMilestone.EndBlock, "no new milestone should have been committed when the Rio guard trips")
 }
 
 // TestPrepareProposal_MultipleTransactionsPerBlock tests the PrepareProposal handler's ability to handle multiple transactions in a single block, ensuring that all transactions are included in the proposal response and that the ExtendedCommitInfo is properly accounted for in the transaction count, thus validating the correct behavior of transaction processing and proposal preparation in scenarios with multiple transactions.
@@ -5385,6 +5643,11 @@ func TestExtendVoteHandler_BudgetHardforkGated(t *testing.T) {
 			app.MilestoneKeeper.IContractCaller = working
 			app.caller = working
 
+			// With extendVoteBudget zeroed and the budget active (at/above activation), both budget
+			// checkpoints observe elapsed time against their respective histograms before short-circuiting.
+			sideTxLoopBefore := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "side_tx_loop")
+			preMilestoneBefore := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "pre_milestone")
+
 			respExtend, err := app.ExtendVoteHandler()(ctx, &abci.RequestExtendVote{
 				Txs:    [][]byte{extCommitBytes, txBytes},
 				Hash:   []byte("test-hash"),
@@ -5392,6 +5655,16 @@ func TestExtendVoteHandler_BudgetHardforkGated(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, respExtend.VoteExtension)
+
+			if budgetActiveForCase := tc.activation <= runHeight; budgetActiveForCase {
+				sideTxLoopAfter := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "side_tx_loop")
+				preMilestoneAfter := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "pre_milestone")
+
+				require.Equal(t, sideTxLoopBefore+1, sideTxLoopAfter,
+					"budget exhaustion in the side-tx loop must record an elapsed observation for phase=side_tx_loop")
+				require.Equal(t, preMilestoneBefore+1, preMilestoneAfter,
+					"budget exhaustion before milestone generation must record an elapsed observation for phase=pre_milestone")
+			}
 
 			var ve sidetxs.VoteExtension
 			require.NoError(t, gogoproto.Unmarshal(respExtend.VoteExtension, &ve))
@@ -7092,4 +7365,26 @@ func TestExtractTxHashMsgEventRecordValidation(t *testing.T) {
 			require.Equal(t, tc.hash, hash)
 		})
 	}
+}
+
+// histogramSampleCount returns the number of observations recorded so far in
+// a plain (non-vector) prometheus.Histogram, by reading its internal dto.Metric.
+// testutil.CollectAndCount is not usable here because it counts the number of
+// distinct time series (always 1 for a non-vector histogram), not the number
+// of observations within that single series.
+func histogramSampleCount(t *testing.T, h interface{ Write(*dto.Metric) error }) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	require.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+// histogramVecSampleCount returns the number of observations recorded so far for one label
+// value of a prometheus.HistogramVec, by reading its internal dto.Metric.
+func histogramVecSampleCount(t *testing.T, hv *prometheus.HistogramVec, labelValue string) uint64 {
+	t.Helper()
+	observer := hv.WithLabelValues(labelValue)
+	h, ok := observer.(prometheus.Histogram)
+	require.True(t, ok, "HistogramVec.WithLabelValues must return a prometheus.Histogram")
+	return histogramSampleCount(t, h)
 }

--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -5726,9 +5726,11 @@ func TestExtendVoteHandler_BudgetHardforkGated(t *testing.T) {
 			app.caller = working
 
 			// With extendVoteBudget zeroed and the budget active (at/above activation), both budget
-			// checkpoints observe elapsed time against their respective histograms before short-circuiting.
+			// checkpoints observe elapsed time against their respective histograms before short-circuiting,
+			// and the side-tx loop's exhaustion is also recorded against the exhausted-count counter.
 			sideTxLoopBefore := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "side_tx_loop")
 			preMilestoneBefore := histogramVecSampleCount(t, metrics.ExtendVoteElapsedSeconds, "pre_milestone")
+			sideTxLoopExhaustedBefore := promtestutil.ToFloat64(metrics.ExtendVoteBudgetExhaustedTotal.WithLabelValues("side_tx_loop"))
 
 			respExtend, err := app.ExtendVoteHandler()(ctx, &abci.RequestExtendVote{
 				Txs:    [][]byte{extCommitBytes, txBytes},
@@ -5746,6 +5748,8 @@ func TestExtendVoteHandler_BudgetHardforkGated(t *testing.T) {
 					"budget exhaustion in the side-tx loop must record an elapsed observation for phase=side_tx_loop")
 				require.Equal(t, preMilestoneBefore+1, preMilestoneAfter,
 					"budget exhaustion before milestone generation must record an elapsed observation for phase=pre_milestone")
+				require.Equal(t, sideTxLoopExhaustedBefore+1, promtestutil.ToFloat64(metrics.ExtendVoteBudgetExhaustedTotal.WithLabelValues("side_tx_loop")),
+					"budget exhaustion in the side-tx loop must increment the exhausted-count counter for phase=side_tx_loop")
 			}
 
 			var ve sidetxs.VoteExtension

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.1
@@ -202,6 +203,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.12.0 // indirect
 	github.com/linxGnu/grocksdb v1.10.3 // indirect
 	github.com/manifoldco/promptui v0.9.0 // indirect
@@ -230,7 +232,6 @@ require (
 	github.com/peterh/liner v1.2.2 // indirect
 	github.com/petermattis/goid v0.0.0-20251121121749-a11dd1a45f9a // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/helper/call.go
+++ b/helper/call.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/contracts/statereceiver"
 	"github.com/0xPolygon/heimdall-v2/contracts/statesender"
 	"github.com/0xPolygon/heimdall-v2/contracts/validatorset"
+	"github.com/0xPolygon/heimdall-v2/metrics"
 	borgrpc "github.com/0xPolygon/heimdall-v2/x/bor/grpc"
 	"github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
@@ -593,6 +594,8 @@ func (c *ContractCaller) GetMainChainBlockTime(ctx context.Context, blockNum uin
 
 // GetBorChainBlock returns bor chain block header
 func (c *ContractCaller) GetBorChainBlock(ctx context.Context, blockNum *big.Int) (header *ethTypes.Header, err error) {
+	defer metrics.RecordBorRPCCallDuration("get_bor_chain_block", time.Now())
+
 	ctx, cancel := context.WithTimeout(ctx, c.BorChainTimeout)
 	defer cancel()
 
@@ -631,6 +634,8 @@ func (c *ContractCaller) GetBorChainBlock(ctx context.Context, blockNum *big.Int
 // In both paths, it tries to get blocks from the range interval
 // but returns only the ones found on the chain.
 func (c *ContractCaller) GetBorChainBlockInfoInBatch(ctx context.Context, start, end int64) ([]*ethTypes.Header, []uint64, []common.Address, error) {
+	defer metrics.RecordBorRPCCallDuration("get_bor_chain_block_info_in_batch", time.Now())
+
 	if start < 0 || end < 0 || end < start {
 		return nil, nil, nil, fmt.Errorf("invalid range [%d,%d]", start, end)
 	}

--- a/helper/call_dispatcher_test.go
+++ b/helper/call_dispatcher_test.go
@@ -6,8 +6,26 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/heimdall-v2/metrics"
 )
+
+// histogramVecSampleCount returns the number of observations recorded so far for one label
+// value of metrics.BorRPCCallDuration, by reading its internal dto.Metric. testutil.CollectAndCount
+// is not suitable here because it counts distinct label combinations (time series), not the
+// number of observations within a single series.
+func histogramVecSampleCount(t *testing.T, method string) uint64 {
+	t.Helper()
+	observer := metrics.BorRPCCallDuration.WithLabelValues(method)
+	h, ok := observer.(prometheus.Histogram)
+	require.True(t, ok, "HistogramVec.WithLabelValues must return a prometheus.Histogram")
+	m := &dto.Metric{}
+	require.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleCount()
+}
 
 // makeDispatcherCaller returns a ContractCaller with the given gRPC flag and a
 // nil gRPC client. The BorChainTimeout is set to a short value, so HTTP-path
@@ -55,6 +73,26 @@ func TestGetBorChainBlockAuthor_GRPCNilClientError(t *testing.T) {
 
 	require.Error(t, err, "nil gRPC client must return an error")
 	require.Nil(t, author)
+}
+
+// TestGetBorChainBlock_GRPCNilClientError verifies that when BorChainGrpcFlag=true and
+// BorChainGrpcClient=nil, GetBorChainBlock returns an error rather than panicking or silently
+// returning a header, and that it records a Bor RPC call duration observation for
+// method="get_bor_chain_block" regardless of the error (the metric is recorded via an
+// unconditional defer at function entry).
+func TestGetBorChainBlock_GRPCNilClientError(t *testing.T) {
+	c := makeDispatcherCaller(true)
+
+	before := histogramVecSampleCount(t, "get_bor_chain_block")
+
+	header, err := c.GetBorChainBlock(context.Background(), nil)
+
+	require.Error(t, err, "nil gRPC client must return an error, not succeed")
+	require.Nil(t, header)
+
+	after := histogramVecSampleCount(t, "get_bor_chain_block")
+	require.Equal(t, before+1, after,
+		"GetBorChainBlock must record a Bor RPC call duration observation for method=get_bor_chain_block even on error")
 }
 
 // TestGetBorChainBlockInfoInBatch_NonGRPCCancelledContext verifies that

--- a/metrics/abci.go
+++ b/metrics/abci.go
@@ -127,6 +127,80 @@ var (
 		},
 		[]string{"phase"},
 	)
+
+	// ExtendVoteElapsedSeconds tracks how much wall-clock time had elapsed inside
+	// ExtendVote, labeled by the same phase values as ExtendVoteBudgetExhaustedTotal,
+	// at the moment each phase's budget check ran (regardless of whether the budget
+	// was exhausted). Pairs with that counter as a distribution: the counter says how
+	// often the budget is hit, this says how close every turn runs to it, which is
+	// what's needed to tune extendVoteBudget against real tail latency.
+	ExtendVoteElapsedSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "extend_vote_elapsed_seconds",
+			Help:      "Wall-clock time elapsed inside ExtendVote at each budget checkpoint, labeled by phase",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"phase"},
+	)
+
+	// MilestoneNoNewHeadersTotal counts ExtendVote turns that skipped milestone
+	// proposition generation because Bor had no new header since the last one
+	// used (ErrNoNewHeadersFound). This is the direct upstream trigger for the
+	// milestone-proposition-generation retry/wait design work.
+	MilestoneNoNewHeadersTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "milestone",
+			Name:      "no_new_headers_total",
+			Help:      "Number of ExtendVote turns that skipped milestone proposition generation because Bor had no new header",
+		},
+	)
+
+	// MilestoneMajorityFoundTotal counts PreBlocker turns that found a supported
+	// milestone proposition, labeled by the voting-power threshold that was met:
+	// "two_thirds" (proposition committed) or "one_third" (pending, span rotation
+	// deferred). This is the success-side denominator for the majority-search
+	// failure counters — without it, failure counts have no rate to be a fraction of.
+	MilestoneMajorityFoundTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "milestone",
+			Name:      "majority_found_total",
+			Help:      "Number of PreBlocker turns that found a supported milestone proposition, labeled by voting-power threshold",
+		},
+		[]string{"threshold"},
+	)
+
+	// VoteExtensionRejectedTotal counts VerifyVoteExtension turns that rejected a
+	// peer's vote extension, labeled by the specific validation failure. A
+	// rejected vote extension does not count toward the 2/3 (or 1/3) majority
+	// threshold at the next height, making this a direct upstream cause of
+	// milestone majority non-convergence.
+	VoteExtensionRejectedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "abci",
+			Name:      "vote_extension_rejected_total",
+			Help:      "Number of VerifyVoteExtension turns that rejected a peer's vote extension, labeled by reason",
+		},
+		[]string{"reason"},
+	)
+
+	// BorRPCCallDuration tracks the latency of individual Bor RPC calls made by
+	// heimdall-v2, labeled by method. method must stay a bounded set of
+	// wrapper/RPC names — never an endpoint URL, block number, tx hash, or error.
+	BorRPCCallDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: "bor",
+			Name:      "rpc_call_duration_seconds",
+			Help:      "Latency of Bor RPC calls made by heimdall-v2, labeled by method",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"method"},
+	)
 )
 
 // RecordABCIHandlerDuration records the time taken for any ABCI handler.
@@ -139,4 +213,34 @@ func RecordABCIHandlerDuration(metric prometheus.Summary, start time.Time) {
 // for the given phase.
 func RecordExtendVoteBudgetExhausted(phase string) {
 	ExtendVoteBudgetExhaustedTotal.WithLabelValues(phase).Inc()
+}
+
+// RecordExtendVoteElapsed observes the elapsed time since start against the
+// given phase's histogram.
+func RecordExtendVoteElapsed(phase string, start time.Time) {
+	ExtendVoteElapsedSeconds.WithLabelValues(phase).Observe(time.Since(start).Seconds())
+}
+
+// RecordMilestoneNoNewHeaders increments the counter for ExtendVote turns
+// that skipped milestone proposition generation due to no new Bor header.
+func RecordMilestoneNoNewHeaders() {
+	MilestoneNoNewHeadersTotal.Inc()
+}
+
+// RecordMilestoneMajorityFound increments the majority-found counter for the
+// given voting-power threshold ("two_thirds" or "one_third").
+func RecordMilestoneMajorityFound(threshold string) {
+	MilestoneMajorityFoundTotal.WithLabelValues(threshold).Inc()
+}
+
+// RecordVoteExtensionRejected increments the vote-extension-rejection counter
+// for the given reason.
+func RecordVoteExtensionRejected(reason string) {
+	VoteExtensionRejectedTotal.WithLabelValues(reason).Inc()
+}
+
+// RecordBorRPCCallDuration observes the elapsed time since start against the
+// given Bor RPC method's histogram.
+func RecordBorRPCCallDuration(method string, start time.Time) {
+	BorRPCCallDuration.WithLabelValues(method).Observe(time.Since(start).Seconds())
 }

--- a/metrics/abci.go
+++ b/metrics/abci.go
@@ -201,6 +201,38 @@ var (
 		},
 		[]string{"method"},
 	)
+
+	// MilestoneMajorityCommitSuppressedTotal counts PreBlocker turns that found
+	// a supported (2/3) milestone proposition that was NOT committed, labeled
+	// by why: "validate_failed" (ValidateMilestoneProposition rejected it) or
+	// "rio_last_span_same_block" (the Rio guard skipped it because the last
+	// span was created in the previous block). Pairs with
+	// MilestoneMajorityFoundTotal{threshold="two_thirds"}: without this, a
+	// validate-failure storm is indistinguishable from healthy convergence.
+	MilestoneMajorityCommitSuppressedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "milestone",
+			Name:      "majority_commit_suppressed_total",
+			Help:      "Number of PreBlocker turns with a 2/3 majority milestone proposition that was found but not committed, labeled by reason",
+		},
+		[]string{"reason"},
+	)
+
+	// MilestoneGenerationDuration tracks the end-to-end wall-clock time spent
+	// inside GenMilestoneProposition, which makes multiple Bor RPC calls
+	// (GetBorChainBlock, GetBorChainBlockInfoInBatch). Complements
+	// BorRPCCallDuration by showing how much of the ExtendVote budget the
+	// milestone-proposition path consumes as a whole, versus the side-tx loop.
+	MilestoneGenerationDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: "milestone",
+			Name:      "proposition_generation_duration_seconds",
+			Help:      "Wall-clock time spent generating a milestone proposition (GenMilestoneProposition)",
+			Buckets:   prometheus.DefBuckets,
+		},
+	)
 )
 
 // RecordABCIHandlerDuration records the time taken for any ABCI handler.
@@ -243,4 +275,16 @@ func RecordVoteExtensionRejected(reason string) {
 // given Bor RPC method's histogram.
 func RecordBorRPCCallDuration(method string, start time.Time) {
 	BorRPCCallDuration.WithLabelValues(method).Observe(time.Since(start).Seconds())
+}
+
+// RecordMilestoneMajorityCommitSuppressed increments the commit-suppressed
+// counter for the given reason.
+func RecordMilestoneMajorityCommitSuppressed(reason string) {
+	MilestoneMajorityCommitSuppressedTotal.WithLabelValues(reason).Inc()
+}
+
+// RecordMilestoneGenerationDuration observes the elapsed time since start
+// against the milestone-proposition-generation histogram.
+func RecordMilestoneGenerationDuration(start time.Time) {
+	MilestoneGenerationDuration.Observe(time.Since(start).Seconds())
 }

--- a/metrics/abci_new_test.go
+++ b/metrics/abci_new_test.go
@@ -1,0 +1,109 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// histogramSampleCount returns the number of observations recorded so far in
+// a plain (non-vector) prometheus.Histogram, by reading its internal dto.Metric.
+func histogramSampleCount(t *testing.T, h interface{ Write(*dto.Metric) error }) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	require.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+// TestRecordExtendVoteElapsed verifies that RecordExtendVoteElapsed observes a
+// sample into the correct phase's histogram bucket.
+func TestRecordExtendVoteElapsed(t *testing.T) {
+	phase := "unit_test_phase_extend_vote_elapsed"
+
+	before := testutil.CollectAndCount(ExtendVoteElapsedSeconds)
+
+	RecordExtendVoteElapsed(phase, time.Now().Add(-5*time.Millisecond))
+
+	after := testutil.CollectAndCount(ExtendVoteElapsedSeconds)
+	require.Equal(t, before+1, after, "RecordExtendVoteElapsed must add exactly one observation")
+}
+
+// TestRecordMilestoneNoNewHeaders verifies that RecordMilestoneNoNewHeaders
+// increments the no-new-headers counter.
+func TestRecordMilestoneNoNewHeaders(t *testing.T) {
+	before := testutil.ToFloat64(MilestoneNoNewHeadersTotal)
+
+	RecordMilestoneNoNewHeaders()
+
+	after := testutil.ToFloat64(MilestoneNoNewHeadersTotal)
+	require.Equal(t, before+1, after, "RecordMilestoneNoNewHeaders must increment the counter by exactly one")
+}
+
+// TestRecordMilestoneMajorityFound verifies that RecordMilestoneMajorityFound
+// increments the counter for the given threshold label only.
+func TestRecordMilestoneMajorityFound(t *testing.T) {
+	threshold := "unit_test_threshold_majority_found"
+
+	before := testutil.ToFloat64(MilestoneMajorityFoundTotal.WithLabelValues(threshold))
+
+	RecordMilestoneMajorityFound(threshold)
+
+	after := testutil.ToFloat64(MilestoneMajorityFoundTotal.WithLabelValues(threshold))
+	require.Equal(t, before+1, after, "RecordMilestoneMajorityFound must increment the counter for the given threshold by exactly one")
+}
+
+// TestRecordVoteExtensionRejected verifies that RecordVoteExtensionRejected
+// increments the counter for the given reason label only.
+func TestRecordVoteExtensionRejected(t *testing.T) {
+	reason := "unit_test_reason_vote_extension_rejected"
+
+	before := testutil.ToFloat64(VoteExtensionRejectedTotal.WithLabelValues(reason))
+
+	RecordVoteExtensionRejected(reason)
+
+	after := testutil.ToFloat64(VoteExtensionRejectedTotal.WithLabelValues(reason))
+	require.Equal(t, before+1, after, "RecordVoteExtensionRejected must increment the counter for the given reason by exactly one")
+}
+
+// TestRecordBorRPCCallDuration verifies that RecordBorRPCCallDuration observes
+// a sample into the correct method's histogram bucket.
+func TestRecordBorRPCCallDuration(t *testing.T) {
+	method := "unit_test_method_bor_rpc_call_duration"
+
+	before := testutil.CollectAndCount(BorRPCCallDuration)
+
+	RecordBorRPCCallDuration(method, time.Now().Add(-5*time.Millisecond))
+
+	after := testutil.CollectAndCount(BorRPCCallDuration)
+	require.Equal(t, before+1, after, "RecordBorRPCCallDuration must add exactly one observation")
+}
+
+// TestRecordMilestoneMajorityCommitSuppressed verifies that
+// RecordMilestoneMajorityCommitSuppressed increments the counter for the
+// given reason label only.
+func TestRecordMilestoneMajorityCommitSuppressed(t *testing.T) {
+	reason := "unit_test_reason_majority_commit_suppressed"
+
+	before := testutil.ToFloat64(MilestoneMajorityCommitSuppressedTotal.WithLabelValues(reason))
+
+	RecordMilestoneMajorityCommitSuppressed(reason)
+
+	after := testutil.ToFloat64(MilestoneMajorityCommitSuppressedTotal.WithLabelValues(reason))
+	require.Equal(t, before+1, after, "RecordMilestoneMajorityCommitSuppressed must increment the counter for the given reason by exactly one")
+}
+
+// TestRecordMilestoneGenerationDuration verifies that
+// RecordMilestoneGenerationDuration observes a sample into the
+// milestone-proposition-generation histogram.
+func TestRecordMilestoneGenerationDuration(t *testing.T) {
+	before := histogramSampleCount(t, MilestoneGenerationDuration)
+
+	RecordMilestoneGenerationDuration(time.Now().Add(-5 * time.Millisecond))
+
+	after := histogramSampleCount(t, MilestoneGenerationDuration)
+	require.Equal(t, before+1, after, "RecordMilestoneGenerationDuration must add exactly one observation")
+}


### PR DESCRIPTION
## Summary

Adds 7 new Prometheus metrics closing observability gaps identified in a cross-model (Codex + Claude) convergence review of heimdall-v2's milestone-finality-latency instrumentation, targeting the Stage A (create→propose) and Stage B (propose→majority) latency questions:

- `heimdallv2_milestone_no_new_headers_total` — ExtendVote turns that skipped proposition generation because Bor had no new header
- `heimdallv2_bor_rpc_call_duration_seconds{method}` — latency of individual Bor RPC calls (previously zero visibility)
- `heimdallv2_abci_extend_vote_elapsed_seconds{phase}` — wall-clock elapsed at each ExtendVote budget checkpoint, pairing with the existing `extend_vote_budget_exhausted_total` counter
- `heimdallv2_milestone_majority_found_total{threshold}` — success-side counter for 2/3 and 1/3 majority search, giving failure counters a denominator
- `heimdallv2_abci_vote_extension_rejected_total{reason}` — counts each of VerifyVoteExtension's 7 REJECT branches; a rejected vote extension doesn't count toward the next height's majority threshold, making this a direct upstream cause of Stage B non-convergence
- `heimdallv2_milestone_proposition_generation_duration_seconds` — end-to-end time inside `GenMilestoneProposition`, showing how much of the ExtendVote budget the milestone path consumes versus the side-tx loop
- `heimdallv2_milestone_majority_commit_suppressed_total{reason}` — a 2/3 majority proposition was found but not committed (`ValidateMilestoneProposition` failure or the Rio last-span-same-block guard); without this, a validate-failure storm is indistinguishable from healthy convergence in `majority_found_total`

Full candidate list, source citations, and the 6-round Codex/Claude convergence log: `investigations/heimdall-observability-metrics-brainstorm.md` in agent-zero (not part of this diff).

All labels are bounded enums over code branches (never per-entity/free-form) per the convergence review's cardinality guardrails; no validator-identity label is used anywhere in this diff.

## Executed tests

- `go build ./...`, `go vet ./app/... ./helper/... ./metrics/...`, `go test ./app/... ./helper/... ./metrics/...` — all passing (467 tests, 6 packages)
- `gofumpt -l` and `golangci-lint run --new-from-rev=origin/develop` — clean on every touched line
- Added direct unit tests for all 7 new metric recorders plus before/after assertions on the existing `app`/`helper` tests that exercise the newly-instrumented branches, closing the initial coverage/mutation-testing gaps CI caught — `codecov/patch` is green and diffguard's mutation-testing score is 96.7% (29/30 killed, see below for the one remaining survivor)
- Claude Code review (`@claude review`) caught a real bug: `ExtendVoteElapsedSeconds` was only ever recorded on the already-budget-exhausted path, making the histogram a duplicate of the existing exhaustion counter instead of showing the full elapsed-time distribution needed to tune `extendVoteBudget` from tail latency. Fixed in c2f4759c to record at every budget checkpoint regardless of outcome.
- `govulncheck` — 7 findings, all pre-existing (grpc/stdlib version, traced through `app/app.go`, `x/bor/grpc/*`, `helper/query.go`), none touching this diff's lines
- Live kurtosis devnet (4 heimdall-v2 validators + 1 RPC node, this branch): confirmed `heimdallv2_milestone_no_new_headers_total`, `heimdallv2_bor_rpc_call_duration_seconds`, `heimdallv2_milestone_majority_found_total`, and `heimdallv2_milestone_proposition_generation_duration_seconds` populate with real data; confirmed `extend_vote_elapsed_seconds`, `vote_extension_rejected_total`, and `majority_commit_suppressed_total` are correctly registered but empty (each requires a fault/degraded condition — budget exhaustion, invalid vote extension, or a commit-suppression path — that a healthy 4-validator devnet doesn't naturally trigger)
- Confirmed the Grafana Alloy scrape allowlist already covers all 7 new metric names via the `heimdallv2_.*` catch-all added in `0xPolygon/pos-ops#950`

## Known CI deviations

Diffguard's `Quality metrics` check is red on two items, neither of which reflects a real gap in this diff:

1. **Churn-weighted-complexity WARN**: `PreBlocker` (complexity 61) and `ExtendVoteHandler` (complexity 27) are flagged because diffguard scores at function granularity and both are among the most heavily-churned functions in the repo (161 commits each). Any diff touching either function trips this warning, independent of diff size. Reducing either function's complexity would mean restructuring consensus-critical code (both are covered by `.claude/rules/consensus-critical.md`) well outside this PR's scope.
2. **One surviving mutant** (`app/abci.go`, the `logger.Warn(...)` call on the ExtendVote side-tx-loop budget-exhaustion path): a log-statement-deletion mutant. This repo has no log-capture test harness/pattern to assert on structured logger output content, and introducing one for a single log line is disproportionate to the gap. Mutation score is 96.7% (29/30) overall, well above the 90% bar; only this one log-line mutant remains unaddressed.

Flagging both for reviewer discussion per team standard rather than silently overriding.

## Rollout notes

Not consensus-affecting — purely additive Prometheus counters/histograms and one wall-clock timing call inside `ExtendVoteHandler` (already non-deterministic/RPC-calling by design). No hard fork required. No operator action needed beyond the already-merged pos-ops scrape-config fix.

